### PR TITLE
Refine DataFrame verbs to use pattern matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,9 +98,10 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Max: 100
   Exclude:
-    - 'lib/red_amber/data_frame_selectable.rb' # Max: 141
-    - 'lib/red_amber/vector_functions.rb' # Max: 114
     - 'lib/red_amber/data_frame_displayable.rb' # Max: 132
+    - 'lib/red_amber/data_frame_selectable.rb' # Max: 141
+    - 'lib/red_amber/data_frame_variable_operation.rb' # Max: 110
+    - 'lib/red_amber/vector_functions.rb' # Max: 114
 
 # Max: 8
 Metrics/PerceivedComplexity:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ penguins.remove(penguins[:bill_length_mm] < 40)
 
 DataFrame manipulating methods like `pick`, `drop`, `slice`, `remove`, `rename` and `assign` accept a block.
 
-This example is usage of block to update numeric columns.
+This example is usage of block to update a column.
 
 ```ruby
 df = RedAmber::DataFrame.new(
@@ -229,23 +229,20 @@ df
 5   (nil)    (nil) (nil)    (nil)
 
 df.assign do
-  vectors.each_with_object({}) do |v, h|
-    h[v.key] = -v if v.numeric?
-  end
+  vectors.select(&:float?).map { |v| [v.key, -v] }
+  # => returns [[:float], [-0.0, -1.1, -2.2, NAN, nil]]
 end
 
 # =>
-#<RedAmber::DataFrame : 5 x 4 Vectors, 0x000000000009a1b4>
-  integer    float string   boolean
-  <uint8> <double> <string> <boolean>
-1       0     -0.0 A        true
-2     255     -1.1 B        false
-3     254     -2.2 C        true
-4     253      NaN D        false
-5   (nil)    (nil) (nil)    (nil)
+#<RedAmber::DataFrame : 5 x 3 Vectors, 0x00000000000e270c>
+    index    float string
+  <uint8> <double> <string>
+1       0     -0.0 A
+2       1     -1.1 B
+3       2     -2.2 C
+4       3      NaN D
+5   (nil)    (nil) (nil)
 ```
-
-Negate (-@) method of unsigned integer Vector returns complement. 
 
 Next example is to eliminate rows containing nil.
 
@@ -253,6 +250,7 @@ Next example is to eliminate rows containing nil.
 # remove all observations containing nil
 nil_removed = penguins.remove { vectors.map(&:is_nil).reduce(&:|) }
 nil_removed.tdr
+
 # =>
 RedAmber::DataFrame : 342 x 8 Vectors
 Vectors : 5 numeric, 3 strings

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ df = df.drop(true, true, false)
 
 Arrow data is immutable, so these methods always return an new object.
 
-`DataFrame#assign` creates new variables (column in the table).
+`DataFrame#assign` creates new columns or update existing columns.
 
 ![assign method image](doc/image/dataframe/assign.png)
 
@@ -247,7 +247,7 @@ end
 
 Negate (-@) method of unsigned integer Vector returns complement. 
 
-Next example is to eliminate observations (row in the table) containing nil.
+Next example is to eliminate rows containing nil.
 
 ```ruby
 # remove all observations containing nil
@@ -311,7 +311,7 @@ grouped.slice { v(:count) > 1 }
 9 Kaminoan       2        221.0       88.0 
 ```
 
-See [DataFrame.md](doc/DataFrame.md) for details.
+See [DataFrame.md](doc/DataFrame.md) for other examples and details.
 
 
 ## `RedAmber::Vector`
@@ -355,7 +355,7 @@ See [Vector.md](doc/Vector.md) for details.
 
 ## Jupyter notebook
 
-[53 Examples of Red Amber](doc/examples_of_red_amber.ipynb)
+[53 Examples of Red Amber](doc/examples_of_red_amber.ipynb) shows more examples in jupyter notebook.
 
 ## Development
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -834,6 +834,24 @@ penguins.to_rover
   
   If assigner is empty or nil, returns self.
 
