### PR TITLE
Refine group

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,11 @@ Lint/BinaryOperatorWithIdenticalOperands:
   Exclude:
     - 'test/test_vector_function.rb'
 
+# Need for test with empty block
+Lint/EmptyBlock:
+  Exclude:
+    - 'test/test_group.rb'
+
 # Max: 120
 Layout/LineLength:
   Max: 118

--- a/README.md
+++ b/README.md
@@ -273,6 +273,44 @@ For this frequently needed task, we can do it much simpler.
 penguins.remove_nil # => same result as above
 ```
 
+`DataFrame#group` method can be used for the grouping tasks.
+
+```ruby
+starwars = RedAmber::DataFrame.load(URI("https://vincentarelbundock.github.io/Rdatasets/csv/dplyr/starwars.csv"))
+starwars
+
+# =>
+#<RedAmber::DataFrame : 87 x 12 Vectors, 0x000000000000607c>
+   unnamed1 name            height     mass hair_color skin_color  eye_color ... species
+    <int64> <string>       <int64> <double> <string>   <string>    <string>  ... <string>
+ 1        1 Luke Skywalker     172     77.0 blond      fair        blue      ... Human
+ 2        2 C-3PO              167     75.0 NA         gold        yellow    ... Droid
+ 3        3 R2-D2               96     32.0 NA         white, blue red       ... Droid
+ 4        4 Darth Vader        202    136.0 none       white       yellow    ... Human
+ 5        5 Leia Organa        150     49.0 brown      light       brown     ... Human
+ :        : :                    :        : :          :           :         ... :
+85       85 BB8              (nil)    (nil) none       none        black     ... Droid
+86       86 Captain Phasma   (nil)    (nil) unknown    unknown     unknown   ... NA
+87       87 Padmé Amidala      165     45.0 brown      light       brown     ... Human
+
+grouped = starwars.group(:species) { [count(:species), mean(:height, :mass)] }
+grouped.slice { v(:count) > 1 }
+
+# =>
+#<RedAmber::DataFrame : 9 x 4 Vectors, 0x000000000006e848>
+  species    count mean(height) mean(mass)
+  <string> <int64>     <double>   <double>
+1 Human         35        176.6       82.8
+2 Droid          6        131.2       69.8
+3 Wookiee        2        231.0      124.0
+4 Gungan         3        208.7       74.0
+5 NA             4        181.3       48.0
+: :              :            :          :
+7 Twi'lek        2        179.0       55.0
+8 Mirialan       2        168.0       53.1
+9 Kaminoan       2        221.0       88.0 
+```
+
 See [DataFrame.md](doc/DataFrame.md) for details.
 
 

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -76,12 +76,12 @@ module RedAmber
     alias_method :var_names, :keys
 
     def key?(key)
-      @keys.include?(key.to_sym)
+      keys.include?(key.to_sym)
     end
     alias_method :has_key?, :key?
 
     def key_index(key)
-      @keys.find_index(key.to_sym)
+      keys.find_index(key.to_sym)
     end
     alias_method :find_index, :key_index
     alias_method :index, :key_index

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -141,8 +141,10 @@ module RedAmber
       end
     end
 
-    def group(*group_keys)
-      Group.new(self, group_keys)
+    def group(*group_keys, &block)
+      g = Group.new(self, group_keys)
+      g = g.aggregate_by(&block) if block
+      g
     end
 
     private

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -16,36 +16,18 @@ module RedAmber
       @group = @table.group(*@group_keys)
     end
 
-    def count(*summary_keys)
-      by(:count, summary_keys)
+    functions = %i[count sum product mean min max stddev variance]
+    functions.each do |function|
+      define_method(function) do |*summary_keys|
+        by(function, summary_keys)
+      end
     end
 
