### PR TITLE
Add Vector#quantile (support arrow 9.0.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
         wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
         sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
         sudo apt update
+        sudo apt install -y -V libarrow-dev
+        sudo apt install -y -V libarrow-glib-dev
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :test do
   gem 'rake'
 
-  gem 'red-parquet', '>= 8.0.0'
+  gem 'red-parquet', '>= 9.0.0'
   gem 'rover-df', '~> 0.3.0'
 
   gem 'rubocop'

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -145,7 +145,7 @@ array[booleans]
 | ✓ `min_max` |  ✓  |  ✓  |  ✓  | ✓ ScalarAggregate|     |
 |[ ]`mode`    |     | [ ] |     |[ ] Mode    |     |
 | ✓ `product` |  ✓  |  ✓  |     | ✓ ScalarAggregate|     |
-|[ ]`quantile`|     | [ ] |     |[ ] Quantile|     |
+| ✓ `quantile`|     |  ✓  |     | ✓ Quantile|Specify probability in (0..1) by a parameter (default=0.5)|
 | ✓ `sd    `  |     |  ✓  |     |          |ddof: 1 at `stddev`|
 | ✓ `stddev`  |     |  ✓  |     | ✓ Variance|ddof: 0 by default|
 | ✓ `sum`     |  ✓  |  ✓  |     | ✓ ScalarAggregate|     |

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -39,8 +39,37 @@ module RedAmber
 
     # Returns other than value
     # - mode
-    # - quantile
     # - tdigest
+
+    # Return quantiles in a Vector
+    #   0.5 quantiles (median) are returned by default.
+    #   Or return quantiles for specified probability (q).
+    #   If quantile lies between two data points, interpolated value is
+    #   returned based on selected interpolation method.
+    #   Nils and NaNs are ignored.
+    #   An array of nils are returned if there are no valid data point.
+    #
+    # @param prob [Float] probability.
+    # @param interpolation [Symbol] specifies interpolation method to use,
+    #   when the quantile lies between the data i and j.
+    #   - Default value is :linear, which returns i + (j - i) * fraction.
+    #   - :lower returns i.
+    #   - :higher returns j.
+    #   - :nearest returns i or j, whichever is closer.
+    #   - :midpoint returns (i + j) / 2.
+    # @param skip_nils [Boolean] wheather to ignore nil.
+    # @param min_count [Integer] min count.
+    # @return [Float, Array<Float>] quantile(s).
+    def quantile(prob = 0.5, interpolation: :linear, skip_nils: true, min_count: 0)
+      raise VectorArgumentError, "Invalid: probability #{prob} must be between 0 and 1" unless (0..1).cover? prob
+
+      datum = find(:quantile).execute([data],
+                                      q: prob,
+                                      interpolation: interpolation,
+                                      skip_nulls: skip_nils,
+                                      min_count: min_count)
+      datum.value.to_a.first
+    end
 
     # [Unary element-wise]: vector.func => vector
     unary_element_wise =

--- a/lib/red_amber/vector_functions.rb
+++ b/lib/red_amber/vector_functions.rb
@@ -92,6 +92,7 @@ module RedAmber
 
     alias_method :sort_indexes, :array_sort_indices
     alias_method :sort_indices, :array_sort_indices
+    alias_method :sort_index, :array_sort_indices
 
     alias_method :uniq, :unique
 

--- a/red_amber.gemspec
+++ b/red_amber.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'red-arrow', '>= 8.0.0'
+  spec.add_dependency 'red-arrow', '>= 9.0.0'
 
   # Development dependency has gone to the Gemfile (rubygems/bundler#7237)
 

--- a/test/test_vector_function.rb
+++ b/test/test_vector_function.rb
@@ -192,6 +192,39 @@ class VectorFunctionTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'Quantile' do
+    setup do
+      @boolean = Vector.new([true, true, nil])
+      @integer = Vector.new([1, 2, nil])
+      @double = Vector.new([1.0, -2, 3])
+      @double2 = Vector.new([1, 0 / 0.0, -1 / 0.0, 1 / 0.0, nil, ''])
+      @string = Vector.new(%w[A B A])
+    end
+
+    test '#quantile @integer' do
+      assert_raise(Arrow::Error::NotImplemented) { @boolean.quantile }
+      assert_raise(Arrow::Error::NotImplemented) { @string.quantile }
+      assert_equal 1.5, @integer.quantile
+      assert_equal 1.5, @integer.quantile(0.5)
+      assert_equal 1.0, @integer.quantile(0)
+      assert_equal 2.0, @integer.quantile(1)
+      assert_equal 1.75, @integer.quantile(0.75)
+      assert_raise(VectorArgumentError) { @integer.quantile(1.5) }
+      assert_nil @integer.quantile(skip_nils: false)
+    end
+
+    test '#quantile @double' do
+      assert_equal 2.0, @double.quantile(0.75)
+      assert_equal Float::INFINITY, @double2.quantile(0.75)
+      assert_nil @double2.quantile(0.75, skip_nils: false)
+      assert_equal 0.5, @double2.quantile(0.5, interpolation: :LINEAR)
+      assert_equal 0.0, @double2.quantile(0.5, interpolation: :LOWER)
+      assert_equal 1.0, @double2.quantile(0.5, interpolation: :HIGHER)
+      assert_equal 1.0, @double2.quantile(0.5, interpolation: :NEAREST)
+      assert_equal 0.5, @double2.quantile(0.5, interpolation: :MIDPOINT)
+    end
+  end
+
   sub_test_case('unary element-wise') do
     setup do
       @boolean = Vector.new([true, true, nil])


### PR DESCRIPTION
Updated dependency to `'red-arrow', '>= 9.0.0'` (#58 ).

Some bug fixes and new features are related to RedAmber.

Arrow::QuantileOptions has supported in Arrow GLib 9.0.0 ([ARROW-16623](https://issues.apache.org/jira/browse/ARROW-16623), Thanks!)

I will add `Vector#quantile` method.

```ruby
quantile(prob = 0.5, interpolation: :linear, skip_nils: true, min_count: 0)
```
- Returns quantile [Float, Integer].
- `prob` may be specified for probability in (0..1).
- 0.5 quantile (median) is returned by default.
-  parameter :interpolation specifies interpolation method to use. Choices are;
    -  :linear, which returns i + (j - i) * fraction.
    - :lower returns i.
    - :higher returns j.
    - :nearest returns i or j, whichever is closer.
    - :midpoint returns (i + j) / 2.
- parameter :skip_nils specifies whether to ignore nil by boolean.