+- Append from left
+
+  `assign_left` method accepts the same parameters and block as `assign`, but append new columns from leftside.
+
+  ```ruby
+  df.assign_left(new_index: [1, 2, 3, 4, 5])
+  
+  # => 
+  #<RedAmber::DataFrame : 5 x 4 Vectors, 0x000000000001787c>
+    new_index   index    float string
+      <uint8> <uint8> <double> <string>
+  1         1       0      0.0 A
+  2         2       1      1.1 B
+  3         3       2      2.2 C
+  4         4       3      NaN D
+  5         5   (nil)    (nil) (nil)
+  ```
+
 ## Updating
 
 ### `sort`

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -728,6 +728,10 @@ penguins.to_rover
 
     `rename {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return key_pairs as a Hash of `{existing_key => new_key}`. Block is called in the context of self.
 
+- Not existing keys
+
+    If specified `existing_key` is not exist, raise a `DataFrameArgumentError`.
+
 - Key type
 
   Symbol key and String key are distinguished.

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -709,7 +709,7 @@ penguins.to_rover
 
 - Key pairs as arguments
 
-    `rename(key_pairs)` accepts key_pairs as arguments. key_pairs should be a Hash of `{existing_key => new_key}`.
+    `rename(key_pairs)` accepts key_pairs as arguments. key_pairs should be a Hash of `{existing_key => new_key}` or an Array of Arrays like `[[existing_key, new_key], ... ]`.
 
     ```ruby
     df = RedAmber::DataFrame.new( 'name' => %w[Yasuko Rui Hinata], 'age' => [68, 49, 28] )
@@ -726,7 +726,7 @@ penguins.to_rover
 
 - Key pairs by a block
 
