### PR TITLE
Shorten option name of #tdr

### DIFF
--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -131,7 +131,7 @@ Class RedAmber::DataFrame represents 2D-data table.
 
   Returns a `Rover::DataFrame`.
 
-- [x] `ls(limit = 10, tally_level: 5, max_element: 5)`
+- [x] `ls(limit = 10, tally: 5, elements: 5)`
 
   - Shows some information about self in a transposed style.
   - `ls_str` returns same info as String.
@@ -158,8 +158,8 @@ Vectors : 5 numeric, 3 strings
 8 :year              uint16     3 {2007=>110, 2008=>114, 2009=>120}
 ```
 
-  - tally_level: max level to use tally mode
-  - max_element: max num of element to show values in each row
+  - tally: max level to use tally mode
+  - elements: max num of element to show values in each observations
 
 ## Selecting
 

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -18,14 +18,14 @@ module RedAmber
     end
 
     # - limit: max num of Vectors to show
-    # - tally_level: max level to use tally mode
-    # - max_element: max element to show values in each row
-    def tdr(limit = 10, tally_level: 5, max_element: 5)
-      puts tdr_str(limit, tally_level: tally_level, max_element: max_element)
+    # - tally: max level to use tally mode
+    # - elements: max element to show values in each vector
+    def tdr(limit = 10, tally: 5, elements: 5)
+      puts tdr_str(limit, tally: tally, elements: elements)
     end
 
-    def tdr_str(limit = 10, tally_level: 5, max_element: 5)
-      "#{shape_str}\n#{dataframe_info(limit, tally_level: tally_level, max_element: max_element)}"
+    def tdr_str(limit = 10, tally: 5, elements: 5)
+      "#{shape_str}\n#{dataframe_info(limit, tally_level: tally, max_element: elements)}"
     end
 
     private # =====

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -95,7 +95,7 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         3 :string  string      5 ["A", "A", "B", "C", "D", ... ]
         4 :boolean boolean     3 [true, false, nil, true, false, ... ], 2 nils
       OUTPUT
-      assert_equal str, @df.tdr_str(tally_level: 2)
+      assert_equal str, @df.tdr_str(tally: 2)
     end
 
     test 'max_element' do
@@ -108,7 +108,7 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         3 :string  string      5 {"A"=>2, "B"=>1, "C"=>1, "D"=>1, "E"=>1}
         4 :boolean boolean     3 {true=>2, false=>2, nil=>2}
       OUTPUT
-      assert_equal str, @df.tdr_str(max_element: 6)
+      assert_equal str, @df.tdr_str(elements: 6)
     end
 
     test 'tally_level and max_element' do
@@ -121,7 +121,7 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         3 :string  string      5 ["A", "A", "B", "C", "D", "E"]
         4 :boolean boolean     3 [true, false, nil, true, false, nil], 2 nils
       OUTPUT
-      assert_equal str, @df.tdr_str(tally_level: 2, max_element: 6)
+      assert_equal str, @df.tdr_str(tally: 2, elements: 6)
     end
 
     test 'empty key and key with blank' do


### PR DESCRIPTION
This PR is to shorten option name of DataFrame#tdr.
It will be easier to remember.

- :tally_mode => :tally
- :max_element => :elements
