### PR TITLE
Change DataFrame#each_row to return {key => row}

### DIFF
--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -169,7 +169,7 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
 
 ### `each_row`
 
-  Yield each row in Array of Arrays.
+  Yield each row in a `{ key => row}` Hash.
   Returns Enumerator if block is not given.
 
 ### `schema`
@@ -1027,7 +1027,3 @@ penguins.to_rover
 ## Encoding
 
 - [ ] One-hot encoding
-
-## Iteration
-
-- [ ] each_rows

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -131,7 +131,11 @@ module RedAmber
       return enum_for(:each_row) unless block_given?
 
       size.times do |i|
-        yield vectors.map { |v| v.data[i] }
+        key_row_pairs =
+          vectors.each_with_object({}) do |v, h|
+            h[v.key] = v.data[i]
+          end
+        yield key_row_pairs
       end
     end
 

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -145,9 +145,12 @@ class DataFrameTest < Test::Unit::TestCase
 
   sub_test_case 'each_row' do
     test 'each_row' do
-      df = DataFrame.new(x: [1, 2, 3])
+      df = DataFrame.new(x: [1, 2, 3], y: [4, 5, 6])
       assert_kind_of Enumerator, df.each_row
-      assert_equal [[1], [2], [3]], df.each_row.to_a # This will crash on 8.0.0
+      # This will crash on 8.0.0
+      assert_equal [{ x: 1, y: 4 },
+                    { x: 2, y: 5 },
+                    { x: 3, y: 6 }], df.each_row.to_a
     end
   end
 


### PR DESCRIPTION
- Change DataFrame#each_row to return {key => row}

I found it is useful to return a Hash {key => row} in `DataFrame#each_row` rather than row only.
I will change the behavior.