-    `rename {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return key_pairs as a Hash of `{existing_key => new_key}`. Block is called in the context of self.
+    `rename {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return key_pairs as a Hash of `{existing_key => new_key}` or an Array of Arrays like `[[existing_key, new_key], ... ]`. Block is called in the context of self.
 
 - Not existing keys
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -747,7 +747,7 @@ penguins.to_rover
 
 - Variables as arguments
 
-    `assign(key_pairs)` accepts pairs of key and values as parameters. `key_pairs` should be a Hash of `{key => Array}`, `{key => Vector}` or `{key => Arrow::Array}`.
+    `assign(key_pairs)` accepts pairs of key and values as parameters. `key_pairs` should be a Hash of `{key => array_like}` or an Array of Arrays like `[[key, array_like], ... ]`. `array_like` is ether `Vector`, `Array` or `Arrow::Array`.
 
     ```ruby
     df = RedAmber::DataFrame.new(
@@ -778,7 +778,7 @@ penguins.to_rover
 
 - Key pairs by a block
 
-    `assign {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return pairs of key and values as a Hash of `{key => array}`, `{key => Vector}` or `{key => Arrow::Array}`. The block is called in the context of self.
+    `assign {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return pairs of key and values as a Hash of `{key => array_like}` or an Array of Arrays like `[[key, array_like], ... ]`. `array_like` is ether `Vector`, `Array` or `Arrow::Array`. The block is called in the context of self.
 
     ```ruby
     df = RedAmber::DataFrame.new(
@@ -797,29 +797,27 @@ penguins.to_rover
     4       3      NaN D
     5   (nil)    (nil) (nil)
 
-    # update numeric variables
+    # update :float
+    # assigner by an Array
     df.assign do
-      assigner = {}
-      vectors.each_with_index do |v, i|
-        assigner[keys[i]] = v * -1 if v.numeric?
-      end
-      assigner
+      vectors.select(&:float?)
+             .map { |v| [v.key, -v] }
     end
 
     # =>
-    #<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000006e000>
-       index    float string
-      <int8> <double> <string>
-    1      0     -0.0 A
-    2     -1     -1.1 B
-    3     -2     -2.2 C
-    4     -3      NaN D
-    5  (nil)    (nil) (nil)
+    #<RedAmber::DataFrame : 5 x 3 Vectors, 0x00000000000dfffc>
+        index    float string             
+      <uint8> <double> <string>           
+    1       0     -0.0 A                  
+    2       1     -1.1 B                  
+    3       2     -2.2 C                  
+    4       3      NaN D                  
+    5   (nil)    (nil) (nil) 
 
-    # Or it ’s shorter like this:
+    # Or we can use assigner by a Hash
     df.assign do
-      variables.select.with_object({}) do |(key, vector), assigner|
-        assigner[key] = vector * -1 if vector.numeric?
+      vectors.select.with_object({}) do |v, assigner|
+        assigner[v.key] = -v if v.float?
       end
     end
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -738,16 +738,16 @@ penguins.to_rover
 
 ### `assign`
 
-  Assign new or updated variables (columns) and create a updated DataFrame.
+  Assign new or updated columns (variables) and create a updated DataFrame.
 
-  - Variables with new keys will append new variables at bottom (right in the table).
+  - Variables with new keys will append new columns from the right.
   - Variables with exisiting keys will update corresponding vectors.
 
     ![assign method image](doc/../image/dataframe/assign.png)
 
 - Variables as arguments
 
-    `assign(key_pairs)` accepts pairs of key and values as arguments. key_pairs should be a Hash of `{key => array}` or `{key => Vector}`.
+    `assign(key_pairs)` accepts pairs of key and values as parameters. `key_pairs` should be a Hash of `{key => Array}`, `{key => Vector}` or `{key => Arrow::Array}`.
 
     ```ruby
     df = RedAmber::DataFrame.new(
@@ -778,7 +778,7 @@ penguins.to_rover
 
 - Key pairs by a block
 
-    `assign {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return pairs of key and values as a Hash of `{key => array}` or `{key => Vector}`. Block is called in the context of self.
+    `assign {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return pairs of key and values as a Hash of `{key => array}`, `{key => Vector}` or `{key => Arrow::Array}`. The block is called in the context of self.
 
     ```ruby
     df = RedAmber::DataFrame.new(
@@ -829,6 +829,10 @@ penguins.to_rover
 - Key type
 
   Symbol key and String key are considered as the same key.
+
+- Empty assignment
+  
+  If assigner is empty or nil, returns self.
 
 ## Updating
 

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -13,26 +13,24 @@ module RedAmber
 
     def initialize(*args)
       @variables = @keys = @vectors = @types = @data_types = nil
-      if args.empty? || args[0] == [] || args[0] == {} || args[0].nil?
+      case args
+      in nil | [nil] | [] | {} | [[]] | [{}]
         # DataFrame.new, DataFrame.new([]), DataFrame.new({}), DataFrame.new(nil)
         #   returns empty DataFrame
         @table = Arrow::Table.new({}, [])
-      elsif args.size > 1
-        @table = Arrow::Table.new(*args)
+      in [Arrow::Table => table]
+        @table = table
+      in [DataFrame => dataframe]
+        @table = dataframe.table
+      in [rover_or_hash]
+        begin
+          # Accepts Rover::DataFrame or Hash
+          @table = Arrow::Table.new(rover_or_hash.to_h)
+        rescue StandardError
+          raise DataFrameTypeError, "invalid argument: #{rover_or_hash}"
+        end
       else
-        arg = args[0]
-        @table =
-          case arg
-          when Arrow::Table then arg
-          when DataFrame then arg.table
-          else
-            begin
-              # Accepts Rover::DataFrame or Hash
-              Arrow::Table.new(arg.to_h)
-            rescue StandardError
-              raise DataFrameTypeError, "invalid argument: #{arg}"
-            end
-          end
+        @table = Arrow::Table.new(*args)
       end
       name_unnamed_keys
     end

--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -97,6 +97,9 @@ module RedAmber
     private
 
     def rename_by_hash(key_pairs)
+      not_existing_keys = key_pairs.keys - keys
+      raise DataFrameArgumentError, "Not existing: #{not_existing_keys}" unless not_existing_keys.empty?
+
       fields =
         keys.map do |key|
           new_key = key_pairs[key]

--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -93,17 +93,19 @@ module RedAmber
       if block
         raise DataFrameArgumentError, 'Must not specify both arguments and a block' unless assigner.empty?
 
-        assigner = instance_eval(&block)
+        assigner = [instance_eval(&block)]
       end
       case assigner
-      in nil | [nil] | {} | [] | [{}] | [[]]
+      in [] | [nil] | [{}] | [[]]
         return self
-      in Hash => key_array_pairs
-      # noop
       in [Hash => key_array_pairs]
       # noop
       in [(Symbol | String) => key, (Vector | Array | Arrow::Array) => array]
         key_array_pairs = { key => array }
+      in [Array => array_in_array]
+        key_array_pairs = try_convert_to_hash(array_in_array)
+      in [Array, *] => array_in_array1
+        key_array_pairs = try_convert_to_hash(array_in_array1)
       else
         raise DataFrameArgumentError, "Invalid argument #{assigner}"
       end

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -246,7 +246,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       assert_equal @df.tdr_str, @df.assign(unchanged_pair).tdr_str
 
       assigner = { index: [-1, -2, -3, -4, -5], new: %w[a a b b c] }
-      assert_equal <<~OUTPUT, @df.assign(assigner).tdr_str
+      str = <<~OUTPUT
         RedAmber::DataFrame : 5 x 5 Vectors
         Vectors : 2 numeric, 2 strings, 1 boolean
         # key     type    level data_preview
@@ -256,6 +256,9 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         4 :bool   boolean     3 {true=>2, false=>2, nil=>1}
         5 :new    string      3 {"a"=>2, "b"=>2, "c"=>1}
       OUTPUT
+      assert_equal str, @df.assign(assigner).tdr_str
+      assert_equal str, @df.assign(assigner.to_a).tdr_str
+      assert_equal str, @df.assign(*assigner.to_a).tdr_str # assign([:x, ary1], [:y, ary2]) style
     end
 
     test 'assign by block' do
@@ -265,22 +268,19 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       assert_equal(@df, @df.assign { {} }) # assign nothing
       assert_equal(@df, @df.assign { [] }) # assign nothing
 
-      actual = @df.assign do
-        assigner = {}
-        vectors.each_with_index do |v, i|
-          assigner[keys[i]] = v * 10 if v.numeric?
-        end
-        assigner
-      end
-      assert_equal <<~OUTPUT, actual.tdr_str
-        RedAmber::DataFrame : 5 x 4 Vectors
-        Vectors : 2 numeric, 1 string, 1 boolean
+      assigner = { index: [-1, -2, -3, -4, -5], new: %w[a a b b c] }
+      str = <<~OUTPUT
+        RedAmber::DataFrame : 5 x 5 Vectors
+        Vectors : 2 numeric, 2 strings, 1 boolean
         # key     type    level data_preview
-        1 :index  uint8       5 [0, 10, 20, 30, nil], 1 nil
-        2 :float  double      5 [0.0, 11.0, 22.0, NaN, nil], 1 NaN, 1 nil
+        1 :index  int8        5 [-1, -2, -3, -4, -5]
+        2 :float  double      5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
         3 :string string      5 ["A", "B", "C", "D", nil], 1 nil
         4 :bool   boolean     3 {true=>2, false=>2, nil=>1}
+        5 :new    string      3 {"a"=>2, "b"=>2, "c"=>1}
       OUTPUT
+      assert_equal str, @df.assign { assigner }.tdr_str
+      assert_equal str, @df.assign { assigner.to_a }.tdr_str
     end
 
     test 'assign_left by param' do

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -175,7 +175,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       assert_equal(@df, @df.rename { nil }) # empty block
       assert_raise(DataFrameArgumentError) { @df.rename { :key } }
       assert_equal(@df, @df.rename { {} }) # rename nothing
-      assert_equal(@df, @df.rename { Hash(key_not_exist: :new_key) }) # rename nothing
+      assert_raise(DataFrameArgumentError) { @df.rename { { key_not_exist: :new_key } } }
 
       str = <<~OUTPUT
         RedAmber::DataFrame : 5 x 4 Vectors

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -171,8 +171,8 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
     end
 
     test 'rename by block' do
-      assert_raise(DataFrameArgumentError) { @df.rename {} } # empty block
-      assert_raise(DataFrameArgumentError) { @df.rename { nil } } # empty block
+      assert_equal(@df, @df.rename {}) # empty block
+      assert_equal(@df, @df.rename { nil }) # empty block
       assert_raise(DataFrameArgumentError) { @df.rename { :key } }
       assert_equal(@df, @df.rename { {} }) # rename nothing
       assert_equal(@df, @df.rename { Hash(key_not_exist: :new_key) }) # rename nothing
@@ -187,7 +187,7 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         4 :bool    boolean     3 {true=>2, false=>2, nil=>1}
       OUTPUT
       assert_equal str, @df.rename {
-        Hash(keys.detect { |key| self[key].type == :uint8 } => :integer)
+        { keys.detect { |key| self[key].type == :uint8 } => :integer }
       }.tdr_str
     end
 

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -267,5 +267,33 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         4 :bool   boolean     3 {true=>2, false=>2, nil=>1}
       OUTPUT
     end
+
+    test 'assign_left by param' do
+      assigner = { index: [-1, -2, -3, -4, -5], new: %w[a a b b c] }
+      assert_equal <<~OUTPUT, @df.assign_left(assigner).tdr_str
+        RedAmber::DataFrame : 5 x 5 Vectors
+        Vectors : 2 numeric, 2 strings, 1 boolean
+        # key     type    level data_preview
+        1 :new    string      3 {"a"=>2, "b"=>2, "c"=>1}
+        2 :index  int8        5 [-1, -2, -3, -4, -5]
+        3 :float  double      5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
+        4 :string string      5 ["A", "B", "C", "D", nil], 1 nil
+        5 :bool   boolean     3 {true=>2, false=>2, nil=>1}
+      OUTPUT
+    end
+
+    test 'assign_left by block' do
+      assigner = { index: [-1, -2, -3, -4, -5], new: %w[a a b b c] }
+      assert_equal <<~OUTPUT, @df.assign_left { assigner }.tdr_str
+        RedAmber::DataFrame : 5 x 5 Vectors
+        Vectors : 2 numeric, 2 strings, 1 boolean
+        # key     type    level data_preview
+        1 :new    string      3 {"a"=>2, "b"=>2, "c"=>1}
+        2 :index  int8        5 [-1, -2, -3, -4, -5]
+        3 :float  double      5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
+        4 :string string      5 ["A", "B", "C", "D", nil], 1 nil
+        5 :bool   boolean     3 {true=>2, false=>2, nil=>1}
+      OUTPUT
+    end
   end
 end

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -191,6 +191,21 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       }.tdr_str
     end
 
+    test 'rename with array' do
+      str = <<~OUTPUT
+        RedAmber::DataFrame : 5 x 4 Vectors
+        Vectors : 2 numeric, 1 string, 1 boolean
+        # key      type    level data_preview
+        1 :integer uint8       5 [0, 1, 2, 3, nil], 1 nil
+        2 :double  double      5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
+        3 :string  string      5 ["A", "B", "C", "D", nil], 1 nil
+        4 :bool    boolean     3 {true=>2, false=>2, nil=>1}
+      OUTPUT
+      assert_equal str, @df.rename(%i[index integer], %i[float double]).tdr_str
+      assert_equal str, @df.rename([%i[index integer], %i[float double]]).tdr_str
+      assert_equal str, @df.rename { [%i[index integer], %i[float double]] }.tdr_str
+    end
+
     test 'rename blank key' do
       df = DataFrame.new('' => [1, 2, 3], 'A' => [4, 5, 6])
       str = <<~OUTPUT


### PR DESCRIPTION
I will try to use pattern matching to parse overloaded parameters in verbs of DataFrame (#rename, #assign, ...).
It will make the code for parsing simpler.

- `DataFrame#rename`
  - Currently accepts `{ existing_key => new_key }` pairs.
  - Also accepts `#rename(existing_key, new_key)`.
  - Add error when specified key is not exist.
