### PR TITLE
Call block by instance_eval in DataFrame#pick/drop/slice/remove

### DIFF
--- a/lib/red_amber/data_frame_observation_operation.rb
+++ b/lib/red_amber/data_frame_observation_operation.rb
@@ -9,7 +9,7 @@ module RedAmber
       if block
         raise DataFrameArgumentError, 'Must not specify both arguments and block.' unless args.empty?
 
-        slicer = yield(self)
+        slicer = instance_eval(&block)
       end
       slicer = [slicer].flatten
       return remove_all_values if slicer.empty? || slicer[0].nil?
@@ -36,7 +36,7 @@ module RedAmber
       if block
         raise DataFrameArgumentError, 'Must not specify both arguments and block.' unless args.empty?
 
-        remover = yield(self)
+        remover = instance_eval(&block)
       end
       remover = [remover].flatten
 

--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -9,7 +9,7 @@ module RedAmber
       if block
         raise DataFrameArgumentError, 'Must not specify both arguments and block.' unless args.empty?
 
-        picker = yield(self)
+        picker = instance_eval(&block)
       end
       picker = [picker].flatten
       return DataFrame.new if picker.empty? || picker == [nil]
@@ -29,7 +29,7 @@ module RedAmber
       if block
         raise DataFrameArgumentError, 'Must not specify both arguments and block.' unless args.empty?
 
-        dropper = yield(self)
+        dropper = instance_eval(&block)
       end
       dropper = [dropper].flatten
 

--- a/test/test_data_frame_observation_operation.rb
+++ b/test/test_data_frame_observation_operation.rb
@@ -93,7 +93,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         3 :string string      5 ["A", "B", "C", "D", nil], 1 nil
         4 :bool   boolean     3 {true=>2, false=>2, nil=>1}
       OUTPUT
-      assert_equal @df.tdr_str, @df.slice { 0...@df.size }.tdr_str # slice all
+      assert_equal @df.tdr_str, @df.slice { 0...size }.tdr_str # slice all
 
       str = <<~OUTPUT
         RedAmber::DataFrame : 3 x 4 Vectors
@@ -115,7 +115,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         3 :string string      2 ["B", "D"]
         4 :bool   boolean     1 {false=>2}
       OUTPUT
-      assert_equal str, @df.slice { |d| d.indexes.map(&:odd?) }.tdr_str
+      assert_equal str, @df.slice { indexes.map(&:odd?) }.tdr_str
     end
   end
 
@@ -207,7 +207,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         3 :string string     0 []
         4 :bool   string     0 []
       OUTPUT
-      assert_equal str, @df.remove { 0...@df.size }.tdr_str # remove all
+      assert_equal str, @df.remove { 0...size }.tdr_str # remove all
 
       str = <<~OUTPUT
         RedAmber::DataFrame : 2 x 4 Vectors
@@ -229,7 +229,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         3 :string string      2 ["B", "D"]
         4 :bool   boolean     1 {false=>2}
       OUTPUT
-      assert_equal str, @df.remove { |d| d.indexes.map(&:even?) }.tdr_str
+      assert_equal str, @df.remove { indexes.map(&:even?) }.tdr_str
     end
   end
 end

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -66,7 +66,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       OUTPUT
       assert_true @df.pick {}.empty? # pick nothing
       assert_equal str, @df.pick { :bool }.tdr_str
-      assert_equal str, @df.pick { |d| d.keys.detect { |k| d[k].boolean? } }.tdr_str
+      assert_equal str, @df.pick { vectors.map(&:boolean?) }.tdr_str
 
       str = <<~OUTPUT
         RedAmber::DataFrame : 5 x 2 Vectors
@@ -76,7 +76,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         2 :float double     5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
       OUTPUT
       assert_equal str, @df.pick { %i[index float] }.tdr_str
-      assert_equal str, @df.pick { |d| d.keys.select { |k| d[k].numeric? } }.tdr_str
+      assert_equal str, @df.pick { vectors.map(&:numeric?) }.tdr_str
     end
   end
 
@@ -126,7 +126,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       OUTPUT
       assert_equal(@df, @df.drop { nil }) # drop nothing
       assert_equal str, @df.drop { :bool }.tdr_str
-      assert_equal str, @df.drop { |d| d.keys.detect { |k| d[k].boolean? } }.tdr_str
+      assert_equal str, @df.drop { vectors.map(&:boolean?) }.tdr_str
 
       str = <<~OUTPUT
         RedAmber::DataFrame : 5 x 2 Vectors
@@ -136,7 +136,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         2 :bool   boolean     3 {true=>2, false=>2, nil=>1}
       OUTPUT
       assert_equal str, @df.drop { %i[index float] }.tdr_str
-      assert_equal str, @df.drop { |d| d.keys.select { |k| d[k].numeric? } }.tdr_str
+      assert_equal str, @df.drop { vectors.map(&:numeric?) }.tdr_str
     end
   end
 end


### PR DESCRIPTION
This PR is to use instance_eval in DataFrame#pick/drop/slice/remove.

Block is called within a context of self under this change, we can omit block parameter or receiver.

For example, this code works like `drop_nil`.

```ruby
# for the dataframe penguins:
penguins.remove { vectors.map(&:is_nil).reduce(&:|) }
```