### PR TITLE
Add each_row method for DataFrame

### DIFF
--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -167,6 +167,11 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
   
   If you need a column-oriented full array, use `.to_h.to_a`
 
+### `each_row`
+
+  Yield each row in Array of Arrays.
+  Returns Enumerator if block is not given.
+
 ### `schema`
 
 - Returns column name and data type in a Hash.

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -129,6 +129,14 @@ module RedAmber
       variables.empty?
     end
 
+    def each_row
+      return enum_for(:each_row) unless block_given?
+
+      size.times do |i|
+        yield vectors.map { |v| v.data[i] }
+      end
+    end
+
     def to_rover
       require 'rover'
       Rover::DataFrame.new(to_h)

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -111,7 +111,7 @@ module RedAmber
 
       index_array = Arrow::UInt64ArrayBuilder.build(normalized_indices.data) # round to integer array
 
-      datum = find(:array_take).execute([data, index_array])
+      datum = find(:take).execute([data, index_array]) # :array_take will fail with ChunkedArray
       Vector.new(datum.value)
     end
 

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -143,6 +143,14 @@ class DataFrameTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'each_row' do
+    test 'each_row' do
+      df = DataFrame.new(x: [1, 2, 3])
+      assert_kind_of Enumerator, df.each_row
+      assert_equal [[1], [2], [3]], df.each_row.to_a # This will crash on 8.0.0
+    end
+  end
+
   sub_test_case '.new and .to_ I/O' do
     # data in Array(hash, schema, array)
     data(

--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -90,6 +90,13 @@ class VectorTest < Test::Unit::TestCase
       assert_equal %w[D A D], @string[Arrow::Array.new([3, 0, -2])].to_a # Arrow
     end
 
+    test '#[indices] with ChunkedArray' do
+      ca = Arrow::ChunkedArray.new([[0, 1], [2, 3]])
+      vector = Vector.new(ca)
+      assert_true vector.chunked?
+      assert_equal 2, vector[2] # This will fail in 8.0.0
+    end
+
     test '#[booleans]' do
       assert_equal %w[B], @string[1].to_a # single value
       assert_equal %w[A E], @string[*@booleans].to_a # arguments


### PR DESCRIPTION
- Add DataFrame#each_row
  - Yield each row in an Array.
  - Returns Enumerator if block is not given.
 