### PR TITLE
Add supports to make up for missing values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,7 +56,7 @@ Metrics/AbcSize:
   Max: 30
   Exclude:
     - 'lib/red_amber/data_frame_displayable.rb' # Max: 55
-    - lib/red_amber/vector_compensable.rb # Max: 36
+    - 'lib/red_amber/vector_compensable.rb' # Max: 36
 
 # Max: 25
 Metrics/BlockLength:
@@ -73,6 +73,8 @@ Metrics/ClassLength:
 # Max: 7
 Metrics/CyclomaticComplexity:
   Max: 12
+  Exclude:
+    - 'lib/red_amber/vector_compensable.rb' # Max: 14
 
 # Max: 10
 Metrics/MethodLength:
@@ -89,6 +91,8 @@ Metrics/ModuleLength:
 # Max: 8
 Metrics/PerceivedComplexity:
   Max: 13
+  Exclude:
+    - 'lib/red_amber/vector_compensable.rb' # Max: 15
 
 # Necessary to define is_na
 Naming/PredicateName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,7 @@ Metrics/AbcSize:
   Max: 30
   Exclude:
     - 'lib/red_amber/data_frame_displayable.rb' # Max: 55
+    - lib/red_amber/vector_compensable.rb # Max: 36
 
 # Max: 25
 Metrics/BlockLength:
@@ -75,7 +76,7 @@ Metrics/CyclomaticComplexity:
 
 # Max: 10
 Metrics/MethodLength:
-  Max: 25
+  Max: 30
   Exclude:
     - 'lib/red_amber/data_frame_displayable.rb' # Max: 33
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -689,7 +689,9 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
 
 ## Treat na data
 
-- [ ] Drop na (NaN, nil)
+### `remove_nil`
+
+  Remove any observations containing nil.
 
 - [ ] Replace na with value
 

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -130,6 +130,8 @@ boolean.all(opts: {skip_nulls: false}) #=> false
 | ✓ `bit_wise_not`|  | (✓) |     |     |integer only|
 | ✓ `ceil`     |     |  ✓  |     |     |       |
 | ✓ `cos`      |     |  ✓  |     |     |       |
+| ✓`fill_nil_backward`| ✓ | ✓ | ✓ |    |       |
+| ✓`fill_nil_forward` | ✓ | ✓ | ✓ |    |       |
 | ✓ `floor`    |     |  ✓  |     |     |       |
 | ✓ `invert`   |  ✓  |     |     |     |`!`, alias `not`|
 |[ ]`ln`       |     | [ ] |     |     |       |

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -196,4 +196,73 @@ boolean.all(opts: {skip_nulls: false}) #=> false
 
 ## Coerce (not impremented)
 
-## Updating (not impremented)
+## Update vector's value
+### `replace_with(booleans, replacements)` => vector
+
+- Accepts Vector, Array, Arrow::Array for booleans and replacements.
+  - Replacements can accept scalar
+- Booleans specifies the position of replacement in true.
+- Replacements specifies the vaues to be replaced.
+  - The number of true in booleans must be equal to the length of replacement
+
+```ruby
+vector = RedAmber::Vector.new([1, 2, 3])
+booleans = [true, false, true]
+replacemants = [4, 5]
+vector.replace_with(booleans, replacemants)
+# => 
+#<RedAmber::Vector(:uint8, size=3):0x000000000001ee10>
+[4, 2, 5] 
+```
+
+- Scalar value in replacements can be broadcasted.
+
+```ruby
+replacemant = 0
+vector.replace_with(booleans, replacement)
+# => 
+#<RedAmber::Vector(:uint8, size=3):0x000000000001ee10>
+[0, 2, 0] 
+```
+
+- Returned data type is automatically up-casted by replacement.
+
+```ruby
+replacement = 1.0
+vector.replace_with(booleans, replacement)
+# => 
+#<RedAmber::Vector(:double, size=3):0x0000000000025d78>
+[1.0, 2.0, 1.0]
+```
+
+- Position of nil in booleans is replaced with nil.
+
+```ruby
+booleans = [true, false, nil]
+replacemant = -1
+vec.replace_with(booleans, replacement)
+=> 
+#<RedAmber::Vector(:int8, size=3):0x00000000000304d0>
+[-1, 2, nil]
+```
+
+- Replacemants can have nil in it.
+
+```ruby
+booleans = [true, false, true]
+replacemants = [nil]
+vec.replace_with(booleans, replacemants)
+=> 
+#<RedAmber::Vector(:int8, size=3):0x00000000000304d0>
+[nil, 2, nil]
+```
+
+- If no replacemants specified, it is same as to specify nil.
+
+```ruby
+booleans = [true, false, true]
+vec.replace_with(booleans)
+=> 
+#<RedAmber::Vector(:int8, size=3):0x00000000000304d0>
+[nil, 2, nil]
+```

