### PR TITLE
Introduce benchmark tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+/benchmark/cache
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,7 @@ group :test do
 
   gem 'test-unit'
   gem 'webrick'
+
+  gem 'benchmark_driver'
+  gem 'red-datasets-arrow'
 end

--- a/benchmark/csv_load_penguins.yml
+++ b/benchmark/csv_load_penguins.yml
@@ -1,0 +1,15 @@
+prelude: |
+  require 'datasets-arrow'
+  require 'rover'
+  require 'red_amber'
+
+  penguins_csv = 'benchmark/cache/penguins.csv'
+
+  unless File.exist?(penguins_csv)
+    arrow = Datasets::Penguins.new.to_arrow
+    RedAmber::DataFrame.new(arrow).save(penguins_csv)
+  end
+
+benchmark:
+  'penguins by Rover': Rover.read_csv(penguins_csv)
+  'penguins by RedAmber': RedAmber::DataFrame.load(penguins_csv)

--- a/benchmark/drop_nil.yml
+++ b/benchmark/drop_nil.yml
@@ -1,0 +1,11 @@
+prelude: |
+  require 'datasets-arrow'
+  require 'red_amber'
+
+  penguins = RedAmber::DataFrame.new(Datasets::Penguins.new.to_arrow)
+
+  def drop_nil(penguins)
+    penguins.remove { vectors.map { |v| v.is_nil} }
+  end
+
+benchmark: drop_nil(penguins)


### PR DESCRIPTION
It is useful to check performance with benchmark test. This pull request introduces `benchmark_driver` gem and create benchmark folder.

There are 2 benchmark tests;
- csv_load_penguins.yml : Compare loading performance with Rover-df (using Ruby's primitive CSV).
- drop_nil.yml : Single benchmark to compare at any git checkouts.

This is a solution for issue #24 .