### PR TITLE
Introduce env variable to set default printing style

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,17 @@ See [Vector.md](doc/Vector.md) for details.
 
 ## TDR concept
 
-I named the data frame representation style in the model above as TDR (Transposed DataFrame Representation). See [TDR.md](doc/tdr.md) for details.
+I named the data frame representation style in the model above as TDR (Transposed DataFrame Representation). 
+
+This library can be used with both TDR mode and usual Table mode.
+If you set the environment variable `RED_AMBER_OUTPUT_MODE` to `"table"`, output style by `inspect` and `to_iruby` is the Table mode. Other value including nil will output TDR style.
+
+You can switch the mode in Ruby like this.
+```ruby
+ENV['RED_AMBER_OUTPUT_STYLE'] = 'table' # => Table mode
+```
+
+For more detail information about TDR, see [TDR.md](doc/tdr.md).
 
 ## Development
 

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -137,23 +137,13 @@ module RedAmber
       require 'iruby'
       return ['text/html', '(empty DataFrame)'] if empty?
 
-      reduced = size > 8 ? self[0..4, -4..-1] : self
-
-      converted = reduced.assign do
-        vectors.select.with_object({}) do |vector, assigner|
-          if vector.has_nil?
-            assigner[vector.key] = vector.to_a.map do |e|
-              e = e.nil? ? '<i>(nil)</i>' : e.to_s # nil
-              e = '""' if e.empty? # empty string
-              e.sub(/(\s+)/, '"\1"') # blank spaces
-            end
-          end
-        end
+      if ENV.fetch('RED_AMBER_OUTPUT_MODE', 'tdr') == 'table'
+        ['text/html', html_table]
+      elsif size <= 5
+        ['text/text', tdr_str(tally: 0)]
+      else
+        ['text/text', tdr_str]
       end
-
-      html = IRuby::HTML.table(converted.to_h, maxrows: 8, maxcols: 15)
-      html = "#{size} x #{n_keys} vector#{pl(n_keys)} ; #{html}"
-      ['text/html', html]
     end
 
     private
@@ -170,6 +160,25 @@ module RedAmber
       end
       @variables, @keys, @vectors = ary
       ary[%i[variables keys vectors].index(var)]
+    end
+
+    def html_table
+      reduced = size > 8 ? self[0..4, -4..-1] : self
+
+      converted = reduced.assign do
+        vectors.select.with_object({}) do |vector, assigner|
+          if vector.has_nil?
+            assigner[vector.key] = vector.to_a.map do |e|
+              e = e.nil? ? '<i>(nil)</i>' : e.to_s # nil
+              e = '""' if e.empty? # empty string
+              e.sub(/(\s+)/, '"\1"') # blank spaces
+            end
+          end
+        end
+      end
+
+      html = IRuby::HTML.table(converted.to_h, maxrows: 8, maxcols: 15)
+      "#{size} x #{n_keys} vector#{pl(n_keys)} ; #{html}"
     end
   end
 end

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -135,14 +135,14 @@ module RedAmber
 
     def to_iruby
       require 'iruby'
-      return ['text/html', '(empty DataFrame)'] if empty?
+      return ['text/plain', '(empty DataFrame)'] if empty?
 
       if ENV.fetch('RED_AMBER_OUTPUT_MODE', 'tdr') == 'table'
         ['text/html', html_table]
       elsif size <= 5
-        ['text/text', tdr_str(tally: 0)]
+        ['text/plain', tdr_str(tally: 0)]
       else
-        ['text/text', tdr_str]
+        ['text/plain', tdr_str]
       end
     end
 

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -14,7 +14,11 @@ module RedAmber
     # def summary() end
 
     def inspect
-      "#<#{shape_str(with_id: true)}>\n#{dataframe_info(3)}"
+      if ENV.fetch('RED_AMBER_OUTPUT_MODE', 'tdr') == 'table'
+        "#<#{shape_str(with_id: true)}>\n#{self}"
+      else
+        "#<#{shape_str(with_id: true)}>\n#{dataframe_info(3)}"
+      end
     end
 
     # - limit: max num of Vectors to show

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -162,7 +162,7 @@ class DataFrameTest < Test::Unit::TestCase
 
     test 'empty' do
       df = DataFrame.new
