### PR TITLE
Add gitter badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RedAmber
 
+[![Gitter Chat](https://badges.gitter.im/red-data-tools/en.svg)](https://gitter.im/red-data-tools/en)
+
 A simple dataframe library for Ruby (experimental).
 
 - Powered by [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow)


### PR DESCRIPTION
Related to #41
I know some people do not like to put badges on their READMEs.
However, a Gitter badge would be a good idea if you are directing people from github issues to Gitter.
This pull request is a suggestion. Feel free to close it.