### PR TITLE
Release 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,115 @@
-## [0.2.0] - unreleased
+## - unreleased
 
 - Document
   - YARD support
 
-- DataFrame#join features
+- `datasets-red-amber` gem
+- `red-amber` gem
 
-## [0.1.6] - Unreleased
+- `Vector#divmod`
+  - Introduce if Arrow's function is ready
 
-- Feedback something to Red Data Tools
+## - Unreleased, will be after Arrow 9.0.0 released
 
 - `DataFrame`
   - Introduce `summary` or ``describe`
-  - Add `Quantile` by own code?
-  - Improve dataframe obs. manipuration methods to accept float as a index (#10)
-  - Improve as more performant by benchmark check.
+    - `Quantile` will be available
 
-- `Vector`
-  - Support more functions
-  - Support coerece
+## [0.1.7] - Unreleased, may be 2022-07-10
 
+- Feedback something to Red Data Tools
+- Support more functions
+- Improve as more performant
 - More examples of frequently needed tasks
+
+- New `Group` API
+- `DataFrame#join features
+
+## [0.1.6] - 2022-06-26 (experimental)
+
+- Bug fixes
+  - Fix mime-type of empty DataFrame in `#to_iruby` (#31)
+  - Fix mime setting in `DataFrame#to_iruby` (#36)
+  - Fix unmatched return val in Selectable (#34)
+  - Fix to return same error as `#[]` in `DataFrame#slice` (#34)
+
+- New features and improvements
+  - Introduce Jupyter support (#29, #30, #31, #32)
+    - Add `DataFrame#to_html (changed to use #to_iruby)
+    - Add feature to show nil in to_iruby
+      - nil is expressed as (nil)
+      - empty string('') is ""
+      - blank spaces are " "
+
+  - Enable to change DataFrame display mode by ENV (#36)
+    - Support ENV['RED_AMBER_OUTPUT_STYLE'] to change display mode in `#inspect` and `#to_iruby`
+      - ENV['RED_AMBER_OUTPUT_STYLE'] = 'table' # => Table mode
+      - ENV['RED_AMBER_OUTPUT_STYLE'] = nil or other than 'table' # => TDR mode
+
+  - Support `require 'red-amber'`, as well (#34)
+
+  - Refine Vector slicing methods (#31)
+    - Introduce `Vector#take` method
+    - Introduce `Vector#filter` method
+    - Improve `Vector#[]` to overload take and filter
+    - Introduce `Vector#drop_nil` method
+    - Introduce `Vector#if_else` method
+    - Intorduce `Vector#is_in` method
+    - Add alias `Vector#all?`, `#any?` methods (#32)
+    - Add `Vector#has_nil?` method(#32)
+    - Add `Vector#empty?` method
+    - Add `Vector#primitive_invert` method
+    - Refactor `Vector#take`, `#filter`
+    - Move `Vector#if_else` from function to Updatable
+    - Move if_else test to updatable
+    - Rename updatable in test
+    - Remove method `Vector#take_out_element_wise`
+    - Rename inner metthod name
+
+  - Refine DataFrame slicing methods (#31)
+    - Introduce `DataFrame#take method
+      - #take is implemented as vector calculation by #if_else
+    - Introduce `DataFrame#fliter method
+    - Change `DataFrame#[] to use take and filter
+      - Float indices is acceptable (#10)
+      - Negative index (like Array) is also acceptable
+
+  - Further refinement in DataFrame slicing methods (#34)
+   -  Improve `DataFrame#[]`, `#slice`, `#remove` by a new engine
+      -  It parses arguments to Vector internally.
+      -  Used Kernel#Array to simplify code (#16) .
+    - recycle: Move `DataFrame#slice`, `#remove` to Selectable
+    - Refine `DataFrame#take`, `#filter` (undocumented)
+
+  - Introduce coerce in Vector (#35)
+    - Introduce `Vector#coerce`
+      - Now we can `-1 * Vector.new([1, 2, 3])`
+    - Add `Vector#to_ary` method
+      - Now we can `[1, 2] + Vector.new([3, 4, 5])`
+
+  - Other new feature or refinements
+    - Common
+      - Refactor helper as common for DataFrame and Vector (#35)
+      - Change name row/col to obs/var (#34)
+      - Rename internal function name (#34)
+      - Delete unused methods (#34)
+    - DataFrame
+      - Change to return instance variable in `#to_arrow`, `#keys` and `#key_index` (#34)
+      - Change to return an Array in `DataFrame#indices` (#35)
+    - Vector
+      - Introduce `Vector#replace` method
+      - Accept Range and expanded Array in `Vector#new`
+      - Add `Vector#indices` method (#35)
+      - Add `Vector#index` method (#35)
+      - Rename VectorCompensable to *Updatable (#33)
+
+  - Documentation
+    - Fix typo in DataFrame.md
 
 ## [0.1.5] - 2022-06-12 (experimental)
 
 - Bug fixes
-  - Fix DF#tdr to display timestamp type (#19)
+  - Fix DataFrame#tdr to display timestamp type (#19)
   - Add TZ setting in CI test to pass temporal tests (#19)
   - Fix example in document of #load(csv_from_URI) (#23)
 
@@ -38,7 +123,7 @@
     - Add `Vector#temporal?` to check if temporal type
     - Refine around DataFrame#variables
     - Refine init of instance variables
-    - Refine DataFrame#type_classes, V#ectortype_class
+    - Refine DataFrame#type_classes, Vector#ectortype_class
     - Refine DataFrame#tdr to shorten temporal data
 
   - Add supports to make up for missing values (#20)
@@ -86,7 +171,7 @@
 
 - Bug fixes
   - Fix missing support for scalar argument (#1)
-  - Fix type name of boolean in DF#types to be same as Vector#type (#6, #7)
+  - Fix type name of boolean in DataFrame#types to be same as Vector#type (#6, #7)
   - Fix zero picking to return empty DataFrame (#8)
   - Fix code at both args and a block given (#8)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RedAmber
 
-A simple dataframe library for Ruby (experimental)
+A simple dataframe library for Ruby (experimental).
 
 - Powered by [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow)
 - Inspired by the dataframe library [Rover-df](https://github.com/ankane/rover)
@@ -42,9 +42,14 @@ Or install it yourself as:
 gem install red_amber
 ```
 
+(From v0.1.6)
+
+RedAmber uses TDR mode for `#inspect` and `#to_iruby` by default. If you prefer Table mode, please set the environment variable
+`RED_AMBER_OUTPUT_MODE` to `"table"`. See [TDR section](#TDR) for detail.
+
 ## `RedAmber::DataFrame`
 
-Represents a set of data in 2D-shape.
+Represents a set of data in 2D-shape. The entity is a Red Arrow's Table object. 
 
 ```ruby
 require 'red_amber' # require 'red-amber' is also OK.
@@ -52,7 +57,41 @@ require 'datasets-arrow'
 
 arrow = Datasets::Penguins.new.to_arrow
 penguins = RedAmber::DataFrame.new(arrow)
-penguins.tdr
+penguins.table
+
+# =>
+#<Arrow::Table:0x111271098 ptr=0x7f9118b3e0b0>
+	species	island	bill_length_mm	bill_depth_mm	flipper_length_mm	body_mass_g	sex	year
+  0	Adelie 	Torgersen	     39.100000	    18.700000	              181	       3750	male	2007
+  1	Adelie 	Torgersen	     39.500000	    17.400000	              186	       3800	female	2007
+  2	Adelie 	Torgersen	     40.300000	    18.000000	              195	       3250	female	2007
+  3	Adelie 	Torgersen	        (null)	       (null)	           (null)	     (null)	(null)	2007
+  4	Adelie 	Torgersen	     36.700000	    19.300000	              193	       3450	female	2007
+  5	Adelie 	Torgersen	     39.300000	    20.600000	              190	       3650	male	2007
+  6	Adelie 	Torgersen	     38.900000	    17.800000	              181	       3625	female	2007
+  7	Adelie 	Torgersen	     39.200000	    19.600000	              195	       4675	male	2007
+  8	Adelie 	Torgersen	     34.100000	    18.100000	              193	       3475	(null)	2007
+  9	Adelie 	Torgersen	     42.000000	    20.200000	              190	       4250	(null)	2007
+...
+334	Gentoo 	Biscoe	     46.200000	    14.100000	              217	       4375	female	2009
+335	Gentoo 	Biscoe	     55.100000	    16.000000	              230	       5850	male	2009
+336	Gentoo 	Biscoe	     44.500000	    15.700000	              217	       4875	(null)	2009
+337	Gentoo 	Biscoe	     48.800000	    16.200000	              222	       6000	male	2009
+338	Gentoo 	Biscoe	     47.200000	    13.700000	              214	       4925	female	2009
+339	Gentoo 	Biscoe	        (null)	       (null)	           (null)	     (null)	(null)	2009
+340	Gentoo 	Biscoe	     46.800000	    14.300000	              215	       4850	female	2009
+341	Gentoo 	Biscoe	     50.400000	    15.700000	              222	       5750	male	2009
+342	Gentoo 	Biscoe	     45.200000	    14.800000	              212	       5200	female	2009
+343	Gentoo 	Biscoe	     49.900000	    16.100000	              213	       5400	male	2009
+```
+
+By default, RedAmber shows self by compact transposed style. This unfamiliar style (TDR) is designed for
+the exploratory data processing. It keeps Vectors as row vectors, shows keys and types at a glance, shows levels 
+for the 'factor-like' variables and shows the number of abnormal values like NaN and nil.
+
+```ruby
+penguins
+
 # =>
 RedAmber::DataFrame : 344 x 8 Vectors
 Vectors : 5 numeric, 3 strings
@@ -139,7 +178,7 @@ Vectors accepts some [functional methods from Arrow](https://arrow.apache.org/do
 
 See [Vector.md](doc/Vector.md) for details.
 
-## TDR concept
+## TDR
 
 I named the data frame representation style in the model above as TDR (Transposed DataFrame Representation). 
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -9,6 +9,8 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
 
 ![dataframe model image](doc/../image/dataframe_model.png)
 
+(No change in this model in v0.1.6 .)
+
 ## Constructors and saving
 
 ### `new` from a Hash
@@ -478,6 +480,7 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
       max = vector.mean + vector.std
       vector.to_a.map { |e| (min..max).include? e }
     end
+
     # =>
     #<RedAmber::DataFrame : 204 x 8 Vectors, 0x000000000000f30c>
     Vectors : 5 numeric, 3 strings
@@ -756,6 +759,8 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
 ## Grouping
 
 ### `group(aggregating_keys, function, target_keys)`
+
+  (This is a temporary API and may change in the future version.)
 
   Create grouped dataframe by `aggregation_keys` and apply `function` to each group and returns in `target_keys`. Aggregated key name is `function(key)` style.
 

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.1.6-HEAD'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
## Release note for v0.1.6

Today is the release day of new version of RedAmber in bi-weekly schedule.
This is a still experimental version but I think it is already usable for many tasks.

Major updates for this version are:

- Jupyter support (thanks for the request by @kojix2) (#29, #30, #31, #32)
- Changeable DataFrame display mode by ENV (#36)
- Introduce new engine and improve DataFrame#[], #slice, #remove (#34)
- Refine slicing methods in Vector and DataFrame (#31)
- Introduce coerce in Vector (#35)

Next update will be on 10th, July if no emergency update required.
I will continue bi-weekly release until Red Arrow 9.0.0 released (maybe at the end of July or in August).
