### PR TITLE
Bump up requirements to Arrow 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A simple dataframe library for Ruby (experimental)
 ## Requirements
 
 ```ruby
-gem 'red-arrow',   '>= 7.0.0'
-gem 'red-parquet', '>= 7.0.0' # if you use IO from/to parquet
+gem 'red-arrow',   '>= 8.0.0'
+gem 'red-parquet', '>= 8.0.0' # if you use IO from/to parquet
 gem 'rover-df',    '~> 0.3.0' # if you use IO from/to Rover::DataFrame
 ```
 

--- a/red_amber.gemspec
+++ b/red_amber.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'red-arrow', '>= 7.0.0'
-  spec.add_dependency 'red-parquet', '>= 7.0.0'
+  spec.add_dependency 'red-arrow', '>= 8.0.0'
+  spec.add_dependency 'red-parquet', '>= 8.0.0'
   spec.add_dependency 'rover-df', '~> 0.3.0'
 
   # Development dependency has gone to the Gemfile (rubygems/bundler#7237)


### PR DESCRIPTION
This is a change in requirement of library from Arrow 7.0.0 to 8.0.0.

Arrow 7.0.0 with Ubuntu 21.04 causes an error in `replace_with_mask` function.
