### PR TITLE
Add function min_max, stddev and variance

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,12 @@ Vectors : 2 numeric, 1 string
 |[ ]`mode`    |     | [ ] |     |[ ] Mode    |     |
 | ✓ `product` |  ✓  |  ✓  |     | ✓ ScalarAggregate|     |
 |[ ]`quantile`|     | [ ] |     |[ ] Quantile|     |
-|[ ]`stddev`  |     |  ✓  |     |[ ] Variance|     |
+| ✓ `sd    `  |     |  ✓  |     |          |ddof: 1 at `stddev`|
+| ✓ `stddev`  |     |  ✓  |     | ✓ Variance|ddof: 0 by default|
 | ✓ `sum`     |  ✓  |  ✓  |     | ✓ ScalarAggregate|     |
 |[ ]`tdigest` |     | [ ] |     |[ ] TDigest |     |
-|[ ]`variance`|     |  ✓  |     |[ ] Variance|     |
+| ✓ `var    `|     |  ✓  |     |   |ddof: 1 at `variance`<br>alias `unbiased_variance`|
+| ✓ `variance`|     |  ✓  |     | ✓ Variance|ddof: 0 by default|
 
 
 Options can be used as follows.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Vectors : 2 numeric, 1 string
 | ✓ `max`     |  ✓  |  ✓  |  ✓  | ✓ ScalarAggregate|     |
 | ✓ `mean`    |  ✓  |  ✓  |     | ✓ ScalarAggregate|     |
 | ✓ `min`     |  ✓  |  ✓  |  ✓  | ✓ ScalarAggregate|     |
-|[ ]`min_max` | [ ] | [ ] | [ ] |[ ] ScalarAggregate|     |
+| ✓ `min_max` |  ✓  |  ✓  |  ✓  | ✓ ScalarAggregate|     |
 |[ ]`mode`    |     | [ ] |     |[ ] Mode    |     |
 | ✓ `product` |  ✓  |  ✓  |     | ✓ ScalarAggregate|     |
 |[ ]`quantile`|     | [ ] |     |[ ] Quantile|     |

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -22,6 +22,16 @@ module RedAmber
     alias_method :median, :approximate_median
     alias_method :count_uniq, :count_distinct
 
+    def unbiased_variance
+      variance(opts: { ddof: 1 })
+    end
+    alias_method :var, :unbiased_variance
+
+    def sd
+      stddev(opts: { ddof: 1 })
+    end
+    alias_method :std, :sd
+
     # option(s) required
     # - index
 

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -223,5 +223,11 @@ module RedAmber
     def find(function_name)
       Arrow::Function.find(function_name)
     end
+
+    # temporary API until RedAmber document prepared.
+    def arrow_doc(function_name)
+      f = find(function_name)
+      "#{f}\n#{'-' * function_name.size}\n#{f.doc.description}"
+    end
   end
 end

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -12,11 +12,11 @@ module RedAmber
   module VectorFunctions
     # [Unary aggregations]: vector.func => scalar
     unary_aggregations =
-      %i[all any approximate_median count count_distinct max mean min product stddev sum variance]
+      %i[all any approximate_median count count_distinct max mean min min_max product stddev sum variance]
     unary_aggregations.each do |function|
       define_method(function) do |opts: nil|
-        output = exec_func_unary(function, options: opts)
-        take_out_scalar(output)
+        datum = exec_func_unary(function, options: opts)
+        take_out_scalar(datum)
       end
     end
     alias_method :median, :approximate_median
@@ -26,7 +26,6 @@ module RedAmber
     # - index
 
     # Returns other than value
-    # - min_max
     # - mode
     # - quantile
     # - tdigest
@@ -36,8 +35,8 @@ module RedAmber
       %i[abs atan bit_wise_not ceil cos floor is_finite is_inf is_nan is_null is_valid sign sin tan trunc]
     unary_element_wise.each do |function|
       define_method(function) do |opts: nil|
-        output = exec_func_unary(function, options: opts)
-        take_out_element_wise(output)
+        datum = exec_func_unary(function, options: opts)
+        take_out_element_wise(datum)
       end
     end
     alias_method :is_nil, :is_null
@@ -53,13 +52,13 @@ module RedAmber
     }
     unary_element_wise_op.each do |function, operator|
       define_method(function) do |opts: nil|
-        output = exec_func_unary(function, options: opts)
-        take_out_element_wise(output)
+        datum = exec_func_unary(function, options: opts)
+        take_out_element_wise(datum)
       end
 
       define_method(operator) do |opts: nil|
-        output = exec_func_unary(function, options: opts)
-        take_out_element_wise(output)
+        datum = exec_func_unary(function, options: opts)
+        take_out_element_wise(datum)
       end
     end
     alias_method :not, :invert
@@ -79,8 +78,8 @@ module RedAmber
       %i[atan2 and_not and_not_kleene bit_wise_and bit_wise_or bit_wise_xor]
     binary_element_wise.each do |function|
       define_method(function) do |other, opts: nil|
-        output = exec_func_binary(function, other, options: opts)
-        take_out_element_wise(output)
+        datum = exec_func_binary(function, other, options: opts)
+        take_out_element_wise(datum)
       end
     end
 
@@ -95,8 +94,8 @@ module RedAmber
     }
     logical_binary_element_wise.each do |method, function|
       define_method(method) do |other, opts: nil|
-        output = exec_func_binary(function, other, options: opts)
-        take_out_element_wise(output)
+        datum = exec_func_binary(function, other, options: opts)
+        take_out_element_wise(datum)
       end
     end
 
