### PR TITLE
Introduce rounding functions to Vector

### DIFF
--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -126,20 +126,20 @@ boolean.all(opts: {skip_nulls: false}) #=> false
 |[ ]`asin`     |     | [ ] |     |     |       |
 | ✓ `atan`     |     |  ✓  |     |     |       |
 | ✓ `bit_wise_not`|  | (✓) |     |     |integer only|
-|[ ]`ceil`     |     |  ✓  |     |     |       |
+| ✓ `ceil`     |     |  ✓  |     |     |       |
 | ✓ `cos`      |     |  ✓  |     |     |       |
-|[ ]`floor`    |     |  ✓  |     |     |       |
+| ✓ `floor`    |     |  ✓  |     |     |       |
 | ✓ `invert`   |  ✓  |     |     |     |`!`, alias `not`|
 |[ ]`ln`       |     | [ ] |     |     |       |
 |[ ]`log10`    |     | [ ] |     |     |       |
 |[ ]`log1p`    |     | [ ] |     |     |       |
 |[ ]`log2`     |     | [ ] |     |     |       |
-|[ ]`round`    |     | [ ] |     |[ ] Round|       |
-|[ ]`round_to_multiple`| | [ ] | |[ ] RoundToMultiple|       |
+| ✓ `round`    |     |  ✓  |     | ✓ Round (:mode, :n_digits)|    |
+| ✓ `round_to_multiple`| | ✓ |   | ✓ RoundToMultiple :mode, :multiple| multiple must be an Arrow::Scalar|
 | ✓ `sign`     |     |  ✓  |     |     |       |
 | ✓ `sin`      |     |  ✓  |     |     |       |
 | ✓ `tan`      |     |  ✓  |     |     |       |
-|[ ]`trunc`    |     |  ✓  |     |     |       |
+| ✓ `trunc`    |     |  ✓  |     |     |       |
 
 ### Binary element-wise: `vector.func(vector) => vector`
 

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -42,7 +42,8 @@ module RedAmber
 
     # [Unary element-wise]: vector.func => vector
     unary_element_wise =
-      %i[abs atan bit_wise_not ceil cos floor is_finite is_inf is_nan is_null is_valid sign sin tan trunc]
+      %i[abs atan bit_wise_not ceil cos floor is_finite is_inf is_nan is_null is_valid
+         round round_to_multiple sign sin tan trunc]
     unary_element_wise.each do |function|
       define_method(function) do |opts: nil|
         datum = exec_func_unary(function, options: opts)
@@ -72,9 +73,6 @@ module RedAmber
       end
     end
     alias_method :not, :invert
-
-    # option(s) required
-    # - round, round_to_multiple
 
     # NaN support needed
     # - acos asin ln log10 log1p log2


### PR DESCRIPTION
### Introduce rounding functions to Vector

This pull request will introduce rounding methods to Vector.

- `#round`
  - With options :mode and :n_digits
  - :n_digits also can be specified with :multiple option in `#round_to_multiple` 
- `ceil`
- `floor`
- `trunc`

See [Apache Arrow C++ document of rouonding functions](https://arrow.apache.org/docs/cpp/compute.html#rounding-functions) for detail.