### PR TITLE
Add DataFrame#to_html to use in Jupyter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,7 +66,7 @@ Metrics/BlockLength:
 
 # Max: 100
 Metrics/ClassLength:
-  Max: 120
+  Max: 125
   Exclude:
     - 'test/**/*'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem 'rubocop-rake'
   gem 'rubocop-rubycw', require: false
 
+  gem 'iruby'
   gem 'test-unit'
   gem 'webrick'
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -179,6 +179,10 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
 
 - Returns a `Rover::DataFrame`.
 
+### `to_html`
+
+- Show the DataFrame as a Table in Jupyter Notebook or Jupyter Lab with IRuby.
+
 ### `tdr(limit = 10, tally: 5, elements: 5)`
 
   - Shows some information about self in a transposed style.

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -133,6 +133,19 @@ module RedAmber
       Rover::DataFrame.new(to_h)
     end
 
+    def to_html
+      require 'iruby'
+      return '(empty DataFrame)' if empty?
+
+      html =
+        if size > 8
+          IRuby::HTML.table((self[0..4, -4..-1]).to_h, maxrows: 8, maxcols: 15)
+        else
+          IRuby::HTML.table(to_h)
+        end
+      "#{size} x #{n_keys} vector#{n_keys > 1 ? 's' : ''} ; #{html}"
+    end
+
     private
 
     # initialize @variable, @keys, @vectors and return one of them

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.1.5'
+  VERSION = '0.1.6-HEAD'
 end


### PR DESCRIPTION
Add DataFrame#to_html to use in Jupyter Notebook or JupyterLab.
This is a solution for #29.

✓ Html table creation
✓ max_rows = 8, max_columns = 15
✓ Guard for empty dataframe
✓ Display shape