--- a/lib/red_amber.rb
+++ b/lib/red_amber.rb
@@ -9,6 +9,7 @@ require_relative 'red_amber/data_frame_selectable'
 require_relative 'red_amber/data_frame_observation_operation'
 require_relative 'red_amber/data_frame_variable_operation'
 require_relative 'red_amber/data_frame'
+require_relative 'red_amber/vector_compensable'
 require_relative 'red_amber/vector_functions'
 require_relative 'red_amber/vector'
 require_relative 'red_amber/version'
@@ -20,4 +21,5 @@ module RedAmber
   class DataFrameTypeError < TypeError; end
 
   class VectorArgumentError < ArgumentError; end
+  class VectorTypeError < TypeError; end
 end

--- a/lib/red_amber.rb
+++ b/lib/red_amber.rb
@@ -18,4 +18,6 @@ module RedAmber
 
   class DataFrameArgumentError < ArgumentError; end
   class DataFrameTypeError < TypeError; end
+
+  class VectorArgumentError < ArgumentError; end
 end

--- a/lib/red_amber/data_frame_observation_operation.rb
+++ b/lib/red_amber/data_frame_observation_operation.rb
@@ -62,6 +62,12 @@ module RedAmber
       raise DataFrameArgumentError, "Invalid argument #{args}"
     end
 
+    def remove_nil
+      func = Arrow::Function.find(:drop_null)
+      DataFrame.new(func.execute([table]).value)
+    end
+    alias_method :drop_nil, :remove_nil
+
     private
 
     # return a DataFrame with same keys as self without values

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -5,6 +5,7 @@ module RedAmber
   #   @data : holds Arrow::ChunkedArray
   class Vector
     # mix-in
+    include VectorCompensable
     include VectorFunctions
 
     # chunked_array may come from column.data

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -18,7 +18,7 @@ module RedAmber
       when Array
         @data = Arrow::Array.new(array)
       else
-        raise ArgumentError, 'Unknown array in argument'
+        raise VectorArgumentError, 'Unknown array in argument'
       end
     end
 