-      assert_equal ['text/html', '(empty DataFrame)'], df.to_iruby
+      assert_equal ['text/plain', '(empty DataFrame)'], df.to_iruby
     end
 
     test 'simple dataframe' do
@@ -192,7 +192,7 @@ class DataFrameTest < Test::Unit::TestCase
 
     test 'empty' do
       df = DataFrame.new
-      assert_equal ['text/html', '(empty DataFrame)'], df.to_iruby
+      assert_equal ['text/plain', '(empty DataFrame)'], df.to_iruby
     end
 
     test 'simple dataframe' do

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -80,11 +80,11 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
       str = <<~OUTPUT
         #<RedAmber::DataFrame : 6 x 4 Vectors, #{format('0x%016x', @df.object_id)}>
         \tinteger\t    double\tstring\tboolean
-        0\t      1\t  1.000000\tA     \ttrue   
-        1\t      2\t       NaN\tA     \tfalse  
+        0\t      1\t  1.000000\tA     \ttrue   \n\
+        1\t      2\t       NaN\tA     \tfalse  \n\
         2\t      3\t       Inf\tB     \t (null)
-        3\t      4\t      -Inf\tC     \ttrue   
-        4\t      5\t    (null)\tD     \tfalse  
+        3\t      4\t      -Inf\tC     \ttrue   \n\
+        4\t      5\t    (null)\tD     \tfalse  \n\
         5\t      6\t  0.000000\tE     \t (null)
       OUTPUT
       assert_equal str, @df.inspect

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -24,7 +24,11 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case 'inspect' do
+  sub_test_case 'inspect by tdr mode' do
+    setup do
+      ENV['RED_AMBER_OUTPUT_MODE'] = 'tdr'
+    end
+
     test 'empty dataframe' do
       df = DataFrame.new
       str = "#<RedAmber::DataFrame : (empty), #{format('0x%016x', df.object_id)}>\n"
@@ -48,6 +52,40 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         2 :double  double      6 [1.0, NaN, Infinity, -Infinity, nil, ... ], 1 NaN, 1 nil
         3 :string  string      5 {"A"=>2, "B"=>1, "C"=>1, "D"=>1, "E"=>1}
          ... 1 more Vector ...
+      OUTPUT
+      assert_equal str, @df.inspect
+    end
+  end
+
+  sub_test_case 'inspect by table mode' do
+    setup do
+      ENV['RED_AMBER_OUTPUT_MODE'] = 'table'
+    end
+
+    test 'empty dataframe' do
+      df = DataFrame.new
+      str = "#<RedAmber::DataFrame : (empty), #{format('0x%016x', df.object_id)}>\n\n"
+      assert_equal str, df.inspect
+    end
+
+    setup do
+      hash = { integer: [1, 2, 3, 4, 5, 6],
+               double: [1, 0 / 0.0, 1 / 0.0, -1 / 0.0, nil, ''],
+               string: %w[A A B C D E],
+               boolean: [true, false, nil, true, false, nil] }
+      @df = DataFrame.new(hash)
+    end
+
+    test 'default' do
+      str = <<~OUTPUT
+        #<RedAmber::DataFrame : 6 x 4 Vectors, #{format('0x%016x', @df.object_id)}>
+        \tinteger\t    double\tstring\tboolean
+        0\t      1\t  1.000000\tA     \ttrue   
+        1\t      2\t       NaN\tA     \tfalse  
+        2\t      3\t       Inf\tB     \t (null)
+        3\t      4\t      -Inf\tC     \ttrue   
+        4\t      5\t    (null)\tD     \tfalse  
+        5\t      6\t  0.000000\tE     \t (null)
       OUTPUT
       assert_equal str, @df.inspect
     end


### PR DESCRIPTION
RedAmber can display a DataFrame in Table style and TDR style.

This change will enable to change the default printing mode:

- `to_iruby` in Jupyter
- `inspect` in irb etc.