-    def sum(*summary_keys)
-      by(:sum, summary_keys)
-    end
-
-    def product(*summary_keys)
-      by(:product, summary_keys)
-    end
-
-    def mean(*summary_keys)
-      by(:mean, summary_keys)
-    end
-
-    def min(*summary_keys)
-      by(:min, summary_keys)
-    end
-
-    def max(*summary_keys)
-      by(:max, summary_keys)
-    end
-
-    def stddev(*summary_keys)
-      by(:stddev, summary_keys)
-    end
-
-    def variance(*summary_keys)
-      by(:variance, summary_keys)
+    def inspect
+      tallys = @dataframe.pick(@group_keys).vectors.map.with_object({}) do |v, h|
+        h[v.key] = v.tally
+      end
+      "#<#{self.class}:#{format('0x%016x', object_id)}\n#{tallys}>"
     end
 
     private

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -38,7 +38,10 @@ module RedAmber
       raise GroupArgumentError, "#{d} is not a key of\n #{@dataframe}." unless summary_keys.empty? || d.empty?
 
       df = RedAmber::DataFrame.new(@group.send(func, *summary_keys))
-      df[df.keys[-1], df.keys[0...-1]]
+      df = df[df.keys[-1], df.keys[0...-1]]
+      # if counts are the same (no nil included), aggregate count columns.
+      df = df[df.keys[0..1]].rename(df.keys[1], :count) if func == :count && df.to_h.values[1..].uniq.size == 1
+      df
     end
   end
 end

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -30,6 +30,18 @@ module RedAmber
       "#<#{self.class}:#{format('0x%016x', object_id)}\n#{tallys}>"
     end
 
+    def aggregate_by(&block)
+      agg = instance_eval(&block)
+      case agg
+      when DataFrame
+        agg
+      when Array
+        agg.reduce { |aggregated, df| aggregated.assign(df.to_h) }
+      else
+        raise GroupArgumentError, "Unknown argument: #{agg}"
+      end
+    end
+
     private
 
     def by(func, summary_keys)

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -37,7 +37,8 @@ module RedAmber
       d = summary_keys - @dataframe.keys
       raise GroupArgumentError, "#{d} is not a key of\n #{@dataframe}." unless summary_keys.empty? || d.empty?
 
