### PR TITLE
Fix group

### DIFF
--- a/lib/red_amber.rb
+++ b/lib/red_amber.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'arrow'
-require 'rover-df'
 
 require_relative 'red_amber/helper'
 require_relative 'red_amber/data_frame_displayable'

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -25,10 +25,13 @@ module RedAmber
           case arg
           when Arrow::Table then arg
           when DataFrame then arg.table
-          when Rover::DataFrame then Arrow::Table.new(arg.to_h)
-          when Hash then Arrow::Table.new(arg)
           else
-            raise DataFrameTypeError, "invalid argument: #{arg}"
+            begin
+              # Accepts Rover::DataFrame or Hash
+              Arrow::Table.new(arg.to_h)
+            rescue StandardError
+              raise DataFrameTypeError, "invalid argument: #{arg}"
+            end
           end
       end
       name_unnamed_keys

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -50,7 +50,7 @@ module RedAmber
       raise GroupArgumentError, "#{d} is not a key of\n #{@dataframe}." unless summary_keys.empty? || d.empty?
 
       df = RedAmber::DataFrame.new(@group.send(func, *summary_keys))
-      df = df[df.keys[-1], df.keys[0...-1]]
+      df = df[@group_keys, df.keys - @group_keys]
       # if counts are the same (no nil included), aggregate count columns.
       df = df[df.keys[0..1]].rename(df.keys[1], :count) if func == :count && df.to_h.values[1..].uniq.size == 1
       df

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.1.8'
+  VERSION = '0.1.9-HEAD'
 end

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -34,6 +34,18 @@ class GroupTest < Test::Unit::TestCase
       OUTPUT
       assert_equal str, @df.group(:i).count(%i[i f s b]).tdr_str(tally: 0)
     end
+    test 'group with multiple keys' do
+      str = <<~OUTPUT
+        RedAmber::DataFrame : 6 x 4 Vectors
+        Vectors : 3 numeric, 1 string
+        # key         type   level data_preview
+        1 :i          uint8      4 [0, 0, 1, 2, 2, ... ], 1 nil
+        2 :s          string     3 ["A", "B", nil, "A", "B", ... ], 1 nil
+        3 :"count(f)" int64      2 [1, 1, 1, 1, 1, ... ]
+        4 :"count(b)" int64      2 [1, 1, 1, 1, 1, ... ]
+      OUTPUT
+      assert_equal str, @df.group(:i, :s).count.tdr_str(tally: 0)
+    end
 
     test 'group count (aggregation)' do
       str = <<~OUTPUT


### PR DESCRIPTION
- Fix the order of multiple group keys
  Only 1 group key comes to left. Other keys remain in right.

- Remove optional `require` for Rover dataframe.
   Fix DataFrame.new for argument with Rover::DataFrame.