--- a/lib/red_amber/vector_compensable.rb
+++ b/lib/red_amber/vector_compensable.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Available functions in Arrow are shown by `Arrow::Function.all.map(&:name)`
+# reference: https://arrow.apache.org/docs/cpp/compute.html
+
+module RedAmber
+  # mix-ins for class Vector
+  # Functions to make up some data (especially missing) for new data.
+  module VectorCompensable
+    # [Ternary]: replace_with(booleans, replacements) => vector
+    # Replace items selected with a boolean mask
+    #
+    # (from Arrow C++ inline doc.)
+    # Given an array and a boolean mask (either scalar or of equal length),
+    # along with replacement values (either scalar or array),
+    # each element of the array for which the corresponding mask element is
+    # true will be replaced by the next value from the replacements,
+    # or with null if the mask is null.
+    # Hence, for replacement arrays, len(replacements) == sum(mask == true).
+
+    def replace_with(booleans, replacements)
+      boolean_ary =
+        if booleans.is_a?(Arrow::BooleanArray)
+          booleans
+        elsif booleans.is_a?(Vector) && booleans.boolean?
+          booleans.data
+        elsif booleans.is_a?(Array) && booleans?(booleans)
+          Arrow::BooleanArray.new(booleans)
+        else
+          raise VectorTypeError, 'Not a valid type'
+        end
+      raise VectorArgumentError, 'Booleans size unmatch' if boolean_ary.length != size
+      raise VectorArgumentError, 'Booleans not have any `true`' unless boolean_ary.any?
+
+      replacement_ary =
+        if Array(replacements).one?
+          case replacements
+          when Arrow::Array then replacements
+          when Vector then replacements.data
+          else
+            Arrow::Array.new(Array(replacements) * Array(boolean_ary).count(true)) # broadcast
+          end
+        else
+          Arrow::Array.new(replacements)
+        end
+      if Array(boolean_ary).count(true) != replacement_ary.length
+        raise VectorArgumentError, 'Replacements size unmatch'
+      end
+
+      values = replacement_ary.class.new(data)
+
+      datum = find('replace_with_mask').execute([values, boolean_ary, replacement_ary])
+      take_out_element_wise(datum)
+    end
+
+    # (related functions)
+    # fill_null_backward, fill_null_forward
+
+    private
+
+    def booleans?(enum)
+      enum.all? { |e| e.is_a?(TrueClass) || e.is_a?(FalseClass) || e.is_a?(NilClass) }
+    end
+  end
+end

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -212,7 +212,7 @@ module RedAmber
       when Arrow::Array, Arrow::ChunkedArray, Arrow::Scalar, Array, Numeric, String, TrueClass, FalseClass
         find(function).execute([data, other], options)
       else
-        raise ArgumentError, "Operand is not supported: #{other.class}"
+        raise VectorArgumentError, "Operand is not supported: #{other.class}"
       end
     end
 

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -193,10 +193,10 @@ module RedAmber
     # choose, index_in, index_in_meta_binary, indices_nonzero
 
     # (others)
-    # coalesce, drop_null, fill_null_backward, fill_null_forward,
+    # coalesce, drop_null,
     # filter, is_in, is_in_meta_binary,
     # list_element, list_flatten, list_parent_indices, list_value_length, make_struct,
-    # max_element_wise, min_element_wise, random, replace_with_mask, select_k_unstable,
+    # max_element_wise, min_element_wise, random, select_k_unstable,
     # sort_indices, struct_field, take
 
     private # =======

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -42,8 +42,8 @@ module RedAmber
 
     # [Unary element-wise]: vector.func => vector
     unary_element_wise =
-      %i[abs atan bit_wise_not ceil cos floor is_finite is_inf is_nan is_null is_valid
-         round round_to_multiple sign sin tan trunc]
+      %i[abs atan bit_wise_not ceil cos fill_null_backward fill_null_forward floor is_finite
+         is_inf is_nan is_null is_valid round round_to_multiple sign sin tan trunc]
     unary_element_wise.each do |function|
       define_method(function) do |opts: nil|
         datum = exec_func_unary(function, options: opts)
@@ -55,6 +55,9 @@ module RedAmber
     def is_na
       numeric? ? (is_nil | is_nan) : is_nil
     end