-      RedAmber::DataFrame.new(@group.send(func, *summary_keys))
+      df = RedAmber::DataFrame.new(@group.send(func, *summary_keys))
+      df[df.keys[-1], df.keys[0...-1]]
     end
   end
 end

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -131,6 +131,18 @@ class DataFrameTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'init_instance_vars' do
+    test 'key?' do
+      df = DataFrame.new(x: [1, 2, 3])
+      assert_true df.key?(:x)
+    end
+
+    test 'key_index' do
+      df = DataFrame.new(x: [1, 2, 3])
+      assert_equal 0, df.key_index(:x)
+    end
+  end
+
   sub_test_case '.new and .to_ I/O' do
     # data in Array(hash, schema, array)
     data(

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -51,6 +51,11 @@ class DataFrameTest < Test::Unit::TestCase
       int32_array = Arrow::Int32Array.new([1, 2])
       assert_raise(DataFrameTypeError) { DataFrame.new(int32_array) }
     end
+
+    test 'empty key renaming' do
+      df = DataFrame.new('': [1, 2], unnamed1: [3, 4])
+      assert_equal %i[unnamed2 unnamed1], df.keys
+    end
   end
 
   sub_test_case 'Properties' do

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -147,6 +147,19 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
       OUTPUT
       assert_equal str, df.inspect
     end
+
+    test 'empty key name' do
+      df = DataFrame.new("": [1, 2, 3], x: %w[A B C])
+      str = <<~OUTPUT
+        #<RedAmber::DataFrame : 3 x 2 Vectors, #{format('0x%016x', df.object_id)}>
+                  x
+          <uint8> <string>
+        1       1 A
+        2       2 B
+        3       3 C
+      OUTPUT
+      assert_equal str, df.inspect
+    end
   end
 
   sub_test_case 'tdr_str' do

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -152,11 +152,11 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
       df = DataFrame.new("": [1, 2, 3], x: %w[A B C])
       str = <<~OUTPUT
         #<RedAmber::DataFrame : 3 x 2 Vectors, #{format('0x%016x', df.object_id)}>
-                  x
-          <uint8> <string>
-        1       1 A
-        2       2 B
-        3       3 C
+          unnamed1 x
+           <uint8> <string>
+        1        1 A
+        2        2 B
+        3        3 C
       OUTPUT
       assert_equal str, df.inspect
     end
@@ -246,10 +246,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
       str = <<~OUTPUT
         RedAmber::DataFrame : 2 x 3 Vectors
         Vectors : 3 numeric
-        # key    type  level data_preview
-        1 :""    uint8     2 [1, 2]
-        2 :"  "  uint8     2 [3, 4]
-        3 :"a b" uint8     2 [5, 6]
+        # key       type  level data_preview
+        1 :unnamed1 uint8     2 [1, 2]
+        2 :"  "     uint8     2 [3, 4]
+        3 :"a b"    uint8     2 [5, 6]
       OUTPUT
       assert_equal str, df.tdr_str
     end

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -200,8 +200,8 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         1 :blank uint8     3 [1, 2, 3]
         2 :A     uint8     3 [4, 5, 6]
       OUTPUT
-      assert_equal str, df.rename(:'', 'blank').tdr_str
-      assert_equal str, df.rename('': 'blank').tdr_str
+      assert_equal str, df.rename(:unnamed1, :blank).tdr_str
+      assert_equal str, df.rename(unnamed1: :blank).tdr_str
     end
   end
 

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -26,11 +26,11 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 4 x 5 Vectors
         Vectors : 5 numeric
         # key         type  level data_preview
-        1 :"count(i)" int64     3 [2, 1, 2, 0]
-        2 :"count(f)" int64     3 [2, 1, 2, 0]
-        3 :"count(s)" int64     3 [2, 0, 2, 1]
-        4 :"count(b)" int64     3 [2, 1, 2, 0]
-        5 :i          uint8     4 [0, 1, 2, nil], 1 nil
+        1 :i          uint8     4 [0, 1, 2, nil], 1 nil
+        2 :"count(i)" int64     3 [2, 1, 2, 0]
+        3 :"count(f)" int64     3 [2, 1, 2, 0]
+        4 :"count(s)" int64     3 [2, 0, 2, 1]
+        5 :"count(b)" int64     3 [2, 1, 2, 0]
       OUTPUT
       assert_equal str, @df.group(:i).count(%i[i f s b]).tdr_str(tally: 0)
     end
@@ -40,11 +40,11 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 3 x 5 Vectors
         Vectors : 2 numeric, 1 string, 2 boolean
         # key       type    level data_preview
-        1 :"max(i)" uint8       2 [2, 2, nil], 1 nil
-        2 :"max(f)" double      3 [2.2, 3.3, nil], 1 nil
-        3 :"max(s)" string      2 ["B", "B", "A"]
-        4 :"max(b)" boolean     3 [true, false, nil], 1 nil
-        5 :b        boolean     3 [true, false, nil], 1 nil
+        1 :b        boolean     3 [true, false, nil], 1 nil
+        2 :"max(i)" uint8       2 [2, 2, nil], 1 nil
+        3 :"max(f)" double      3 [2.2, 3.3, nil], 1 nil
+        4 :"max(s)" string      2 ["B", "B", "A"]
+        5 :"max(b)" boolean     3 [true, false, nil], 1 nil
       OUTPUT
       assert_equal str, @df.group(:b).max(%i[i f s b]).tdr_str(tally: 0)
     end
@@ -54,10 +54,10 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 3 x 4 Vectors
         Vectors : 3 numeric, 1 boolean
         # key        type    level data_preview
-        1 :"mean(i)" double      2 [1.0, 1.0, nil], 1 nil
-        2 :"mean(f)" double      3 [NaN, 2.2, nil], 1 NaN, 1 nil
-        3 :"mean(b)" double      3 [1.0, 0.0, nil], 1 nil
-        4 :b         boolean     3 [true, false, nil], 1 nil
+        1 :b         boolean     3 [true, false, nil], 1 nil
+        2 :"mean(i)" double      2 [1.0, 1.0, nil], 1 nil
+        3 :"mean(f)" double      3 [NaN, 2.2, nil], 1 NaN, 1 nil
+        4 :"mean(b)" double      3 [1.0, 0.0, nil], 1 nil
       OUTPUT
       assert_equal str, @df.group(:b).mean(%i[i f b]).tdr_str(tally: 0)
     end
@@ -67,11 +67,11 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 3 x 5 Vectors
         Vectors : 2 numeric, 1 string, 2 boolean
         # key       type    level data_preview
-        1 :"min(i)" uint8       2 [0, 0, nil], 1 nil
-        2 :"min(f)" double      3 [0.0, 1.1, nil], 1 nil
-        3 :"min(s)" string      1 ["A", "A", "A"]
-        4 :"min(b)" boolean     3 [true, false, nil], 1 nil
-        5 :b        boolean     3 [true, false, nil], 1 nil
+        1 :b        boolean     3 [true, false, nil], 1 nil
+        2 :"min(i)" uint8       2 [0, 0, nil], 1 nil
+        3 :"min(f)" double      3 [0.0, 1.1, nil], 1 nil
+        4 :"min(s)" string      1 ["A", "A", "A"]
+        5 :"min(b)" boolean     3 [true, false, nil], 1 nil
       OUTPUT
       assert_equal str, @df.group(:b).min(%i[i f s b]).tdr_str(tally: 0)
     end
@@ -81,10 +81,10 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 3 x 4 Vectors
         Vectors : 3 numeric, 1 boolean
         # key           type    level data_preview
-        1 :"product(i)" uint64      2 [0, 0, nil], 1 nil
-        2 :"product(f)" double      3 [NaN, 3.63, nil], 1 NaN, 1 nil
-        3 :"product(b)" uint64      3 [1, 0, nil], 1 nil
-        4 :b            boolean     3 [true, false, nil], 1 nil
+        1 :b            boolean     3 [true, false, nil], 1 nil
+        2 :"product(i)" uint64      2 [0, 0, nil], 1 nil
+        3 :"product(f)" double      3 [NaN, 3.63, nil], 1 NaN, 1 nil
+        4 :"product(b)" uint64      3 [1, 0, nil], 1 nil
       OUTPUT
       assert_equal str, @df.group(:b).product(%i[i f b]).tdr_str(tally: 0)
     end
@@ -94,9 +94,9 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 3 x 3 Vectors
         Vectors : 2 numeric, 1 boolean
         # key          type    level data_preview
-        1 :"stddev(i)" double      3 [0.816496580927726, 1.0, nil], 1 nil
-        2 :"stddev(f)" double      3 [NaN, 1.0999999999999999, nil], 1 NaN, 1 nil
-        3 :b           boolean     3 [true, false, nil], 1 nil
+        1 :b           boolean     3 [true, false, nil], 1 nil
+        2 :"stddev(i)" double      3 [0.816496580927726, 1.0, nil], 1 nil
+        3 :"stddev(f)" double      3 [NaN, 1.0999999999999999, nil], 1 NaN, 1 nil
       OUTPUT
       assert_equal str, @df.group(:b).stddev(%i[i f]).tdr_str(tally: 0)
     end
@@ -106,10 +106,10 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 3 x 4 Vectors
         Vectors : 3 numeric, 1 boolean
         # key       type    level data_preview
-        1 :"sum(i)" uint64      3 [3, 2, nil], 1 nil
-        2 :"sum(f)" double      3 [NaN, 4.4, nil], 1 NaN, 1 nil
-        3 :"sum(b)" uint64      3 [3, 0, nil], 1 nil
-        4 :b        boolean     3 [true, false, nil], 1 nil
+        1 :b        boolean     3 [true, false, nil], 1 nil
+        2 :"sum(i)" uint64      3 [3, 2, nil], 1 nil
+        3 :"sum(f)" double      3 [NaN, 4.4, nil], 1 NaN, 1 nil
+        4 :"sum(b)" uint64      3 [3, 0, nil], 1 nil
       OUTPUT
       assert_equal str, @df.group(:b).sum(%i[i f b]).tdr_str(tally: 0)
     end
@@ -119,9 +119,9 @@ class GroupTest < Test::Unit::TestCase
         RedAmber::DataFrame : 3 x 3 Vectors
         Vectors : 2 numeric, 1 boolean
         # key            type    level data_preview
-        1 :"variance(i)" double      3 [0.6666666666666666, 1.0, nil], 1 nil
-        2 :"variance(f)" double      3 [NaN, 1.2099999999999997, nil], 1 NaN, 1 nil
-        3 :b             boolean     3 [true, false, nil], 1 nil
+        1 :b             boolean     3 [true, false, nil], 1 nil
+        2 :"variance(i)" double      3 [0.6666666666666666, 1.0, nil], 1 nil
+        3 :"variance(f)" double      3 [NaN, 1.2099999999999997, nil], 1 NaN, 1 nil
       OUTPUT
       assert_equal str, @df.group(:b).variance(%i[i f]).tdr_str(tally: 0)
     end

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -35,6 +35,18 @@ class GroupTest < Test::Unit::TestCase
       assert_equal str, @df.group(:i).count(%i[i f s b]).tdr_str(tally: 0)
     end
 
+    test 'group count (aggregation)' do
+      str = <<~OUTPUT
+        RedAmber::DataFrame : 4 x 2 Vectors
+        Vectors : 2 numeric
+        # key    type  level data_preview
+        1 :i     uint8     4 [0, 1, 2, nil], 1 nil
+        2 :count int64     3 [2, 1, 2, 0]
+      OUTPUT
+      df = @df.pick(:i, :f, :b)
+      assert_equal str, df.group(:i).count.tdr_str(tally: 0)
+    end
+
     test 'group max' do
       str = <<~OUTPUT
         RedAmber::DataFrame : 3 x 5 Vectors

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -137,5 +137,28 @@ class GroupTest < Test::Unit::TestCase
       OUTPUT
       assert_equal str, @df.group(:b).variance(%i[i f]).tdr_str(tally: 0)
     end
+
+    test 'group with a block' do
+      assert_raise(GroupArgumentError) { @df.group(:i) {} }
+
+      str = <<~OUTPUT
+        RedAmber::DataFrame : 4 x 2 Vectors
+        Vectors : 2 numeric
+        # key    type  level data_preview
+        1 :i     uint8     4 [0, 1, 2, nil], 1 nil
+        2 :count int64     3 [2, 1, 2, 0]
+      OUTPUT
+      assert_equal str, @df.group(:i) { count(:i, :f, :b) }.tdr_str(tally: 0)
+
+      str = <<~OUTPUT
+        RedAmber::DataFrame : 4 x 3 Vectors
+        Vectors : 3 numeric
+        # key       type   level data_preview
+        1 :i        uint8      4 [0, 1, 2, nil], 1 nil
+        2 :count    int64      3 [2, 1, 2, 0]
+        3 :"sum(f)" double     4 [1.1, 2.2, NaN, nil], 1 NaN, 1 nil
+      OUTPUT
+      assert_equal str, @df.group(:i) { [count(:i, :f, :b), sum] }.tdr_str(tally: 0)
+    end
   end
 end


### PR DESCRIPTION
This request is to refine Group class and group method in DataFrame.

- Group summary function will be created by `define_method`.

- Group key comes first (leftmost) in the result.
  ```ruby
  DataFrame.new(x: [1,2,2], y: [4,5,6]).group(:x).count
  #=>
  #<RedAmber::DataFrame : 2 x 2 Vectors, 0x000000000001877c>                           
          x   count                                                                    
    <uint8> <int64>                                                                    
  1       1       1
  2       2       2
  ```
- Show only one `:count` if all count result is the same.
  ```ruby
  df.group(:x).count(:x, :y)
  # same result as above
  ```
- Add block acceptability in the `DataFrame#group` (#28).
  The block is in the context of instance (`instance_eval`).

- Fix unnamed column in table formatter.
  Used special column key for index column in the Table format.

- Rename empty key to `:unnamed#{n}` in `DataFrame.new`.
  Key name in `:""` will renamed to `unnamed1`. If it is used, use `unnamed1.succ`.

- Add more examples and images in README.
  Add more useful examples and add images of method manipulation.

- Add doc. of group manipulations in README.