### PR TITLE
Add vector shift

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,9 +78,10 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 12
   Exclude:
-    - 'lib/red_amber/data_frame_selectable.rb' # Max: 14
-    - 'lib/red_amber/vector_updatable.rb' # Max: 14
     - 'lib/red_amber/data_frame_displayable.rb' # Max: 18
+    - 'lib/red_amber/data_frame_selectable.rb' # Max: 14
+    - 'lib/red_amber/vector_selectable.rb' # Max: 13
+    - 'lib/red_amber/vector_updatable.rb' # Max: 14
 
 # Max: 10
 Metrics/MethodLength:

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -500,3 +500,28 @@ vector.is_in(1, -1)
 #<RedAmber::Vector(:boolean, size=3):0x000000000000f320>
 [true, false, true]
 ```
+
+### `shift(amount = 1, fill: nil)`
+
+Shift vector's values by specified `amount`. Shifted space is filled by value `fill`.
+
+```ruby
+vector = RedAmber::Vector.new([1, 2, 3, 4, 5])
+vector.shift
+
+# =>
+#<RedAmber::Vector(:uint8, size=5):0x00000000000072d8>  
+[nil, 1, 2, 3, 4]
+
+vector.shift(-2)
+
+# =>
+#<RedAmber::Vector(:uint8, size=5):0x0000000000009970>  
+[3, 4, 5, nil, nil]
+
+vector.shift(fill: Float::NAN)
+
+# =>
+#<RedAmber::Vector(:double, size=5):0x0000000000011d3c>                    
+[NaN, 1.0, 2.0, 3.0, 4.0]
+```

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -64,6 +64,8 @@ module RedAmber
         return filter_by_array(arg)
       when Arrow::Array
         array = arg
+      when Range
+        array = normalize_element(arg)
       else
         unless arg.is_a?(Numeric) || booleans?([arg])
           raise VectorArgumentError, "Argument must be numeric or boolean: #{args}"

--- a/lib/red_amber/vector_updatable.rb
+++ b/lib/red_amber/vector_updatable.rb
@@ -58,6 +58,18 @@ module RedAmber
       is_nil.if_else(false, self).invert
     end
 
+    def shift(amount = 1, fill: nil)
+      raise VectorArgumentError, 'Shift amount is too large' if amount.abs > size
+
+      if amount.positive?
+        replace(amount..-1, self[0...-amount]).replace(0...amount, fill)
+      elsif amount.negative?
+        replace(0...amount, self[-amount..]).replace(amount..-1, fill)
+      else # amount == 0
+        self
+      end
+    end
+
     private
 
     # [Ternary]: replace_with(booleans, replacements) => vector

--- a/lib/red_amber/vector_updatable.rb
+++ b/lib/red_amber/vector_updatable.rb
@@ -12,7 +12,15 @@ module RedAmber
     # @param replacer [Array, Vector, Arrow::Array] new data to replace for.
     # @return [Vector] Replaced new Vector
     def replace(args, replacer)
-      args = args.is_a?(Array) ? args : Array(args)
+      args =
+        case args
+        when Array
+          args
+        when Range
+          normalize_element(args)
+        else
+          Array(args)
+        end
       replacer = Array(replacer)
       return self if args.empty? || args[0].nil?
 

--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -99,6 +99,14 @@ class VectorTest < Test::Unit::TestCase
       assert_raise(VectorArgumentError) { @string[nil] } # nil array
       assert_raise(VectorArgumentError) { @string[[nil] * 5] } # nil array
     end
+
+    test '#[Range]' do
+      assert_equal %w[B C D], @string[1..3] # Normal Range
+      assert_equal %w[B C D E], @string[1..] # Endless Range
+      assert_equal %w[A B C], @string[..2] # Beginless Range
+      assert_equal %w[B C D], @string[1..-2] # Range to index from tail
+      assert_raise(RedAmber::DataFrameArgumentError) { @string[1..6] }
+    end
   end
 
   sub_test_case '#is_in' do

--- a/test/test_vector_updatable.rb
+++ b/test/test_vector_updatable.rb
@@ -31,6 +31,13 @@ class VectorTest < Test::Unit::TestCase
       assert_equal [1, 2, 0], vec.replace([2, -1], 0).to_a
     end
 
+    test 'replace Range' do
+      vec = Vector.new([1, 2, 3])
+      expected = [0, 0, 3]
+      assert_equal expected, vec.replace([0..1], 0).to_a
+      assert_equal expected, vec.replace([0...-1], 0).to_a
+    end
+
     test 'replace UInt single' do
       vec = Vector.new([1, 2, 3])
       assert_equal [1, 2, 0], vec.replace([false, false, true], 0).to_a

--- a/test/test_vector_updatable.rb
+++ b/test/test_vector_updatable.rb
@@ -133,4 +133,13 @@ class VectorTest < Test::Unit::TestCase
       assert_equal [false, true, true], Vector.new([true, false, nil]).primitive_invert.to_a
     end
   end
+
+  sub_test_case '#shift' do
+    test '#shift' do
+      vector = Vector.new([1, 2, 3, 4, 5])
+      assert_equal [nil, 1, 2, 3, 4], vector.shift
+      assert_equal [3, 4, 5, nil, nil], vector.shift(-2)
+      assert_equal [0, 0, 1, 2, 3], vector.shift(2, fill: 0)
+    end
+  end
 end


### PR DESCRIPTION
This request will  add `Vector#shift` method.

`Vector#shift` shifts vector's values by specified `amount`. Shifted space is filled by value `fill`.

```ruby
vector = RedAmber::Vector.new([1, 2, 3, 4, 5])
vector.shift

# =>
# Default shift value is 1
#<RedAmber::Vector(:uint8, size=5):0x00000000000072d8>  
[nil, 1, 2, 3, 4]

vector.shift(-2)

# =>
# Negative amount will shift to left
#<RedAmber::Vector(:uint8, size=5):0x0000000000009970>  
[3, 4, 5, nil, nil]

vector.shift(fill: Float::NAN)

# =>
# `fill` argument will specify filler
#<RedAmber::Vector(:double, size=5):0x0000000000011d3c>                    
[NaN, 1.0, 2.0, 3.0, 4.0]
```
