### PR TITLE
Introduce Vector#replace method

### DIFF
--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -466,7 +466,7 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
      ... 5 more Vectors ...
     ```
 
-- Keys or booleans by a block
+- Indices or booleans by a block
 
     `slice {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return indeces or a boolean Array with a same length as `size`. Block is called in the context of self.
 
@@ -518,7 +518,7 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
 
   ![remove method image](doc/../image/dataframe/remove.png)
 
-- Keys as arguments
+- Indices as arguments
 
     `remove(indeces)` accepts indeces as arguments. Indeces should be an Integer or a Range of Integer.
 
@@ -557,7 +557,7 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
     8 :year              uint16     3 {2007=>103, 2008=>113, 2009=>117}    
     ```
 
-- Keys or booleans by a block
+- Indices or booleans by a block
 
     `remove {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return indeces or a boolean Array with a same length as `size`. Block is called in the context of self.
 

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -375,12 +375,13 @@ vector.replace(vector == 'NA', nil)
 Specified indices are used 'as sorted'. Position in indices and replacer may not have correspondence.
 
 ```ruby
+vector = RedAmber::Vector.new([1, 2, 3])
 indices = [2, 1]
 replacer = [4, 5]
 vector.replace(indices, replacer)
 # =>
 #<RedAmber::Vector(:uint8, size=3):0x000000000000f244>
-[1, 4, 5]
+[1, 4, 5] # not [1, 5, 4]
 ```
 
 

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -289,39 +289,40 @@ boolean.all(opts: {skip_nulls: false}) #=> false
 ## Coerce (not impremented)
 
 ## Update vector's value
-### `replace_with(booleans, replacements)` => vector
+### `replace(specifier, replacer)` => vector
 
-- Accepts Vector, Array, Arrow::Array for booleans and replacements.
-  - Replacements can accept scalar
-- Booleans specifies the position of replacement in true.
-- Replacements specifies the vaues to be replaced.
-  - The number of true in booleans must be equal to the length of replacement
+- Accepts Scalar, Range  of Integer, Vector, Array, Arrow::Array as a specifier
+- Accepts Scalar, Vector, Array and Arrow::Array as a replacer.
+- Boolean specifiers specify the position of replacer in true.
+- Index specifiers specify the position of replacer in indices.
+- replacer specifies the values to be replaced.
+  - The number of true in booleans must be equal to the length of replacer
 
 ```ruby
 vector = RedAmber::Vector.new([1, 2, 3])
 booleans = [true, false, true]
-replacemants = [4, 5]
-vector.replace_with(booleans, replacemants)
+replacer = [4, 5]
+vector.replace(booleans, replacer)
 # => 
 #<RedAmber::Vector(:uint8, size=3):0x000000000001ee10>
 [4, 2, 5] 
 ```
 
-- Scalar value in replacements can be broadcasted.
+- Scalar value in replacer can be broadcasted.
 
 ```ruby
-replacemant = 0
-vector.replace_with(booleans, replacement)
+replacer = 0
+vector.replace(booleans, replacer)
 # => 
 #<RedAmber::Vector(:uint8, size=3):0x000000000001ee10>
 [0, 2, 0] 
 ```
 
-- Returned data type is automatically up-casted by replacement.
+- Returned data type is automatically up-casted by replacer.
 
 ```ruby
-replacement = 1.0
-vector.replace_with(booleans, replacement)
+replacer = 1.0
+vector.replace(booleans, replacer)
 # => 
 #<RedAmber::Vector(:double, size=3):0x0000000000025d78>
 [1.0, 2.0, 1.0]
@@ -331,29 +332,29 @@ vector.replace_with(booleans, replacement)
 
 ```ruby
 booleans = [true, false, nil]
-replacemant = -1
-vec.replace_with(booleans, replacement)
+replacer = -1
+vec.replace(booleans, replacer)
 => 
 #<RedAmber::Vector(:int8, size=3):0x00000000000304d0>
 [-1, 2, nil]
 ```
 
-- Replacemants can have nil in it.
+- replacer can have nil in it.
 
 ```ruby
 booleans = [true, false, true]
-replacemants = [nil]
-vec.replace_with(booleans, replacemants)
+replacer = [nil]
+vec.replace(booleans, replacer)
 => 
 #<RedAmber::Vector(:int8, size=3):0x00000000000304d0>
 [nil, 2, nil]
 ```
 
-- If no replacemants specified, it is same as to specify nil.
+- If no replacer specified, it is same as to specify nil.
 
 ```ruby
 booleans = [true, false, true]
-vec.replace_with(booleans)
+vec.replace(booleans)
 => 
 #<RedAmber::Vector(:int8, size=3):0x00000000000304d0>
 [nil, 2, nil]
@@ -363,11 +364,25 @@ vec.replace_with(booleans)
 
 ```ruby
 vector = RedAmber::Vector.new(['A', 'B', 'NA'])
-vector.replace_with(vector == 'NA', nil)
+vector.replace(vector == 'NA', nil)
 # =>
 #<RedAmber::Vector(:string, size=3):0x000000000000f8ac>
 ["A", "B", nil]
 ```
+
+- Specifier in indices.
+
+Specified indices are used 'as sorted'. Position in indices and replacer may not have correspondence.
+
+```ruby
+indices = [2, 1]
+replacer = [4, 5]
+vector.replace(indices, replacer)
+# =>
+#<RedAmber::Vector(:uint8, size=3):0x000000000000f244>
+[1, 4, 5]
+```
+
 
 ### `fill_nil_forward`, `fill_nil_backward` => vector
 

--- a/lib/red_amber/vector_updatable.rb
+++ b/lib/red_amber/vector_updatable.rb
@@ -7,53 +7,26 @@ module RedAmber
   # mix-ins for class Vector
   # Functions to make up some data (especially missing) for new data.
   module VectorUpdatable
-    # [Ternary]: replace_with(booleans, replacements) => vector
-    # Replace items selected with a boolean mask
-    #
-    # (from Arrow C++ inline doc.)
-    # Given an array and a boolean mask (either scalar or of equal length),
-    # along with replacement values (either scalar or array),
-    # each element of the array for which the corresponding mask element is
-    # true will be replaced by the next value from the replacements,
-    # or with null if the mask is null.
-    # Hence, for replacement arrays, len(replacements) == sum(mask == true).
+    # Replace data
+    # @param arg [Array, Vector, Arrow::Array] index specifier
+    # @param replacer [Array, Vector, Arrow::Array] new data to replace for.
+    # @return [Vector] Replaced new Vector
+    def replace(args, replacer)
+      args = args.is_a?(Array) ? args : Array(args)
+      replacer = Array(replacer)
+      return self if args.empty? || args[0].nil?
 
-    def replace_with(booleans, replacements = nil)
-      specifier =
-        if booleans.is_a?(Arrow::BooleanArray)
-          booleans
-        elsif booleans.is_a?(Vector) && booleans.boolean?
-          booleans.data
-        elsif booleans.is_a?(Array) && booleans?(booleans)
-          Arrow::BooleanArray.new(booleans)
+      replacer = nil if replacer.empty?
+      vector = parse_to_vector(args)
+      booleans =
+        if vector.boolean?
+          vector
+        elsif vector.numeric?
+          Vector.new(indices).is_in(vector)
         else
-          raise VectorTypeError, 'Not a valid type'
+          raise VectorArgumentError, "Invalid data type #{args}"
         end
-      raise VectorArgumentError, 'Booleans size unmatch' if specifier.length != size
-      raise VectorArgumentError, 'Booleans not have any `true`' unless specifier.any?
-
-      r = Array(replacements) # scalar to [scalar]
-      r = [nil] if r.empty?
-
-      replacer =
-        if r.size == 1
-          case replacements
-          when Arrow::Array then replacements
-          when Vector then replacements.data
-          else
-            Arrow::Array.new(r * specifier.to_a.count(true)) # broadcast
-          end
-        else
-          Arrow::Array.new(r)
-        end
-      replacer = data.class.new(replacer) if replacer.uniq == [nil]
-
-      raise VectorArgumentError, 'Replacements size unmatch' if Array(specifier).count(true) != replacer.length
-
-      values = replacer.class.new(data)
-
-      datum = find('replace_with_mask').execute([values, specifier, replacer])
-      Vector.new(datum.value)
+      replace_with(booleans, replacer)
     end
 
     # (related functions)
@@ -75,6 +48,57 @@ module RedAmber
       raise VectorTypeError, "Not a boolean Vector: #{self}" unless boolean?
 
       is_nil.if_else(false, self).invert
+    end
+
+    private
+
+    # [Ternary]: replace_with(booleans, replacements) => vector
+    # Replace items selected with a boolean mask
+    #
+    # (from Arrow C++ inline doc.)
+    # Given an array and a boolean mask (either scalar or of equal length),
+    # along with replacement values (either scalar or array),
+    # each element of the array for which the corresponding mask element is
+    # true will be replaced by the next value from the replacements,
+    # or with null if the mask is null.
+    # Hence, for replacement arrays, len(replacements) == sum(mask == true).
+
+    def replace_with(booleans, replacer = nil)
+      specifier =
+        if booleans.is_a?(Arrow::BooleanArray)
+          booleans
+        elsif booleans.is_a?(Vector) && booleans.boolean?
+          booleans.data
+        elsif booleans.is_a?(Array) && booleans?(booleans)
+          Arrow::BooleanArray.new(booleans)
+        else
+          raise VectorTypeError, 'Not a valid type'
+        end
+      raise VectorArgumentError, 'Booleans size unmatch' if specifier.length != size
+      raise VectorArgumentError, 'Booleans not have any `true`' unless specifier.any?
+
+      r = Array(replacer) # scalar to [scalar]
+      r = [nil] if r.empty?
+
+      replacer =
+        if r.size == 1
+          case replacer
+          when Arrow::Array then replacer
+          when Vector then replacer.data
+          else
+            Arrow::Array.new(r * specifier.to_a.count(true)) # broadcast
+          end
+        else
+          Arrow::Array.new(r)
+        end
+      replacer = data.class.new(replacer) if replacer.uniq == [nil]
+
+      raise VectorArgumentError, 'Replacements size unmatch' if Array(specifier).count(true) != replacer.length
+
+      values = replacer.class.new(data)
+
+      datum = find('replace_with_mask').execute([values, specifier, replacer])
+      Vector.new(datum.value)
     end
   end
 end

--- a/test/test_vector_updatable.rb
+++ b/test/test_vector_updatable.rb
@@ -6,51 +6,70 @@ class VectorTest < Test::Unit::TestCase
   include RedAmber
   include Helper
 
-  sub_test_case('replace_with') do
+  sub_test_case('replace') do
     test 'empty vector' do
       vec = Vector.new([])
-      assert_raise(VectorArgumentError) { vec.replace_with([], nil) }
+      assert_true vec.replace(nil, nil).empty?
+      assert_true vec.replace([], nil).empty?
+      assert_true vec.replace([nil], nil).empty?
+    end
+
+    test 'replace UInt argument' do
+      vec = Vector.new([1, 2, 3])
+      assert_equal [0, 2, 0], vec.replace([0, 2], 0).to_a
+      assert_equal [0, 2, 0], vec.replace([2, 0], [0]).to_a
+      assert_equal [0, 2, 4], vec.replace([0, 2], [0, 4]).to_a
+      assert_raise(VectorArgumentError) { vec.replace([0, 2], [0, 0, 0]) } # size mismatch
+      assert_raise(VectorArgumentError) { vec.replace([0, 1, 2], [0, 0]) } # size mismatch
+      assert_equal [5, 2, 4], vec.replace([0, 2, nil], [5, 4]).to_a
+      assert_equal [0, 2, nil], vec.replace([0, 2], [0, nil]).to_a
+    end
+
+    test 'replace Int/Range argument mixture' do
+      vec = Vector.new([1, 2, 3])
+      assert_equal [0, 0, 0], vec.replace([0..1, 2], 0).to_a
+      assert_equal [1, 2, 0], vec.replace([2, -1], 0).to_a
     end
 
     test 'replace UInt single' do
       vec = Vector.new([1, 2, 3])
-      assert_equal [1, 2, 0], vec.replace_with([false, false, true], 0).to_a
-      assert_equal [1, 2, 0], vec.replace_with([false, false, true], [0]).to_a
-      assert_raise(VectorArgumentError) { vec.replace_with([true], 0) } # boolean size mismatch
-      assert_raise(VectorArgumentError) { vec.replace_with([false, false, nil], 0) } # no true in boolean
-      assert_raise(VectorArgumentError) { vec.replace_with([true, false, nil], [0, 0]) } # replacement size mismatch
+      assert_equal [1, 2, 0], vec.replace([false, false, true], 0).to_a
+      assert_equal [1, 2, 0], vec.replace([false, false, true], [0]).to_a
+      assert_raise(VectorArgumentError) { vec.replace([true], 0) } # boolean size mismatch
+      assert_raise(VectorArgumentError) { vec.replace([false, false, nil], 0) } # no true in boolean
+      assert_raise(VectorArgumentError) { vec.replace([true, false, nil], [0, 0]) } # replacement size mismatch
     end
 
-    test 'replace UInt multi/broadcast' do
+    test 'replace multi/broadcast' do
       vec = Vector.new([1, 2, 3])
-      assert_equal [0, 2, 0], vec.replace_with([true, false, true], [0, 0]).to_a
-      assert_equal [0, 2, 0], vec.replace_with([true, false, true], [0]).to_a
-      assert_equal [0, 2, 0], vec.replace_with([true, false, true], 0).to_a
+      assert_equal [0, 2, 0], vec.replace([true, false, true], [0, 0]).to_a
+      assert_equal [0, 2, 0], vec.replace([true, false, true], [0]).to_a
+      assert_equal [0, 2, 0], vec.replace([true, false, true], 0).to_a
     end
 
-    test 'replace UInt multi/upcast' do
+    test 'replace multi/upcast' do
       vec = Vector.new([1, 2, 3])
-      assert_equal [0, 2, -1], vec.replace_with([true, false, true], [0, -1]).to_a
-      assert_equal :int8, vec.replace_with([true, false, true], [0, -1]).type
+      assert_equal [0, 2, -1], vec.replace([true, false, true], [0, -1]).to_a
+      assert_equal :int8, vec.replace([true, false, true], [0, -1]).type
     end
 
     test 'replace containing nil' do
       vec = Vector.new([1, 2, 3])
-      assert_equal [0, 2, nil], vec.replace_with([true, false, nil], [0]).to_a
+      assert_equal [0, 2, nil], vec.replace([true, false, nil], [0]).to_a
     end
 
     test 'replace Arrow::Array' do
       vec = Vector.new([1, 2, 3])
       booleans = Arrow::Array.new([true, false, nil])
-      assert_equal [0, 2, nil], vec.replace_with(booleans, [0]).to_a
+      assert_equal [0, 2, nil], vec.replace(booleans, [0]).to_a
     end
 
     test 'replace with nil' do
       vec = Vector.new([1, 2, 3])
-      assert_equal [0, 2, nil], vec.replace_with([true, false, true], [0, nil]).to_a # 1 nil
-      assert_equal [nil, 2, nil], vec.replace_with([true, false, true], [nil]).to_a # broadcast with nil
-      assert_equal [nil, 2, nil], vec.replace_with([true, false, true], nil).to_a # broadcast with nil
-      assert_equal [nil, 2, nil], vec.replace_with([true, false, true]).to_a # broadcast without replacemant
+      assert_equal [0, 2, nil], vec.replace([true, false, true], [0, nil]).to_a # 1 nil
+      assert_equal [nil, 2, nil], vec.replace([true, false, true], [nil]).to_a # broadcast with nil
+      assert_equal [nil, 2, nil], vec.replace([true, false, true], nil).to_a # broadcast with nil
+      assert_raise(ArgumentError) { vec.replace([true, false, true]) } # w/o replacer
     end
   end
 


### PR DESCRIPTION
This change will add new method to Vector.

## `replace(specifier, replacer)` => vector

- Accepts Scalar, Range  of Integer, Vector, Array, Arrow::Array as a specifier
- Accepts Scalar, Vector, Array and Arrow::Array as a replacer.
- Boolean specifiers specify the position of replacer in true.
- Index specifiers specify the position of replacer in indices.
- replacer specifies the values to be replaced.
  - The number of true in booleans must be equal to the length of replacer

```ruby
vector = RedAmber::Vector.new([1, 2, 3])
booleans = [true, false, true]
replacer = [4, 5]
vector.replace(booleans, replacer)
# => 
#<RedAmber::Vector(:uint8, size=3):0x000000000001ee10>
[4, 2, 5] 
```