+
+    alias_method :fill_nil_backward, :fill_null_backward
+    alias_method :fill_nil_forward, :fill_null_forward
 
     # [Unary element-wise with operator]: vector.func => vector, op vector
     unary_element_wise_op = {

--- a/test/test_data_frame_observation_operation.rb
+++ b/test/test_data_frame_observation_operation.rb
@@ -232,4 +232,23 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       assert_equal str, @df.remove { indexes.map(&:even?) }.tdr_str
     end
   end
+
+  sub_test_case 'remove_nil empty' do
+    test 'Empty dataframe' do
+      df = DataFrame.new
+      assert_true df.remove_nil.empty?
+    end
+
+    test 'remove_nil' do
+      assert_equal <<~OUTPUT, @df.remove_nil.tdr_str
+        RedAmber::DataFrame : 4 x 4 Vectors
+        Vectors : 2 numeric, 1 string, 1 boolean
+        # key     type    level data_preview
+        1 :index  uint8       4 [0, 1, 2, 3]
+        2 :float  double      4 [0.0, 1.1, 2.2, NaN], 1 NaN
+        3 :string string      4 ["A", "B", "C", "D"]
+        4 :bool   boolean     2 {true=>2, false=>2}
+      OUTPUT
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,12 +17,16 @@ module Helper
   end
 
   def assert_equal_array(expected, actual, message = nil)
-    assert_equal(expected.to_a, actual.to_a, message)
+    assert_equal(Array(expected), Array(actual), message)
   end
 
   def assert_equal_array_in_delta(expected, actual, delta = 0.001, message = '')
-    expected.to_a.zip(actual.to_a) do |e, a|
+    Array(expected).zip(Array(actual)) do |e, a|
       assert_in_delta(e, a, delta, message)
     end
+  end
+
+  def assert_equal_array_with_nan(expected, actual, message = nil)
+    assert_equal(Array(expected).to_s, Array(actual).to_s, message)
   end
 end

--- a/test/test_vector_compensable.rb
+++ b/test/test_vector_compensable.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class VectorTest < Test::Unit::TestCase
+  include RedAmber
+  include Helper
+
+  sub_test_case('replace_with') do
+    test 'empty vector' do
+      vec = Vector.new([])
+      assert_raise(VectorArgumentError) { vec.replace_with([], nil) }
+    end
+
+    test 'replace UInt single' do
+      vec = Vector.new([1, 2, 3])
+      assert_equal [1, 2, 0], vec.replace_with([false, false, true], 0).to_a
+      assert_equal [1, 2, 0], vec.replace_with([false, false, true], [0]).to_a
+      assert_raise(VectorArgumentError) { vec.replace_with([true], 0) }
+      assert_raise(VectorArgumentError) { vec.replace_with([false, false, nil], 0) }
+      assert_raise(VectorArgumentError) { vec.replace_with([true, false, nil], [0, 0]) }
+    end
+
+    test 'replace UInt multi/broadcast' do
+      vec = Vector.new([1, 2, 3])
+      assert_equal [0, 2, 0], vec.replace_with([true, false, true], [0, 0]).to_a
+      assert_equal [0, 2, 0], vec.replace_with([true, false, true], 0).to_a
+    end
+
+    test 'replace UInt multi/upcast' do
+      vec = Vector.new([1, 2, 3])
+      assert_equal [0, 2, -1], vec.replace_with([true, false, true], [0, -1]).to_a
+      assert_equal :int8, vec.replace_with([true, false, true], [0, -1]).type
+    end
+
+    test 'replace containing nil' do
+      vec = Vector.new([1, 2, 3])
+      assert_equal [0, 2, nil], vec.replace_with([true, false, nil], [0]).to_a
+    end
+
+    test 'replace Arrow::Array' do
+      vec = Vector.new([1, 2, 3])
+      booleans = Arrow::Array.new([true, false, nil])
+      assert_equal [0, 2, nil], vec.replace_with(booleans, [0]).to_a
+    end
+  end
+end

--- a/test/test_vector_compensable.rb
+++ b/test/test_vector_compensable.rb
@@ -16,14 +16,15 @@ class VectorTest < Test::Unit::TestCase
       vec = Vector.new([1, 2, 3])
       assert_equal [1, 2, 0], vec.replace_with([false, false, true], 0).to_a
       assert_equal [1, 2, 0], vec.replace_with([false, false, true], [0]).to_a
-      assert_raise(VectorArgumentError) { vec.replace_with([true], 0) }
-      assert_raise(VectorArgumentError) { vec.replace_with([false, false, nil], 0) }
-      assert_raise(VectorArgumentError) { vec.replace_with([true, false, nil], [0, 0]) }
+      assert_raise(VectorArgumentError) { vec.replace_with([true], 0) } # boolean size mismatch
+      assert_raise(VectorArgumentError) { vec.replace_with([false, false, nil], 0) } # no true in boolean
+      assert_raise(VectorArgumentError) { vec.replace_with([true, false, nil], [0, 0]) } # replacement size mismatch
     end
 
     test 'replace UInt multi/broadcast' do
       vec = Vector.new([1, 2, 3])
       assert_equal [0, 2, 0], vec.replace_with([true, false, true], [0, 0]).to_a
+      assert_equal [0, 2, 0], vec.replace_with([true, false, true], [0]).to_a
       assert_equal [0, 2, 0], vec.replace_with([true, false, true], 0).to_a
     end
 
@@ -42,6 +43,14 @@ class VectorTest < Test::Unit::TestCase
       vec = Vector.new([1, 2, 3])
       booleans = Arrow::Array.new([true, false, nil])
       assert_equal [0, 2, nil], vec.replace_with(booleans, [0]).to_a
+    end
+
+    test 'replace with nil' do
+      vec = Vector.new([1, 2, 3])
+      assert_equal [0, 2, nil], vec.replace_with([true, false, true], [0, nil]).to_a # 1 nil
+      assert_equal [nil, 2, nil], vec.replace_with([true, false, true], [nil]).to_a # broadcast with nil
+      assert_equal [nil, 2, nil], vec.replace_with([true, false, true], nil).to_a # broadcast with nil
+      assert_equal [nil, 2, nil], vec.replace_with([true, false, true]).to_a # broadcast without replacemant
     end
   end
 end

--- a/test/test_vector_function.rb
+++ b/test/test_vector_function.rb
@@ -404,6 +404,29 @@ class VectorFunctionTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case('unary element-wise fill_nil_forward/backward') do
+    setup do
+      @boolean = Vector.new([true, false, nil, true, nil])
+      @integer = Vector.new([0, 1, nil, 3, nil])
+      @double = Vector.new([Math::PI, Float::INFINITY, nil, Float::NAN, nil])
+      @string = Vector.new(['A', 'B', nil, '', nil])
+    end
+
+    test '#fill_nil_backward' do
+      assert_equal_array [true, false, true, true, nil], @boolean.fill_nil_backward
+      assert_equal_array [0, 1, 3, 3, nil], @integer.fill_nil_backward
+      assert_equal_array_with_nan [Math::PI, Float::INFINITY, Float::NAN, Float::NAN, nil], @double.fill_nil_backward
+      assert_equal_array ['A', 'B', '', '', nil], @string.fill_nil_backward
+    end
+
+    test '#fill_nil_forward' do
+      assert_equal_array [true, false, false, true, true], @boolean.fill_nil_forward
+      assert_equal_array [0, 1, 1, 3, 3], @integer.fill_nil_forward
+      assert_equal_array_with_nan [Math::PI, Float::INFINITY, Float::INFINITY, Float::NAN, Float::NAN], @double.fill_nil_forward
+      assert_equal_array ['A', 'B', 'B', '', ''], @string.fill_nil_forward
+    end
+  end
+
   sub_test_case('binary element-wise') do
     setup do
       @boolean = Vector.new([true, true, nil])


### PR DESCRIPTION
This pull request is to Add support to make up for missing values.

- Create a new module `Compensable`
- Introduce `replace_with(booleans, replacements)` => vector
  - Using Arrow's ternary function `replace_with_mask`
  - Accepts Vector, Array, Arrow::Array for booleans and replacements
  - Scalar value in replacements is broadcasted
  - Up cast by replacements
- Introduce new `VectorArgumentError`, `VectorTypeError`

This will be a general case for compensating operations.