@@ -128,13 +127,13 @@ module RedAmber
     }
     binary_element_wise_op.each do |function, operator|
       define_method(function) do |other, opts: nil|
-        output = exec_func_binary(function, other, options: opts)
-        take_out_element_wise(output)
+        datum = exec_func_binary(function, other, options: opts)
+        take_out_element_wise(datum)
       end
 
       define_method(operator) do |other, opts: nil|
-        output = exec_func_binary(function, other, options: opts)
-        take_out_element_wise(output)
+        datum = exec_func_binary(function, other, options: opts)
+        take_out_element_wise(datum)
       end
     end
     alias_method :eq, :equal
@@ -209,13 +208,19 @@ module RedAmber
       end
     end
 
-    def take_out_scalar(output)
-      output = output.value
-      output.is_a?(Arrow::StringScalar) ? output.to_s : output.value
+    def take_out_scalar(datum)
+      output = datum.value
+      case output
+      when Arrow::StringScalar then output.to_s
+      when Arrow::StructScalar
+        output.value.map { |s| s.is_a?(Arrow::StringScalar) ? s.to_s : s.value }
+      else
+        output.value
+      end
     end
 
-    def take_out_element_wise(output)
-      Vector.new(output.value)
+    def take_out_element_wise(datum)
+      Vector.new(datum.value)
     end
 
     module_function # ======

--- a/test/test_vector_function.rb
+++ b/test/test_vector_function.rb
@@ -694,4 +694,17 @@ class VectorFunctionTest < Test::Unit::TestCase
       assert_equal_array [false, false, false], @string != @string
     end
   end
+
+  sub_test_case('module_function .arrow_doc') do
+    test 'add' do
+      expected = <<~OUT
+        add(x, y): Add the arguments element-wise
+        ---
+        Results will wrap around on integer overflow.
+        Use function \"add_checked\" if you want overflow
+        to return an error.
+      OUT
+      assert_equal expected.chomp, VectorFunctions.arrow_doc(:add).to_s
+    end
+  end
 end

--- a/test/test_vector_function.rb
+++ b/test/test_vector_function.rb
@@ -121,6 +121,18 @@ class VectorFunctionTest < Test::Unit::TestCase
       assert_equal 'null', @string2.min(opts: { skip_nulls: false })
     end
 
+    test '#min_max' do
+      assert_equal [true, true], @boolean.min_max
+      assert_equal [false, false], @boolean.min_max(opts: { skip_nulls: false })
+      assert_equal [1, 3], @integer.min_max
+      assert_equal [0, 0], @integer2.min_max(opts: { skip_nulls: false })
+      assert_equal([-2, 3], @double.min_max)
+      assert_equal([-Float::INFINITY, Float::INFINITY], @double2.min_max)
+      assert_equal [0.0, 0.0], @double2.min_max(opts: { skip_nulls: false })
+      assert_equal %w[A B], @string.min_max
+      assert_equal %w[null null], @string2.min_max(opts: { skip_nulls: false })
+    end
+
     test '#product' do
       assert_equal 1, @boolean.product
       assert_equal 0, @boolean.product(opts: { skip_nulls: false })

--- a/test/test_vector_function.rb
+++ b/test/test_vector_function.rb
@@ -146,8 +146,19 @@ class VectorFunctionTest < Test::Unit::TestCase
     test '#stddev' do
       assert_raise(Arrow::Error::NotImplemented) { @boolean.stddev }
       assert_equal 0.816496580927726, @integer.stddev
+      assert_equal 0.0, @integer2.stddev(opts: { skip_nulls: false })
       assert_equal 2.0548046676563256, @double.stddev
+      assert_true @double2.stddev.nan?
+      assert_equal 0.0, @double2.stddev(opts: { skip_nulls: false })
       assert_raise(Arrow::Error::NotImplemented) { @string.stddev }
+    end
+
+    test '#sd (unbiased version of stddev)' do
+      assert_raise(Arrow::Error::NotImplemented) { @boolean.sd }
+      assert_equal 1.0, @integer.sd
+      assert_equal 2.5166114784235836, @double.sd
+      assert_true @double2.sd.nan?
+      assert_raise(Arrow::Error::NotImplemented) { @string.sd }
     end
 
     test '#sum' do
@@ -165,8 +176,19 @@ class VectorFunctionTest < Test::Unit::TestCase
     test '#variance' do
       assert_raise(Arrow::Error::NotImplemented) { @boolean.variance }
       assert_equal 0.6666666666666666, @integer.variance
+      assert_equal 0.0, @integer2.variance(opts: { skip_nulls: false })
       assert_equal 4.222222222222222, @double.variance
+      assert_true @double2.variance.nan?
+      assert_equal 0.0, @double2.variance(opts: { skip_nulls: false })
       assert_raise(Arrow::Error::NotImplemented) { @string.variance }
+    end
+
+    test '#var (==unbiased_variance)' do
+      assert_raise(Arrow::Error::NotImplemented) { @boolean.var }
+      assert_equal 1.0, @integer.var
+      assert_equal 6.333333333333334, @double.var
+      assert_true @double2.var.nan?
+      assert_raise(Arrow::Error::NotImplemented) { @string.var }
     end
   end
 


### PR DESCRIPTION
Add more functions to Vector.

- `min_max` returns array [min, max].
- `stddev` returns standard deviation at ddof=0 (that means divisor used in the calculation is N-0).
- `sd` is 'unbiased' and equals to `stddev(opts: {ddof: 1})`.
- `variance` defaults to ddof=0.
- `unbiased_variance` and `var` equal to `var(opts: {ddof: 1})`.

also refined some variable name.