### PR TITLE
Prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,75 @@
-## [0.1.9] - Unreleased
+## [0.2.0] - 2022-08-15
 
-- Supports Arrow 9.0.0
+- Bump version up to 0.2.0
+
+- Bug fixes
+
+  - Fix order of multiple group keys (#55)
+  
+    Only 1 group key comes to left. Other keys remain in right.
+
+  - Remove optional `require` for rover (#55)
+
+    Fix DataFrame.new for argument with Rover::DataFrame.
+
+  - Fix occasional failure in CI (#59)
+
+    Sometimes the CI test fails. I added -dev dependency 
+    in Arrow install by apt, not doing in bundler.
+
+  - Fix calling :take in V#[] (#56)
+
+    Fixed to call Arrow function :take instead of :array_take in Vector#take_by_vector. This will prevent the error below
+    when called with Arrow::ChunkedArray.
+
+  - Raise error renaming non existing key (#61)
+
+    Add error when specified key is not exist.
+
+  - Fix DataFrame#rename #assign by array (#65)
+
+- New features and improvements
+
+  - Support Arrow 9.0.0
+    - Upgrade to Arrow 9.0.0 (#59)
+    - Add Vector#quantile method (#59)
+      Arrow::QuantileOptions has supported in Arrow GLib 9.0.0 (ARROW-16623, Thanks!)
+  
+    - Add Vector#quantiles (#62)
+
+    - Add DataFrame#each_row (#56)
+      - Returns Enumerator if block is not given.
+      - Change DataFrame#each_row to return a Hash {key => row} (#63)
+
+  - Refactor to use pattern match in overloaded parameter parsing (#61)
+    - Refine DataFrame.new to use pattern match
+    - Use pattern match in DataFrame#assign
+    - Use pattern match in DataFrame#rename
+  
+  - Accept Array for renamer/assigner in #rename/#assign (#61)
+    - Accept assigner by Arrays in DataFrame#assign
+    - Accept renamer pairs by Arrays in DataFrame#rename
+    - Add DataFrame#assign_left method
+
+  - Add summary/describe (#62)
+    - Introduce DataFrame#summary(#describe)
+
+  - Introduce reshaping methods for DataFrame (#64)
+    - Introduce DataFrame#transpose method
+    - Intorduce DataFrame#to_long method
+    - Intorduce DataFrame#to_wide method
+
+  - Others
+ 
+    - Add alias sort_index for array_sort_indices (#59)
+    - Enable :width option in DataFrame#to_s (#62)
+    - Add options to DataFrame#format_table (#62)
+
+  - Update Documents
+  
+    - Add Yard doc for some methods
+  
+    - Update Jupyter notebook '61 Examples of Red Amber' (#65)
 
 ## [0.1.8] - 2022-08-04 (experimental)
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,20 @@
 [![Gem Version](https://badge.fury.io/rb/red_amber.svg)](https://badge.fury.io/rb/red_amber)
 [![Ruby](https://github.com/heronshoes/red_amber/actions/workflows/test.yml/badge.svg)](https://github.com/heronshoes/red_amber/actions/workflows/test.yml)
 
-A simple dataframe library for Ruby (experimental).
+A simple dataframe library for Ruby.
 
 - Powered by [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow) [![Gitter Chat](https://badges.gitter.im/red-data-tools/en.svg)](https://gitter.im/red-data-tools/en)
 - Inspired by the dataframe library [Rover-df](https://github.com/ankane/rover)
 
 ## Requirements
 
+Supported Ruby versions is >= 2.7.
+
+Since v0.2.0, this library uses pattern matching which is an experimental feature in 2.7 . It is usable but a warning message will be shown in 2.7 .
+I recommend Ruby 3 for performance.
+
 ```ruby
+# Libraries required
 gem 'red-arrow',   '>= 9.0.0'
 
 gem 'red-parquet', '>= 9.0.0' # Optional, if you use IO from/to parquet
@@ -122,16 +128,16 @@ df = df.drop(true, true, false)
 
 # =>
 #<RedAmber::DataFrame : 344 x 1 Vector, 0x0000000000048760>
-    body_mass_g                                     
-       <uint16>                                     
-  1        3750                                     
-  2        3800                                     
-  3        3250                                     
-  4       (nil)                                     
-  5        3450                                     
-  :           :                                     
-342        5750                                     
-343        5200                                     
+    body_mass_g
+       <uint16>
+  1        3750
+  2        3800
+  3        3250
+  4       (nil)
+  5        3450
+  :           :
+342        5750
+343        5200
 344        5400
 ```
 
@@ -368,7 +374,7 @@ See [Vector.md](doc/Vector.md) for details.
 
 ## Jupyter notebook
 
-[53 Examples of Red Amber](doc/examples_of_red_amber.ipynb) shows more examples in jupyter notebook.
+[61 Examples of Red Amber](doc/examples_of_red_amber.ipynb) shows more examples in jupyter notebook.
 
 ## Development
 
@@ -378,6 +384,12 @@ cd red_amber
 bundle install
 bundle exec rake test
 ```
+
+I will appreciate if you could help to improve this project. Here are a few ways you can help:
+
+- [Report bugs or suggest new features](https://github.com/heronshoes/red_amber/issues)
+- Fix bugs and [submit pull requests](https://github.com/heronshoes/red_amber/pulls)
+- Write, clarify, or fix documentation
 
 ## License
 

--- a/doc/examples_of_red_amber.ipynb
+++ b/doc/examples_of_red_amber.ipynb
@@ -5,7 +5,7 @@
    "id": "e355db8b-ebb6-4ea6-97b5-3b9fdadc302c",
    "metadata": {},
    "source": [
-    "# 53 examples of Red Amber"
+    "# 61 examples of Red Amber"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "f20f4970-db38-4d96-9a36-d4cf9d007596",
    "metadata": {},
    "source": [
-    "Last update: August 3, 2022, for RedAmber Version 0.1.8"
+    "Last update: August 14, 2022, for RedAmber Version 0.2.0"
    ]
   },
   {
@@ -72,7 +72,7 @@
     {
      "data": {
       "text/plain": [
-       "\"0.1.8-HEAD\""
+       "{:RedAmber=>\"0.2.0\", :Arrow=>\"9.0.0\"}"
       ]
      },
      "execution_count": 1,
@@ -83,7 +83,7 @@
    "source": [
     "require 'red_amber' # require 'red-amber' is also OK\n",
     "include RedAmber\n",
-    "VERSION"
+    "{RedAmber: VERSION, Arrow: Arrow::VERSION}"
    ]
   },
   {
@@ -108,7 +108,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f1cc>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f154>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -138,7 +138,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f1e0>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f168>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -152,7 +152,7 @@
     }
    ],
    "source": [
-    "# From a schema and a column array\n",
+    "# From a schema and a row-oriented array\n",
     "DataFrame.new({ x: :uint8, y: :string }, [[1, 'A'], [2, 'B'], [3, 'C']])"
    ]
   },
@@ -168,7 +168,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f1f4>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f17c>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -182,7 +182,7 @@
     }
    ],
    "source": [
-    "# From a Arrow::Table\n",
+    "# From an Arrow::Table\n",
     "table = Arrow::Table.new(x: [1, 2, 3], y: %w[A B C])\n",
     "DataFrame.new(table)"
    ]
@@ -199,7 +199,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f208>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f2a8>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -231,7 +231,7 @@
        "RedAmber::DataFrame <344 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f21c>\n",
+       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -262,7 +262,7 @@
    "id": "3a2d12b4-7623-42c7-9e32-76cf303c7cea",
    "metadata": {},
    "source": [
-    "It should be in future version;\n",
+    "It should be in the future version;\n",
     "```ruby\n",
     "require 'datasets-red-amber'\n",
     "penguins = Datasets::Penguins.new.to_red_amber\n",
@@ -281,18 +281,18 @@
        "RedAmber::DataFrame <32 x 11 vectors> <table><tr><th>mpg</th><th>cyl</th><th>disp</th><th>hp</th><th>drat</th><th>wt</th><th>qsec</th><th>vs</th><th>am</th><th>gear</th><th>carb</th></tr><tr><td>21.0</td><td>6</td><td>160.0</td><td>110</td><td>3.9</td><td>2.62</td><td>16.46</td><td>0</td><td>1</td><td>4</td><td>4</td></tr><tr><td>21.0</td><td>6</td><td>160.0</td><td>110</td><td>3.9</td><td>2.875</td><td>17.02</td><td>0</td><td>1</td><td>4</td><td>4</td></tr><tr><td>22.8</td><td>4</td><td>108.0</td><td>93</td><td>3.85</td><td>2.32</td><td>18.61</td><td>1</td><td>1</td><td>4</td><td>1</td></tr><tr><td>21.4</td><td>6</td><td>258.0</td><td>110</td><td>3.08</td><td>3.215</td><td>19.44</td><td>1</td><td>0</td><td>3</td><td>1</td></tr><tr><td colspan='11'>&#8942;</td></tr><tr><td>19.7</td><td>6</td><td>145.0</td><td>175</td><td>3.62</td><td>2.77</td><td>15.5</td><td>0</td><td>1</td><td>5</td><td>6</td></tr><tr><td>15.0</td><td>8</td><td>301.0</td><td>335</td><td>3.54</td><td>3.57</td><td>14.6</td><td>0</td><td>1</td><td>5</td><td>8</td></tr><tr><td>21.4</td><td>4</td><td>121.0</td><td>109</td><td>4.11</td><td>2.78</td><td>18.6</td><td>1</td><td>1</td><td>4</td><td>2</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 32 x 11 Vectors, 0x000000000000f230>\n",
+       "#<RedAmber::DataFrame : 32 x 11 Vectors, 0x000000000000f2d0>\n",
        "        mpg     cyl     disp       hp     drat       wt     qsec      vs      am ...    carb\n",
        "   <double> <uint8> <double> <uint16> <double> <double> <double> <uint8> <uint8> ... <uint8>\n",
-       " 1     21.0       6    160.0      110      3.9      2.6     16.5       0       1 ...       4\n",
-       " 2     21.0       6    160.0      110      3.9      2.9     17.0       0       1 ...       4\n",
-       " 3     22.8       4    108.0       93      3.9      2.3     18.6       1       1 ...       1\n",
-       " 4     21.4       6    258.0      110      3.1      3.2     19.4       1       0 ...       1\n",
-       " 5     18.7       8    360.0      175      3.2      3.4     17.0       0       0 ...       2\n",
+       " 1     21.0       6    160.0      110      3.9     2.62    16.46       0       1 ...       4\n",
+       " 2     21.0       6    160.0      110      3.9     2.88    17.02       0       1 ...       4\n",
+       " 3     22.8       4    108.0       93     3.85     2.32    18.61       1       1 ...       1\n",
+       " 4     21.4       6    258.0      110     3.08     3.22    19.44       1       0 ...       1\n",
+       " 5     18.7       8    360.0      175     3.15     3.44    17.02       0       0 ...       2\n",
        " :        :       :        :        :        :        :        :       :       : ...       :\n",
-       "30     19.7       6    145.0      175      3.6      2.8     15.5       0       1 ...       6\n",
-       "31     15.0       8    301.0      335      3.5      3.6     14.6       0       1 ...       8\n",
-       "32     21.4       4    121.0      109      4.1      2.8     18.6       1       1 ...       2\n"
+       "30     19.7       6    145.0      175     3.62     2.77     15.5       0       1 ...       6\n",
+       "31     15.0       8    301.0      335     3.54     3.57     14.6       0       1 ...       8\n",
+       "32     21.4       4    121.0      109     4.11     2.78     18.6       1       1 ...       2\n"
       ]
      },
      "execution_count": 7,
@@ -333,7 +333,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f244>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f2e4>\n",
        "  name         age\n",
        "  <string> <int64>\n",
        "1 Yasuko        68\n",
@@ -347,7 +347,7 @@
     }
    ],
    "source": [
-    "DataFrame.load(\"test/entity/with_header.csv\")"
+    "DataFrame.load(\"../test/entity/with_header.csv\")"
    ]
   },
   {
@@ -370,7 +370,7 @@
        "RedAmber::DataFrame <344 x 7 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>MALE</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>FEMALE</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>FEMALE</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td></td></tr><tr><td colspan='7'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>MALE</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>FEMALE</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>MALE</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 344 x 7 Vectors, 0x000000000000f258>\n",
+       "#<RedAmber::DataFrame : 344 x 7 Vectors, 0x000000000000f2f8>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ... sex\n",
        "    <string> <string>        <double>      <double>           <int64> ... <string>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ... MALE\n",
@@ -456,7 +456,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#<RedAmber::DataFrame : 5 x 4 Vectors, 0x000000000000f26c>\n",
+      "#<RedAmber::DataFrame : 5 x 4 Vectors, 0x000000000000f30c>\n",
       "        x        y s        b\n",
       "  <uint8> <double> <string> <boolean>\n",
       "1       1      1.0 A        true\n",
@@ -487,7 +487,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f21c>\n",
+      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
       "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
       "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
       "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -524,7 +524,7 @@
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f8894884748 ptr=0x558436460680>\n",
+       "#<Arrow::Table:0x7f54b8433320 ptr=0x55d81a4486e0>\n",
        "\tx\t         y\ts\tb\n",
        "0\t1\t  1.000000\tA\ttrue\n",
        "1\t2\t  2.000000\tB\tfalse\n",
@@ -551,7 +551,7 @@
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f88948ea688 ptr=0x55843586f1a0>\n",
+       "#<Arrow::Table:0x7f54b849dec8 ptr=0x55d81ac6f650>\n",
        "\tspecies\tisland\tbill_length_mm\tbill_depth_mm\tflipper_length_mm\tbody_mass_g\tsex\tyear\n",
        "  0\tAdelie \tTorgersen\t     39.100000\t    18.700000\t              181\t       3750\tmale\t2007\n",
        "  1\tAdelie \tTorgersen\t     39.500000\t    17.400000\t              186\t       3800\tfemale\t2007\n",
@@ -1276,7 +1276,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f280>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1306,7 +1306,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f294>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f334>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1328,7 +1328,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f2a8>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f348>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1350,7 +1350,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f2bc>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f35c>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1372,7 +1372,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f2d0>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f370>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1419,13 +1419,13 @@
     {
      "data": {
       "text/plain": [
-       "[#<RedAmber::Vector(:uint8, size=5):0x000000000000f280>\n",
+       "[#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
        "[1, 2, 3, 4, 5]\n",
-       ", #<RedAmber::Vector(:double, size=5):0x000000000000f2e4>\n",
+       ", #<RedAmber::Vector(:double, size=5):0x000000000000f384>\n",
        "[1.0, 2.0, 3.0, NaN, nil]\n",
-       ", #<RedAmber::Vector(:string, size=5):0x000000000000f2f8>\n",
+       ", #<RedAmber::Vector(:string, size=5):0x000000000000f398>\n",
        "[\"A\", \"B\", \"C\", \"D\", nil]\n",
-       ", #<RedAmber::Vector(:boolean, size=5):0x000000000000f30c>\n",
+       ", #<RedAmber::Vector(:boolean, size=5):0x000000000000f3ac>\n",
        "[true, false, true, false, nil]\n",
        "]"
       ]
@@ -1460,13 +1460,13 @@
     {
      "data": {
       "text/plain": [
-       "{:x=>#<RedAmber::Vector(:uint8, size=5):0x000000000000f280>\n",
+       "{:x=>#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
        "[1, 2, 3, 4, 5]\n",
-       ", :y=>#<RedAmber::Vector(:double, size=5):0x000000000000f2e4>\n",
+       ", :y=>#<RedAmber::Vector(:double, size=5):0x000000000000f384>\n",
        "[1.0, 2.0, 3.0, NaN, nil]\n",
-       ", :s=>#<RedAmber::Vector(:string, size=5):0x000000000000f2f8>\n",
+       ", :s=>#<RedAmber::Vector(:string, size=5):0x000000000000f398>\n",
        "[\"A\", \"B\", \"C\", \"D\", nil]\n",
-       ", :b=>#<RedAmber::Vector(:boolean, size=5):0x000000000000f30c>\n",
+       ", :b=>#<RedAmber::Vector(:boolean, size=5):0x000000000000f3ac>\n",
        "[true, false, true, false, nil]\n",
        "}"
       ]
@@ -1514,7 +1514,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f320>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f3c0>\n",
        "        x        y\n",
        "  <uint8> <double>\n",
        "1       1      1.0\n",
@@ -1546,7 +1546,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f334>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f3d4>\n",
        "        x        y\n",
        "  <uint8> <double>\n",
        "1       1      1.0\n",
@@ -1578,7 +1578,7 @@
        "RedAmber::DataFrame <5 x 3 vectors> <table><tr><th>s</th><th>b</th><th>x</th></tr><tr><td>A</td><td>true</td><td>1</td></tr><tr><td>B</td><td>false</td><td>2</td></tr><tr><td>C</td><td>true</td><td>3</td></tr><tr><td>D</td><td>false</td><td>4</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f348>\n",
+       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f3e8>\n",
        "  s        b               x\n",
        "  <string> <boolean> <uint8>\n",
        "1 A        true            1\n",
@@ -1625,7 +1625,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>1</td><td>1.0</td><td>A</td><td>true</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>2</td><td>2.0</td><td>B</td><td>false</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f35c>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f3fc>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       1      1.0 A        true\n",
@@ -1655,7 +1655,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>2</td><td>2.0</td><td>B</td><td>false</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f370>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f410>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       2      2.0 B        false\n",
@@ -1686,7 +1686,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>2</td><td>2.0</td><td>B</td><td>false</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f384>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f424>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       2      2.0 B        false\n",
@@ -1717,7 +1717,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>1</td><td>1.0</td><td>A</td><td>true</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f398>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f438>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       1      1.0 A        true\n",
@@ -1748,7 +1748,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>4</td><td>NaN</td><td>D</td><td>false</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f3ac>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f44c>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       3      3.0 C        true\n",
@@ -1777,7 +1777,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f30c>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f3ac>\n",
        "[true, false, true, false, nil]\n"
       ]
      },
@@ -1803,7 +1803,7 @@
        "RedAmber::DataFrame <2 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>1</td><td>1.0</td><td>A</td><td>true</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 4 Vectors, 0x000000000000f3c0>\n",
+       "#<RedAmber::DataFrame : 2 x 4 Vectors, 0x000000000000f460>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       1      1.0 A        true\n",
@@ -1905,7 +1905,7 @@
     "tags": []
    },
    "source": [
-    "`DataFrame#pick` accepts an Array of keys to pick up columns (variables). You can change the order of columns at a same time."
+    "`DataFrame#pick` accepts an Array of keys to pick up columns (variables) and creates a new DataFrame. You can change the order of columns at a same time."
    ]
   },
   {
@@ -1922,7 +1922,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>s</th><th>y</th></tr><tr><td>A</td><td>1.0</td></tr><tr><td>B</td><td>2.0</td></tr><tr><td>C</td><td>3.0</td></tr><tr><td>D</td><td>NaN</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f3d4>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f474>\n",
        "  s               y\n",
        "  <string> <double>\n",
        "1 A             1.0\n",
@@ -1963,7 +1963,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>y</th><th>s</th></tr><tr><td>1.0</td><td>A</td></tr><tr><td>2.0</td><td>B</td></tr><tr><td>3.0</td><td>C</td></tr><tr><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f3e8>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f488>\n",
        "         y s\n",
        "  <double> <string>\n",
        "1      1.0 A\n",
@@ -2006,7 +2006,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f3fc>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f49c>\n",
        "        x        y\n",
        "  <uint8> <double>\n",
        "1       1      1.0\n",
@@ -2052,7 +2052,7 @@
     "tags": []
    },
    "source": [
-    "`DataFrame#drop` accepts an Array keys to drop columns (variables) to create remainer DataFrame."
+    "`DataFrame#drop` accepts an Array keys to drop columns (variables) to create a remainer DataFrame."
    ]
   },
   {
@@ -2067,7 +2067,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>y</th><th>s</th></tr><tr><td>1.0</td><td>A</td></tr><tr><td>2.0</td><td>B</td></tr><tr><td>3.0</td><td>C</td></tr><tr><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f410>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f4b0>\n",
        "         y s\n",
        "  <double> <string>\n",
        "1      1.0 A\n",
@@ -2107,7 +2107,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>y</th><th>s</th></tr><tr><td>1.0</td><td>A</td></tr><tr><td>2.0</td><td>B</td></tr><tr><td>3.0</td><td>C</td></tr><tr><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f424>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f4c4>\n",
        "         y s\n",
        "  <double> <string>\n",
        "1      1.0 A\n",
@@ -2149,7 +2149,7 @@
        "RedAmber::DataFrame <5 x 1 vector> <table><tr><th>x</th></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f438>\n",
+       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f4d8>\n",
        "        x\n",
        "  <uint8>\n",
        "1       1\n",
@@ -2188,7 +2188,7 @@
        "RedAmber::DataFrame <5 x 1 vector> <table><tr><th>x</th></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f44c>\n",
+       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f4ec>\n",
        "        x\n",
        "  <uint8>\n",
        "1       1\n",
@@ -2259,7 +2259,9 @@
    "id": "12a24264-9b7a-42a1-a541-e292e3876e35",
    "metadata": {},
    "source": [
-    "## 26. Vector#invert, #primitive_invert"
+    "## 26. Vector#invert, #primitive_invert\n",
+    "\n",
+    "For the boolean Vector;"
    ]
   },
   {
@@ -2271,7 +2273,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f460>\n",
+       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f500>\n",
        "[true, true, false, nil]\n"
       ]
      },
@@ -2301,7 +2303,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f474>\n",
+       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f514>\n",
        "[false, false, true, nil]\n"
       ]
      },
@@ -2335,7 +2337,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f488>\n",
+       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f528>\n",
        "[false, false, true, true]\n"
       ]
      },
@@ -2397,7 +2399,7 @@
        "RedAmber::DataFrame <5 x 1 vector> <table><tr><th>x</th></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f49c>\n",
+       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f53c>\n",
        "        x\n",
        "  <uint8>\n",
        "1       1\n",
@@ -2434,7 +2436,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f280>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -2452,7 +2454,38 @@
    "id": "6d973934-e08b-4b45-8efb-52f9167e7238",
    "metadata": {},
    "source": [
-    "This behavior may be useful to use in a block of DataFrame manipulation verbs (like pick, drop, slice, remove, assign, rename)."
+    "This behavior may be useful to use with DataFrame manipulation verbs (like pick, drop, slice, remove, assign, rename)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "6beefc5a-dc47-42cc-a283-456073c4251e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f550>\n",
+       "        x        y\n",
+       "  <uint8> <double>\n",
+       "1       1      1.0\n",
+       "2       2      2.0\n",
+       "3       3      3.0\n",
+       "4       4      NaN\n",
+       "5       5    (nil)\n"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.pick { keys.select { |key| df[key].numeric? } }"
    ]
   },
   {
@@ -2481,7 +2514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 71,
    "id": "9cdce2e4-7876-4be6-bd1f-bc8ab6e6c871",
    "metadata": {},
    "outputs": [
@@ -2491,7 +2524,7 @@
        "RedAmber::DataFrame <10 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 10 x 8 Vectors, 0x000000000000f4b0>\n",
+       "#<RedAmber::DataFrame : 10 x 8 Vectors, 0x000000000000f564>\n",
        "   species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "   <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        " 1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -2505,35 +2538,35 @@
        "10 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# returns 5 rows at the start and 5 rows from the end\n",
+    "# returns 5 rows from the start and 5 rows from the end\n",
     "penguins.slice(0...5, -5..-1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
-   "id": "380ab809-09ae-4e69-a8e6-8d53d1e7822d",
+   "execution_count": 72,
+   "id": "93c3f6f0-7bc9-4909-8f32-20e8c1ddfd3a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <1 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Biscoe</td><td>42.2</td><td>19.5</td><td>197</td><td>4275</td><td>male</td><td>2009</td></tr></table>"
+       "RedAmber::DataFrame <1 x 9 vectors> <table><tr><th>index</th><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>113</td><td>Adelie</td><td>Biscoe</td><td>42.2</td><td>19.5</td><td>197</td><td>4275</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 1 x 8 Vectors, 0x000000000000f4c4>\n",
-       "  species  island   bill_length_mm bill_depth_mm flipper_length_mm body_mass_g ...     year\n",
-       "  <string> <string>       <double>      <double>           <uint8>    <uint16> ... <uint16>\n",
-       "1 Adelie   Biscoe             42.2          19.5               197        4275 ...     2009\n"
+       "#<RedAmber::DataFrame : 1 x 9 Vectors, 0x000000000000f578>\n",
+       "     index species  island   bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
+       "  <uint16> <string> <string>       <double>      <double>           <uint8> ... <uint16>\n",
+       "1      113 Adelie   Biscoe             42.2          19.5               197 ...     2009\n"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2541,7 +2574,8 @@
    "source": [
     "# slice accepts Float index\n",
     "# 33% of 344 observations in index => 113.52 th data ??\n",
-    "penguins.slice(penguins.size * 0.33)"
+    "indexed_penguins = penguins.assign_left { [:index, indexes] } # #assign_left and assigner by Array is 0.2.0 feature\n",
+    "indexed_penguins.slice(penguins.size * 0.33)"
    ]
   },
   {
@@ -2565,18 +2599,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 73,
    "id": "f58ca131-7375-4489-90ce-6ba54b898eb5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=344):0x000000000000f4d8>\n",
+       "#<RedAmber::Vector(:boolean, size=344):0x000000000000f58c>\n",
        "[false, false, true, nil, false, false, false, false, false, true, false, false, ... ]\n"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2588,7 +2622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 74,
    "id": "176ab365-c66a-4712-97b9-4381a536321b",
    "metadata": {},
    "outputs": [
@@ -2598,7 +2632,7 @@
        "RedAmber::DataFrame <242 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>42.0</td><td>20.2</td><td>190</td><td>4250</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>41.1</td><td>17.6</td><td>182</td><td>3200</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>42.5</td><td>20.7</td><td>197</td><td>4500</td><td>male</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 242 x 8 Vectors, 0x000000000000f4ec>\n",
+       "#<RedAmber::DataFrame : 242 x 8 Vectors, 0x000000000000f5a0>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           40.3          18.0               195 ...     2007\n",
@@ -2612,7 +2646,7 @@
        "242 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2634,7 +2668,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 75,
    "id": "c95d3426-0bbb-430e-8d83-6e22434d99ed",
    "metadata": {},
    "outputs": [
@@ -2644,7 +2678,7 @@
        "RedAmber::DataFrame <204 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.3</td><td>20.6</td><td>190</td><td>3650</td><td>male</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>47.2</td><td>13.7</td><td>214</td><td>4925</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>46.8</td><td>14.3</td><td>215</td><td>4850</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 204 x 8 Vectors, 0x000000000000f500>\n",
+       "#<RedAmber::DataFrame : 204 x 8 Vectors, 0x000000000000f5b4>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -2658,7 +2692,7 @@
        "204 Gentoo   Biscoe              45.2          14.8               212 ...     2009\n"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2691,20 +2725,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 76,
    "id": "8e4a8108-154b-4621-acd1-704ddf229d61",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f88a4c37268 ptr=0x5584364b26a0>\n",
+       "#<Arrow::Table:0x7f54b8439518 ptr=0x55d81a8f6f30>\n",
        "\t     a\tb\t         c\n",
        "0\t     1\tA\t  1.000000\n",
        "1\t(null)\t(null)\t    (null)\n"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2725,19 +2759,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 77,
    "id": "851c3bf6-b9e9-41bd-92c5-5372ed934549",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f88a4ca82b0 ptr=0x5584364b1a80>\n",
+       "#<Arrow::Table:0x7f54b83fdf40 ptr=0x55d81abf1a70>\n",
        "\ta\tb\t         c\n",
        "0\t1\tA\t  1.000000\n"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2772,7 +2806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 78,
    "id": "17e38ab8-886b-4114-bcaf-ee18df7d00cd",
    "metadata": {},
    "outputs": [
@@ -2782,7 +2816,7 @@
        "RedAmber::DataFrame <334 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.3</td><td>20.6</td><td>190</td><td>3650</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>38.9</td><td>17.8</td><td>181</td><td>3625</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.2</td><td>19.6</td><td>195</td><td>4675</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>34.1</td><td>18.1</td><td>193</td><td>3475</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>44.5</td><td>15.7</td><td>217</td><td>4875</td><td><i>(nil)</i></td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>48.8</td><td>16.2</td><td>222</td><td>6000</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>47.2</td><td>13.7</td><td>214</td><td>4925</td><td>female</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 334 x 8 Vectors, 0x000000000000f514>\n",
+       "#<RedAmber::DataFrame : 334 x 8 Vectors, 0x000000000000f5c8>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.3          20.6               190 ...     2007\n",
@@ -2796,7 +2830,7 @@
        "334 Gentoo   Biscoe              47.2          13.7               214 ...     2009\n"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2816,7 +2850,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 79,
    "id": "6f169420-7eb2-457f-8d59-7a5c90aa3fa5",
    "metadata": {},
    "outputs": [
@@ -2826,7 +2860,7 @@
        "RedAmber::DataFrame <333 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f528>\n",
+       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f5dc>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -2840,7 +2874,7 @@
        "333 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2860,7 +2894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 80,
    "id": "a6807c65-25e5-4ee1-8d1b-6018c46b3999",
    "metadata": {},
    "outputs": [
@@ -2870,7 +2904,7 @@
        "RedAmber::DataFrame <140 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>34.1</td><td>18.1</td><td>193</td><td>3475</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>37.8</td><td>17.1</td><td>186</td><td>3300</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 140 x 8 Vectors, 0x000000000000f53c>\n",
+       "#<RedAmber::DataFrame : 140 x 8 Vectors, 0x000000000000f5f0>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen          (nil)         (nil)             (nil) ...     2007\n",
@@ -2884,7 +2918,7 @@
        "140 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2917,7 +2951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 81,
    "id": "8575614e-f702-4ee4-ac7b-745e9b32e803",
    "metadata": {},
    "outputs": [
@@ -2927,7 +2961,7 @@
        "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td><td>A</td><td>1.0</td></tr><tr><td>2</td><td>B</td><td>2.0</td></tr><tr><td><i>(nil)</i></td><td>C</td><td>3.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000f550>\n",
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000f604>\n",
        "        a b               c\n",
        "  <uint8> <string> <double>\n",
        "1       1 A             1.0\n",
@@ -2935,7 +2969,7 @@
        "3   (nil) C             3.0\n"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2946,18 +2980,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 82,
    "id": "932a5e71-8cef-44e5-a789-ce97329bc001",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f564>\n",
+       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f618>\n",
        "[true, false, nil]\n"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2968,7 +3002,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 83,
    "id": "74cf6aa6-8913-433d-97ad-bba2d548afe5",
    "metadata": {},
    "outputs": [
@@ -2978,7 +3012,7 @@
        "[false, true, true]"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2989,7 +3023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 84,
    "id": "5e466a06-cb17-4dc1-a5b0-34bfd3ffb78b",
    "metadata": {},
    "outputs": [
@@ -2999,7 +3033,7 @@
        "true"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3018,18 +3052,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 85,
    "id": "077b216f-0a08-413e-95c9-12789d15a9ba",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f578>\n",
+       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f62c>\n",
        "[false, true, nil]\n"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3040,7 +3074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 86,
    "id": "b3df62a6-c4a3-44cb-bde6-f6be12b120c8",
    "metadata": {},
    "outputs": [
@@ -3050,14 +3084,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td><td>A</td><td>1.0</td></tr><tr><td><i>(nil)</i></td><td>C</td><td>3.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000f58c>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000f640>\n",
        "        a b               c\n",
        "  <uint8> <string> <double>\n",
        "1       1 A             1.0\n",
        "2   (nil) C             3.0\n"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3076,18 +3110,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 87,
    "id": "296ca3cd-a6da-4603-a576-d8c36a810e4f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f5a0>\n",
+       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f654>\n",
        "[false, true, true]\n"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3098,7 +3132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 88,
    "id": "ba5b8c0b-b94e-4209-adcd-258ea3b87bfd",
    "metadata": {},
    "outputs": [
@@ -3108,13 +3142,13 @@
        "RedAmber::DataFrame <1 x 3 vectors> <table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td><td>A</td><td>1.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000f5b4>\n",
+       "#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000f668>\n",
        "        a b               c\n",
        "  <uint8> <string> <double>\n",
        "1       1 A             1.0\n"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3125,7 +3159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 89,
    "id": "2446792f-0b0a-4642-acae-b4fec89261c1",
    "metadata": {},
    "outputs": [
@@ -3135,7 +3169,7 @@
        "true"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3162,7 +3196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 90,
    "id": "de4bb615-d14d-4c90-ab54-db2f375b9f00",
    "metadata": {},
    "outputs": [
@@ -3172,7 +3206,7 @@
        "RedAmber::DataFrame <333 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f5c8>\n",
+       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f67c>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -3186,7 +3220,7 @@
        "333 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3205,7 +3239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 91,
    "id": "27a3da5f-0ea2-4c5d-a6c3-c0e20f2224a3",
    "metadata": {},
    "outputs": [
@@ -3215,7 +3249,7 @@
        "RedAmber::DataFrame <333 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f5dc>\n",
+       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f690>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -3229,7 +3263,7 @@
        "333 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3259,12 +3293,12 @@
    "id": "3f6924ec-e86c-4089-ae40-6783027d3ce0",
    "metadata": {},
    "source": [
-    "`#rename(key_pairs)` accepts key_pairs as arguments. key_pairs should be a Hash of `{existing_key => new_key}` ."
+    "`#rename(key_pairs)` accepts key_pairs as arguments. key_pairs should be a Hash of `{existing_key => new_key}` or an Array of Array `[[existing_key, new_key], ...]` ."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 92,
    "id": "9396c96d-83d7-4b92-a4ca-27bc9e4d7b9d",
    "metadata": {},
    "outputs": [
@@ -3274,7 +3308,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f5f0>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f6a4>\n",
        "  name         age\n",
        "  <string> <uint8>\n",
        "1 Yasuko        68\n",
@@ -3282,7 +3316,7 @@
        "3 Hinata        28\n"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3294,7 +3328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 93,
    "id": "fad279c6-1ca0-4493-bd69-0e9ef011bff7",
    "metadata": {},
    "outputs": [
@@ -3304,7 +3338,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age_in_1993</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f604>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f6b8>\n",
        "  name     age_in_1993\n",
        "  <string>     <uint8>\n",
        "1 Yasuko            68\n",
@@ -3312,13 +3346,15 @@
        "3 Hinata            28\n"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "comecome.rename(:age => :age_in_1993)"
+    "comecome.rename(:age => :age_in_1993)\n",
+    "# comecome.rename(:age, :age_in_1993) # is also OK\n",
+    "# comecome.rename([:age, :age_in_1993]) # is also OK"
    ]
   },
   {
@@ -3326,7 +3362,7 @@
    "id": "9dabb005-9822-4c4b-aaa5-fa6f28f2ed43",
    "metadata": {},
    "source": [
-    "`#rename {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return key_pairs as a Hash of {existing_key => new_key}. Block is called in the context of self."
+    "`#rename {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return key_pairs as a Hash of `{existing_key => new_key}` or an Array of Array `[[existing_key, new_key], ...]`. Block is called in the context of self."
    ]
   },
   {
@@ -3361,12 +3397,12 @@
    "id": "b4b22da0-4ee2-4196-88e1-1cfea6a72f4d",
    "metadata": {},
    "source": [
-    "`#assign(key_pairs)` accepts pairs of key and values as arguments. key_pairs should be a Hash of `{key => array}` or `{key => Vector}` ."
+    "`#assign(key_pairs)` accepts pairs of key and array_like values as arguments. The pairs should be a Hash of `{key => array_like}` or an Array of Array `[[key, array_like], ... ]`. `array_like` is one of `Vector`, `Array` or `Arrow::Array`. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 94,
    "id": "56dcfed8-a6f9-4d8c-bac3-e8ce7c0674a7",
    "metadata": {},
    "outputs": [
@@ -3376,7 +3412,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f618>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f6cc>\n",
        "  name         age\n",
        "  <string> <uint8>\n",
        "1 Yasuko        68\n",
@@ -3384,7 +3420,7 @@
        "3 Hinata        28\n"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3395,7 +3431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 95,
    "id": "8da8d282-8798-44d5-bb7b-7fa2df922308",
    "metadata": {},
    "outputs": [
@@ -3405,7 +3441,7 @@
        "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>name</th><th>age</th><th>brother</th></tr><tr><td>Yasuko</td><td>97</td><td>Santa</td></tr><tr><td>Rui</td><td>78</td><td><i>(nil)</i></td></tr><tr><td>Hinata</td><td>57</td><td>Momotaro</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000f62c>\n",
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000f6e0>\n",
        "  name         age brother\n",
        "  <string> <uint8> <string>\n",
        "1 Yasuko        97 Santa\n",
@@ -3413,7 +3449,7 @@
        "3 Hinata        57 Momotaro\n"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3429,12 +3465,12 @@
    "id": "e6d3ddfc-b16d-4b20-83df-357e9cdb32e6",
    "metadata": {},
    "source": [
-    "`#assign {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return pairs of key and values as a Hash of `{key => array}` or `{key => Vector}`. Block is called in the context of self."
+    "`#assign {block}` is also acceptable. We can't use both arguments and a block at a same time. The block should return pairs of key and array_like values as a Hash of `{key => array_like}` or an Array of Array `[[key, array_like], ... ]`. `array_like` is one of `Vector`, `Array` or `Arrow::Array`. Block is called in the context of self."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 96,
    "id": "8d69edd0-7ad7-4318-8033-1785ce2543db",
    "metadata": {},
    "outputs": [
@@ -3444,7 +3480,7 @@
        "RedAmber::DataFrame <5 x 3 vectors> <table><tr><th>index</th><th>float</th><th>string</th></tr><tr><td>0</td><td>0.0</td><td>A</td></tr><tr><td>1</td><td>1.1</td><td>B</td></tr><tr><td>2</td><td>2.2</td><td>C</td></tr><tr><td>3</td><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f640>\n",
+       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f6f4>\n",
        "    index    float string\n",
        "  <uint8> <double> <string>\n",
        "1       0      0.0 A\n",
@@ -3454,7 +3490,7 @@
        "5   (nil)    (nil) (nil)\n"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3468,7 +3504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 97,
    "id": "e884af01-d82b-42e7-8e92-62baf19919cb",
    "metadata": {},
    "outputs": [
@@ -3478,7 +3514,7 @@
        "RedAmber::DataFrame <5 x 3 vectors> <table><tr><th>index</th><th>float</th><th>string</th></tr><tr><td>0</td><td>-0.0</td><td>A</td></tr><tr><td>255</td><td>-1.1</td><td>B</td></tr><tr><td>254</td><td>-2.2</td><td>C</td></tr><tr><td>253</td><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f654>\n",
+       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f708>\n",
        "    index    float string\n",
        "  <uint8> <double> <string>\n",
        "1       0     -0.0 A\n",
@@ -3488,7 +3524,7 @@
        "5   (nil)    (nil) (nil)\n"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3496,12 +3532,37 @@
    "source": [
     "# update numeric variables\n",
     "df.assign do\n",
-    "  assigner = {}\n",
-    "  vectors.each_with_index do |v, i|\n",
-    "    assigner[keys[i]] = -v if v.numeric?\n",
-    "  end\n",
-    "  assigner\n",
+    "  vectors.select(&:numeric?).map { |v| [v.key, -v] }\n",
     "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b8e2090-628f-4b17-8929-cbb5e0285dff",
+   "metadata": {},
+   "source": [
+    "In this example, columns :x and :y are updated. Column :x returns complements for #negate method because :x is :uint8 type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "9452f8db-5f23-4044-ac87-ac5695fae8ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[:uint8, :double, :string]"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.types"
    ]
   },
   {
@@ -3522,18 +3583,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 99,
    "id": "2bfbe584-be54-486b-af32-e76b37c10e49",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=3):0x000000000000f668>\n",
+       "#<RedAmber::Vector(:uint8, size=3):0x000000000000f71c>\n",
        "[1, 2, 3]\n"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3544,18 +3605,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 100,
    "id": "ce35d901-38a8-4f13-b2d1-29b83f6c5438",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:int16, size=3):0x000000000000f67c>\n",
+       "#<RedAmber::Vector(:int16, size=3):0x000000000000f730>\n",
        "[-1, -2, -3]\n"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3567,18 +3628,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 101,
    "id": "7d5fc2be-f590-4678-92e9-faa27b618266",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:int16, size=3):0x000000000000f690>\n",
+       "#<RedAmber::Vector(:int16, size=3):0x000000000000f744>\n",
        "[-1, -2, -3]\n"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3590,18 +3651,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 102,
    "id": "fa90a6af-add7-42f2-9707-7d726575aeb6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=3):0x000000000000f6a4>\n",
+       "#<RedAmber::Vector(:uint8, size=3):0x000000000000f758>\n",
        "[255, 254, 253]\n"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3631,7 +3692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 103,
    "id": "b12bd7c8-2981-426c-8ae3-154504a8ea15",
    "metadata": {},
    "outputs": [
@@ -3641,7 +3702,7 @@
        "[3, 4, 5]"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3652,7 +3713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 104,
    "id": "c0cb5a98-7cdf-43a8-b2f7-f9df1961c761",
    "metadata": {},
    "outputs": [
@@ -3662,7 +3723,7 @@
        "[1, 2, 3, 4, 5]"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3691,18 +3752,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 105,
    "id": "d003b06a-859f-4de0-9e35-803efac85169",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f6b8>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f76c>\n",
        "[0, 1, 1, 3, 3]\n"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3714,18 +3775,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 106,
    "id": "c5d74006-d364-4e86-8a5e-9e96e87a96e0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f6cc>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f780>\n",
        "[0, 1, 3, 3, nil]\n"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3756,7 +3817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 107,
    "id": "ebad37ad-0a09-48b1-ba3a-4e030a917837",
    "metadata": {},
    "outputs": [
@@ -3766,7 +3827,7 @@
        "true"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3778,7 +3839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 108,
    "id": "97fc24da-03d4-406d-b353-562896775d60",
    "metadata": {},
    "outputs": [
@@ -3788,7 +3849,7 @@
        "true"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3807,7 +3868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 109,
    "id": "3e0e5800-665a-4a05-b2cb-d152f3f077de",
    "metadata": {},
    "outputs": [
@@ -3817,7 +3878,7 @@
        "false"
       ]
      },
-     "execution_count": 107,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3828,7 +3889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 110,
    "id": "3e43f0c4-a254-4735-ac28-de14d2670c67",
    "metadata": {},
    "outputs": [
@@ -3838,7 +3899,7 @@
        "true"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3869,7 +3930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 111,
    "id": "2af73e32-1d7e-4f80-b54e-c40ef08b7034",
    "metadata": {},
    "outputs": [
@@ -3879,7 +3940,7 @@
        "3"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3891,7 +3952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 112,
    "id": "fe6d8d85-27b0-438f-b1b4-1b15e9eb05f9",
    "metadata": {},
    "outputs": [
@@ -3901,7 +3962,7 @@
        "2"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3928,7 +3989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 113,
    "id": "0afec200-f377-432b-a260-ae5a0c5ce794",
    "metadata": {},
    "outputs": [
@@ -3938,7 +3999,7 @@
        "0.816496580927726"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3950,7 +4011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 114,
    "id": "2e40ac09-cb7f-4978-87e8-53f84f16f7c7",
    "metadata": {},
    "outputs": [
@@ -3960,7 +4021,7 @@
        "1.0"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3972,7 +4033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 115,
    "id": "e6158e3b-4af8-467c-a355-8e9f2e579548",
    "metadata": {},
    "outputs": [
@@ -3982,7 +4043,7 @@
        "0.6666666666666666"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3993,7 +4054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 116,
    "id": "d64d39f2-d979-49f1-9946-65890f40d646",
    "metadata": {},
    "outputs": [
@@ -4003,7 +4064,7 @@
        "1.0"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4031,18 +4092,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 117,
    "id": "ab5a357a-e98c-40a1-9b89-0b38645e416f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=3):0x000000000000f6e0>\n",
+       "#<RedAmber::Vector(:double, size=3):0x000000000000f794>\n",
        "[-1.0, 2.0, -3.0]\n"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4054,18 +4115,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 118,
    "id": "8a06c856-d61c-4752-a296-1fa207ffd9a1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=3):0x000000000000f6f4>\n",
+       "#<RedAmber::Vector(:double, size=3):0x000000000000f7a8>\n",
        "[-1.0, 2.0, -3.0]\n"
       ]
      },
-     "execution_count": 116,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4098,18 +4159,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 119,
    "id": "e7a069b0-3547-4cd2-a2f0-0740f186b191",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f708>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f7bc>\n",
        "[15.15, 2.5, 3.5, -4.5, -5.5]\n"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4120,18 +4181,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 120,
    "id": "5ee84b24-8830-4788-a404-d5e1cca22abf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f71c>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f7d0>\n",
        "[15.0, 2.0, 4.0, -4.0, -6.0]\n"
       ]
      },
-     "execution_count": 118,
+     "execution_count": 120,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4142,18 +4203,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 121,
    "id": "20adb1ad-473c-4245-b959-7848c239fb76",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f730>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f7e4>\n",
        "[15.0, 2.0, 4.0, -4.0, -6.0]\n"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4164,18 +4225,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 122,
    "id": "d2777ad8-2c24-48e4-8f5f-77403e3109ea",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f744>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f7f8>\n",
        "[16.0, 3.0, 4.0, -5.0, -6.0]\n"
       ]
      },
-     "execution_count": 120,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4186,18 +4247,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 123,
    "id": "a8ab2735-74cb-4cfe-a5a2-61bfa90c72ac",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f758>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f80c>\n",
        "[15.0, 3.0, 4.0, -4.0, -5.0]\n"
       ]
      },
-     "execution_count": 121,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4208,18 +4269,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 124,
    "id": "3575481c-40ed-405f-a69c-7581d4dce2cf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f76c>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f820>\n",
        "[15.0, 2.0, 3.0, -4.0, -5.0]\n"
       ]
      },
-     "execution_count": 122,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4230,18 +4291,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 125,
    "id": "a86e4c5c-aced-4a88-b692-4e26b90f1653",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f780>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f834>\n",
        "[15.0, 3.0, 4.0, -5.0, -6.0]\n"
       ]
      },
-     "execution_count": 123,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4252,18 +4313,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 126,
    "id": "73f51bab-ff46-4b99-96a5-8c6547ad9d35",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f794>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f848>\n",
        "[15.0, 3.0, 3.0, -5.0, -5.0]\n"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4274,18 +4335,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 127,
    "id": "a12c684c-4a63-4dac-a81b-969978812a24",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f7a8>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f85c>\n",
        "[15.0, 2.0, 4.0, -4.0, -6.0]\n"
       ]
      },
-     "execution_count": 125,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4296,18 +4357,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 128,
    "id": "17370f2b-0957-411b-8145-56aa9fc956ac",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f7bc>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f870>\n",
        "[15.2, 2.5, 3.5, -4.5, -5.5]\n"
       ]
      },
-     "execution_count": 126,
+     "execution_count": 128,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4318,18 +4379,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 129,
    "id": "53072cff-b28b-4672-b30a-8ca37562bc21",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f7d0>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f884>\n",
        "[20.0, 0.0, 0.0, -0.0, -10.0]\n"
       ]
      },
-     "execution_count": 127,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4358,18 +4419,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 130,
    "id": "2d4f5853-1ed9-4d8b-87a9-b5c1faac5fae",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f7e4>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f898>\n",
        "[true, false, nil, false, false, false, nil, false, nil]\n"
       ]
      },
-     "execution_count": 128,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4383,18 +4444,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 131,
    "id": "236c9733-8d45-467e-b288-e6c18b9c39d2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f7f8>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8ac>\n",
        "[true, false, nil, true, false, nil, true, false, nil]\n"
       ]
      },
-     "execution_count": 129,
+     "execution_count": 131,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4406,18 +4467,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 132,
    "id": "4e984a9c-7d9c-465d-bf26-0c685dedd4bf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f80c>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8c0>\n",
        "[true, false, nil, false, false, nil, nil, nil, nil]\n"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4429,18 +4490,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 133,
    "id": "0120ebf5-355d-41f5-83d5-49b9802f337b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f820>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8d4>\n",
        "[true, true, true, true, false, nil, true, nil, nil]\n"
       ]
      },
-     "execution_count": 131,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4451,18 +4512,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 134,
    "id": "24ceee23-79df-4fcd-afd8-f3839a087785",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f834>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8e8>\n",
        "[true, true, true, false, false, false, nil, nil, nil]\n"
       ]
      },
-     "execution_count": 132,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4474,18 +4535,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 135,
    "id": "c152d04b-71a0-4b18-acd1-b5ab9e413d00",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f848>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8fc>\n",
        "[true, true, nil, true, false, nil, nil, nil, nil]\n"
       ]
      },
-     "execution_count": 133,
+     "execution_count": 135,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4513,18 +4574,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 136,
    "id": "19558f9e-fdc4-46e5-90d0-724e4e8fbd8e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f85c>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000f910>\n",
        "[3.141592653589793, Infinity, -Infinity, NaN, nil]\n"
       ]
      },
-     "execution_count": 134,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4535,18 +4596,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 137,
    "id": "d90a7168-1f87-4363-9589-c1f161babc7d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f870>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f924>\n",
        "[true, false, false, false, nil]\n"
       ]
      },
-     "execution_count": 135,
+     "execution_count": 137,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4557,18 +4618,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 138,
    "id": "7d88049b-695f-4b0c-a105-8fb5797a58b1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f884>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f938>\n",
        "[false, true, true, false, nil]\n"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 138,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4579,18 +4640,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 139,
    "id": "7d86a7b5-84bf-4031-9811-4076281920cf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f898>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f94c>\n",
        "[false, false, false, true, true]\n"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4601,18 +4662,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 140,
    "id": "d562f826-7a37-4c57-8f92-777555987246",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f8ac>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f960>\n",
        "[false, false, false, false, true]\n"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 140,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4623,18 +4684,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 141,
    "id": "e460dc6b-e48f-4462-9ce8-aa6069ebae27",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f8c0>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f974>\n",
        "[true, true, true, true, false]\n"
       ]
      },
-     "execution_count": 139,
+     "execution_count": 141,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4653,8 +4714,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
-   "id": "e0e56ecc-b24c-4a40-b3bb-26bb64eb59ef",
+   "execution_count": 142,
+   "id": "0751e820-a22d-45b5-9005-df523d2353be",
    "metadata": {},
    "outputs": [
     {
@@ -4663,7 +4724,7 @@
        "RedAmber::DataFrame <68 x 9 vectors> <table><tr><th>index</th><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>2</td><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>3</td><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>5</td><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td>7</td><td>Adelie</td><td>Torgersen</td><td>38.9</td><td>17.8</td><td>181</td><td>3625</td><td>female</td><td>2007</td></tr><tr><td colspan='9'>&#8942;</td></tr><tr><td>317</td><td>Gentoo</td><td>Biscoe</td><td>49.4</td><td>15.8</td><td>216</td><td>4925</td><td>male</td><td>2009</td></tr><tr><td>331</td><td>Gentoo</td><td>Biscoe</td><td>50.5</td><td>15.2</td><td>216</td><td>5000</td><td>female</td><td>2009</td></tr><tr><td>337</td><td>Gentoo</td><td>Biscoe</td><td>44.5</td><td>15.7</td><td>217</td><td>4875</td><td><i>(nil)</i></td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 68 x 9 Vectors, 0x000000000000f8d4>\n",
+       "#<RedAmber::DataFrame : 68 x 9 Vectors, 0x000000000000f988>\n",
        "      index species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "   <uint16> <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        " 1        2 Adelie   Torgersen           39.5          17.4               186 ...     2007\n",
@@ -4677,7 +4738,7 @@
        "68      337 Gentoo   Biscoe              44.5          15.7               217 ...     2009\n"
       ]
      },
-     "execution_count": 140,
+     "execution_count": 142,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4685,11 +4746,8 @@
    "source": [
     "# prime-th rows ... Don't ask me what it means.\n",
     "require 'prime'\n",
-    "penguins_with_index =\n",
-    "  penguins.assign do\n",
-    "    { index: Vector.new(penguins.indices) + 1 }\n",
-    "  end.pick { [keys[-1], keys[0..-2]] }\n",
-    "penguins_with_index.slice { Vector.new(Prime.each(size).to_a) - 1 }"
+    "penguins.assign_left(:index, Vector.new(penguins.indices) + 1) # since 0.2.0\n",
+    "        .slice { Vector.new(Prime.each(size).to_a) - 1 }"
    ]
   },
   {
@@ -4710,7 +4768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 143,
    "id": "b2a118fa-f3c0-4f31-9b45-6db27ccbebe6",
    "metadata": {},
    "outputs": [
@@ -4720,7 +4778,7 @@
        "RedAmber::DataFrame <35 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>37.8</td><td>17.1</td><td>186</td><td>3300</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Biscoe</td><td>37.8</td><td>18.3</td><td>174</td><td>3400</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Dream</td><td>39.5</td><td>16.7</td><td>178</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>48.5</td><td>15.0</td><td>219</td><td>4850</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.5</td><td>15.2</td><td>216</td><td>5000</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>46.8</td><td>14.3</td><td>215</td><td>4850</td><td>female</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 35 x 8 Vectors, 0x000000000000f8e8>\n",
+       "#<RedAmber::DataFrame : 35 x 8 Vectors, 0x000000000000f99c>\n",
        "   species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "   <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        " 1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -4734,7 +4792,7 @@
        "35 Gentoo   Biscoe              46.8          14.3               215 ...     2009\n"
       ]
      },
-     "execution_count": 141,
+     "execution_count": 143,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4762,7 +4820,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 144,
    "id": "a721804b-006e-44c6-8d38-885eae747eaa",
    "metadata": {},
    "outputs": [
@@ -4772,7 +4830,7 @@
        "RedAmber::DataFrame <344 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f21c>\n",
+       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -4786,7 +4844,7 @@
        "344 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 142,
+     "execution_count": 144,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4798,7 +4856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 145,
    "id": "e4c9f70c-a4b1-4a81-bbc4-e9b14a6b6cb0",
    "metadata": {},
    "outputs": [
@@ -4806,7 +4864,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f21c>\n",
+      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
       "Vectors : 5 numeric, 3 strings\n",
       "# key                type   level data_preview\n",
       "1 :species           string     3 {\"Adelie\"=>152, \"Chinstrap\"=>68, \"Gentoo\"=>124}\n",
@@ -4824,7 +4882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 146,
    "id": "2786e9a7-e321-43c5-b56e-9f2ca9d62f8b",
    "metadata": {},
    "outputs": [
@@ -4844,7 +4902,7 @@
        "8 :year              uint16     3 {2007=>110, 2008=>114, 2009=>120}\n"
       ]
      },
-     "execution_count": 144,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4855,7 +4913,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 147,
    "id": "b00c858b-b14a-492b-bc22-d6a707bcc1ba",
    "metadata": {},
    "outputs": [
@@ -4865,7 +4923,7 @@
        "\"Table\""
       ]
      },
-     "execution_count": 145,
+     "execution_count": 147,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4896,7 +4954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 148,
    "id": "13569004-bb23-45fa-8d11-fe5f367641a6",
    "metadata": {},
    "outputs": [
@@ -4906,14 +4964,14 @@
        "RedAmber::DataFrame <2 x 2 vectors> <table><tr><th>unnamed2</th><th>unnamed1</th></tr><tr><td>1</td><td>3</td></tr><tr><td>2</td><td>4</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x000000000000f8fc>\n",
+       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x000000000000f9b0>\n",
        "  unnamed2 unnamed1\n",
        "   <uint8>  <uint8>\n",
        "1        1        3\n",
        "2        2        4\n"
       ]
      },
-     "execution_count": 146,
+     "execution_count": 148,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4944,18 +5002,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 149,
    "id": "ee602e52-7988-4fab-b5e3-c466acf01c98",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Group:0x000000000000f910\n",
+       "#<RedAmber::Group:0x000000000000f9c4\n",
        "{:species=>{\"Adelie\"=>152, \"Chinstrap\"=>68, \"Gentoo\"=>124}}>"
       ]
      },
-     "execution_count": 147,
+     "execution_count": 149,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4976,7 +5034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 150,
    "id": "20b23ada-b895-4921-b57b-8d46b451e494",
    "metadata": {},
    "outputs": [
@@ -4986,7 +5044,7 @@
        "RedAmber::DataFrame <3 x 8 vectors> <table><tr><th>species</th><th>count(island)</th><th>count(bill_length_mm)</th><th>count(bill_depth_mm)</th><th>count(flipper_length_mm)</th><th>count(body_mass_g)</th><th>count(sex)</th><th>count(year)</th></tr><tr><td>Adelie</td><td>152</td><td>151</td><td>151</td><td>151</td><td>151</td><td>146</td><td>152</td></tr><tr><td>Chinstrap</td><td>68</td><td>68</td><td>68</td><td>68</td><td>68</td><td>68</td><td>68</td></tr><tr><td>Gentoo</td><td>124</td><td>123</td><td>123</td><td>123</td><td>123</td><td>119</td><td>124</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 8 Vectors, 0x000000000000f924>\n",
+       "#<RedAmber::DataFrame : 3 x 8 Vectors, 0x000000000000f9d8>\n",
        "  species   count(island) count(bill_length_mm) count(bill_depth_mm) ... count(year)\n",
        "  <string>        <int64>               <int64>              <int64> ...     <int64>\n",
        "1 Adelie              152                   151                  151 ...         152\n",
@@ -4994,7 +5052,7 @@
        "3 Gentoo              124                   123                  123 ...         124\n"
       ]
      },
-     "execution_count": 148,
+     "execution_count": 150,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5013,7 +5071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 151,
    "id": "e6936488-9f23-47bd-8492-537c5be1afb3",
    "metadata": {},
    "outputs": [
@@ -5023,7 +5081,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>species</th><th>count</th></tr><tr><td>Adelie</td><td>151</td></tr><tr><td>Chinstrap</td><td>68</td></tr><tr><td>Gentoo</td><td>123</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f938>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f9ec>\n",
        "  species     count\n",
        "  <string>  <int64>\n",
        "1 Adelie        151\n",
@@ -5031,7 +5089,7 @@
        "3 Gentoo        123\n"
       ]
      },
-     "execution_count": 149,
+     "execution_count": 151,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5070,7 +5128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 152,
    "id": "913f576b-ec86-4e94-af05-7c656ea24cc2",
    "metadata": {},
    "outputs": [
@@ -5080,15 +5138,15 @@
        "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>species</th><th>count</th><th>mean(body_mass_g)</th></tr><tr><td>Adelie</td><td>152</td><td>3700.662251655629</td></tr><tr><td>Chinstrap</td><td>68</td><td>3733.0882352941176</td></tr><tr><td>Gentoo</td><td>124</td><td>5076.016260162602</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000f94c>\n",
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fa00>\n",
        "  species     count mean(body_mass_g)\n",
        "  <string>  <int64>          <double>\n",
-       "1 Adelie        152            3700.7\n",
-       "2 Chinstrap      68            3733.1\n",
-       "3 Gentoo        124            5076.0\n"
+       "1 Adelie        152           3700.66\n",
+       "2 Chinstrap      68           3733.09\n",
+       "3 Gentoo        124           5076.02\n"
       ]
      },
-     "execution_count": 150,
+     "execution_count": 152,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5107,7 +5165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 153,
    "id": "67c7fc55-7b30-469c-bd0c-cda5732863fe",
    "metadata": {},
    "outputs": [
@@ -5117,15 +5175,15 @@
        "RedAmber::DataFrame <3 x 7 vectors> <table><tr><th>species</th><th>count</th><th>mean(bill_length_mm)</th><th>mean(bill_depth_mm)</th><th>mean(flipper_length_mm)</th><th>mean(body_mass_g)</th><th>mean(year)</th></tr><tr><td>Adelie</td><td>152</td><td>38.79139072847684</td><td>18.346357615894032</td><td>189.95364238410596</td><td>3700.662251655629</td><td>2008.0131578947369</td></tr><tr><td>Chinstrap</td><td>68</td><td>48.83382352941177</td><td>18.420588235294115</td><td>195.8235294117647</td><td>3733.0882352941176</td><td>2007.9705882352941</td></tr><tr><td>Gentoo</td><td>124</td><td>47.504878048780476</td><td>14.982113821138206</td><td>217.1869918699187</td><td>5076.016260162602</td><td>2008.0806451612902</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 7 Vectors, 0x000000000000f960>\n",
+       "#<RedAmber::DataFrame : 3 x 7 Vectors, 0x000000000000fa14>\n",
        "  species     count mean(bill_length_mm) mean(bill_depth_mm) ... mean(year)\n",
        "  <string>  <int64>             <double>            <double> ...   <double>\n",
-       "1 Adelie        152                 38.8                18.3 ...     2008.0\n",
-       "2 Chinstrap      68                 48.8                18.4 ...     2008.0\n",
-       "3 Gentoo        124                 47.5                15.0 ...     2008.1\n"
+       "1 Adelie        152                38.79               18.35 ...    2008.01\n",
+       "2 Chinstrap      68                48.83               18.42 ...    2007.97\n",
+       "3 Gentoo        124                 47.5               14.98 ...    2008.08\n"
       ]
      },
-     "execution_count": 151,
+     "execution_count": 153,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5156,18 +5214,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 154,
    "id": "013f2db6-3e1d-481f-a908-57605729b51d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f974>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000fa28>\n",
        "[nil, 1, 2, 3, 4]\n"
       ]
      },
-     "execution_count": 152,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5179,18 +5237,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 155,
    "id": "7625acd7-d6a0-4775-b5e0-ca87f95f4f28",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f988>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000fa3c>\n",
        "[3, 4, 5, nil, nil]\n"
       ]
      },
-     "execution_count": 153,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5201,18 +5259,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": 156,
    "id": "34a9ac2a-2e3f-44bc-8ba7-c4487dc3528e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f99c>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fa50>\n",
        "[NaN, 1.0, 2.0, 3.0, 4.0]\n"
       ]
      },
-     "execution_count": 154,
+     "execution_count": 156,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5256,7 +5314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": 157,
    "id": "24774ccc-8f0f-4ce4-9ba0-bebed8781c38",
    "metadata": {},
    "outputs": [
@@ -5266,7 +5324,7 @@
        "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>5</td><td>-1</td><td>50</td></tr><tr><td>6</td><td>-1</td><td>-30</td></tr><tr><td>7</td><td>-1</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000f9b0>\n",
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fa64>\n",
        "      AAA    BBB    CCC\n",
        "  <uint8> <int8> <int8>\n",
        "1       4     10    100\n",
@@ -5275,7 +5333,7 @@
        "4       7     -1    -50\n"
       ]
      },
-     "execution_count": 155,
+     "execution_count": 157,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5286,7 +5344,7 @@
     "  \"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]  # You can omit {}\n",
     ")\n",
     "\n",
-    "df.assign( BBB: df[:BBB].replace(df[:AAA] >= 5, -1) )"
+    "df.assign(BBB: df[:BBB].replace(df[:AAA] >= 5, -1))"
    ]
   },
   {
@@ -5299,7 +5357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": 158,
    "id": "3f97227b-cbee-4515-b76d-3514401967d9",
    "metadata": {},
    "outputs": [
@@ -5309,7 +5367,7 @@
        "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>5</td><td>-1</td><td>-2</td></tr><tr><td>6</td><td>-1</td><td>-2</td></tr><tr><td>7</td><td>-1</td><td>-2</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000f9c4>\n",
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fa78>\n",
        "      AAA    BBB    CCC\n",
        "  <uint8> <int8> <int8>\n",
        "1       4     10    100\n",
@@ -5318,7 +5376,7 @@
        "4       7     -1     -2\n"
       ]
      },
-     "execution_count": 156,
+     "execution_count": 158,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5340,7 +5398,7 @@
     "tags": []
    },
    "source": [
-    "## 53. From the Pandas cookbook (splitting)\n",
+    "## 53. From the Pandas cookbook (Splitting)\n",
     "Split a frame with a boolean criterion\n",
     "\n",
     "https://pandas.pydata.org/docs/user_guide/cookbook.html#splitting"
@@ -5374,7 +5432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 159,
    "id": "b08e74d4-aba8-4fb5-a815-5d5384e92f81",
    "metadata": {},
    "outputs": [
@@ -5384,14 +5442,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>5</td><td>20</td><td>50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000f9d8>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fa8c>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       4      10    100\n",
        "2       5      20     50\n"
       ]
      },
-     "execution_count": 157,
+     "execution_count": 159,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5403,12 +5461,13 @@
     "  \"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]\n",
     ")\n",
     "\n",
-    "df.slice(df[:AAA] <= 5)"
+    "df.slice(df[:AAA] <= 5)\n",
+    "# df[df[:AAA] <= 5] # is also OK"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": 160,
    "id": "caa72796-ff7e-4275-849f-04698114ee08",
    "metadata": {},
    "outputs": [
@@ -5418,14 +5477,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>6</td><td>30</td><td>-30</td></tr><tr><td>7</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000f9ec>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000faa0>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       6      30    -30\n",
        "2       7      40    -50\n"
       ]
      },
-     "execution_count": 158,
+     "execution_count": 160,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5434,6 +5493,1276 @@
     "df.remove(df[:AAA] <= 5)\n",
     "# df.slice(df[:AAA] > 5) # do the same thing"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba7588e9-bbac-4547-a56c-3eea9f819460",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 54. From the Pandas cookbook (Building criteria)\n",
+    "Split a frame with a boolean criterion\n",
+    "\n",
+    "https://pandas.pydata.org/docs/user_guide/cookbook.html#building-criteria"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6d01b08-1af7-47b0-a9e4-f27ab41fe24e",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "df = pd.DataFrame(\n",
+    "    {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+    ")\n",
+    "\n",
+    "# and\n",
+    "df.loc[(df[\"BBB\"] < 25) & (df[\"CCC\"] >= -40), \"AAA\"]\n",
+    "\n",
+    "# returns a series =>\n",
+    "0    4\n",
+    "1    5\n",
+    "Name: AAA, dtype: int64\n",
+    "\n",
+    "# or\n",
+    "df.loc[(df[\"BBB\"] > 25) | (df[\"CCC\"] >= -40), \"AAA\"]\n",
+    "\n",
+    "# returns a series =>\n",
+    "0    4\n",
+    "1    5\n",
+    "2    6\n",
+    "3    7\n",
+    "Name: AAA, dtype: int64\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "id": "46066e96-91e5-4a96-9840-7e4ce6f06818",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 1 vector> <table><tr><th>AAA</th></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 1 Vector, 0x000000000000fab4>\n",
+       "      AAA\n",
+       "  <uint8>\n",
+       "1       4\n",
+       "2       5\n"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Red Amber\n",
+    "df = DataFrame.new(\n",
+    "  # You can omit {}\n",
+    "  \"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]\n",
+    ")\n",
+    "\n",
+    "df.slice( (df[:BBB] < 25) & (df[:CCC] >= 40) ).pick(:AAA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "id": "dc8304c2-be28-420e-b2d5-a4b636eaac8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 1 vector> <table><tr><th>AAA</th></tr><tr><td>4</td></tr><tr><td>5</td></tr><tr><td>6</td></tr><tr><td>7</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 1 Vector, 0x000000000000fac8>\n",
+       "      AAA\n",
+       "  <uint8>\n",
+       "1       4\n",
+       "2       5\n",
+       "3       6\n",
+       "4       7\n"
+      ]
+     },
+     "execution_count": 162,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice( (df[:BBB] > 25) | (df[:CCC] >= 40) ).pick(:AAA)\n",
+    "# df[ (df[:BBB] > 25) | (df[:CCC] >= 40) ][:AAA)] # also OK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79616705-f497-4bb4-ad1d-5ee93c0093ce",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# or (with assignment)\n",
+    "df.loc[(df[\"BBB\"] > 25) | (df[\"CCC\"] >= 75), \"AAA\"] = 0.1\n",
+    "df\n",
+    "\n",
+    "# returns a dataframe =>\n",
+    "   AAA  BBB  CCC\n",
+    "0  0.1   10  100\n",
+    "1  5.0   20   50\n",
+    "2  0.1   30  -30\n",
+    "3  0.1   40  -50\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "id": "7ab3b044-5a0f-4a38-8a42-aed1228b6462",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>0.1</td><td>10</td><td>100</td></tr><tr><td>5.0</td><td>20</td><td>50</td></tr><tr><td>0.1</td><td>30</td><td>-30</td></tr><tr><td>0.1</td><td>40</td><td>-50</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fadc>\n",
+       "       AAA     BBB    CCC\n",
+       "  <double> <uint8> <int8>\n",
+       "1      0.1      10    100\n",
+       "2      5.0      20     50\n",
+       "3      0.1      30    -30\n",
+       "4      0.1      40    -50\n"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# df.assign(AAA: df[:AAA].replace((df[:BBB] > 25) | (df[:CCC] >= 75), 0.1)) # by one liner\n",
+    "\n",
+    "booleans = (df[:BBB] > 25) | (df[:CCC] >= 75)\n",
+    "replaced = df[:AAA].replace(booleans, 0.1)\n",
+    "df.assign(AAA: replaced)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd4a47c-f619-462b-94c0-4c488761d5b0",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Select rows with data closest to certain value using argsort\n",
+    "df = pd.DataFrame(\n",
+    "    {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+    ")\n",
+    "aValue = 43.0\n",
+    "df.loc[(df.CCC - aValue).abs().argsort()]\n",
+    "\n",
+    "# returns a dataframe =>\n",
+    "   AAA  BBB  CCC\n",
+    "1    5   20   50\n",
+    "0    4   10  100\n",
+    "2    6   30  -30\n",
+    "3    7   40  -50\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "id": "13cb1d45-2d13-4708-ad76-57efd72e609b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>5</td><td>20</td><td>50</td></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>6</td><td>30</td><td>-30</td></tr><tr><td>7</td><td>40</td><td>-50</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000faf0>\n",
+       "      AAA     BBB    CCC\n",
+       "  <uint8> <uint8> <int8>\n",
+       "1       5      20     50\n",
+       "2       4      10    100\n",
+       "3       6      30    -30\n",
+       "4       7      40    -50\n"
+      ]
+     },
+     "execution_count": 164,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a_value = 43\n",
+    "df[(df[:CCC] - a_value).abs.sort_indexes]\n",
+    "# df.slice (df[:CCC] - a_value).abs.sort_indexes # also OK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9330117b-40e0-4574-8900-7857622daad4",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Dynamically reduce a list of criteria using a binary operators\n",
+    "df = pd.DataFrame(\n",
+    "    {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+    ")\n",
+    "Crit1 = df.AAA <= 5.5\n",
+    "Crit2 = df.BBB == 10.0\n",
+    "Crit3 = df.CCC > -40.0\n",
+    "AllCrit = Crit1 & Crit2 & Crit3\n",
+    "\n",
+    "import functools\n",
+    "\n",
+    "CritList = [Crit1, Crit2, Crit3]\n",
+    "AllCrit = functools.reduce(lambda x, y: x & y, CritList)\n",
+    "df[AllCrit]\n",
+    "\n",
+    "# returns a dataframe =>\n",
+    "   AAA  BBB  CCC\n",
+    "0    4   10  100\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
+   "id": "40336e62-d411-4655-8ec5-8d30876ada47",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <1 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000fb04>\n",
+       "      AAA     BBB    CCC\n",
+       "  <uint8> <uint8> <int8>\n",
+       "1       4      10    100\n"
+      ]
+     },
+     "execution_count": 165,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crit1 = df[:AAA] <= 5.5\n",
+    "crit2 = df[:BBB] == 10.0\n",
+    "crit3 = df[:CCC] >= -40.0\n",
+    "df[crit1 & crit2 & crit3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62e03375-573d-4368-a26e-1be3a4d58cf8",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 55. From the Pandas cookbook (Dataframes)\n",
+    "\n",
+    "https://pandas.pydata.org/docs/user_guide/cookbook.html#dataframes"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "55cee55f-7caf-423c-863a-187f96fa3072",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Using both row labels and value conditionals\n",
+    "df = pd.DataFrame(\n",
+    "    {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+    ")\n",
+    "df[(df.AAA <= 6) & (df.index.isin([0, 2, 4]))] \n",
+    "\n",
+    "# returns =>\n",
+    "   AAA  BBB  CCC\n",
+    "0    4   10  100\n",
+    "2    6   30  -30\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "id": "272396f6-f689-43d5-ba34-e7c6ac0e1c28",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>6</td><td>30</td><td>-30</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fb18>\n",
+       "      AAA     BBB    CCC\n",
+       "  <uint8> <uint8> <int8>\n",
+       "1       4      10    100\n",
+       "2       6      30    -30\n"
+      ]
+     },
+     "execution_count": 166,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Red Amber\n",
+    "df = DataFrame.new(\n",
+    "  \"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]\n",
+    ")\n",
+    "\n",
+    "df[(df[:AAA] <= 6) & df.indices.map { |i| [0, 2, 4].include? i }]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26bfea62-12e4-4a01-976e-6184ecafa2fd",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Use loc for label-oriented slicing and iloc positional slicing GH2904\n",
+    "df = pd.DataFrame(\n",
+    "    {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]},\n",
+    "    index=[\"foo\", \"bar\", \"boo\", \"kar\"],\n",
+    ")\n",
+    "\n",
+    "# There are 2 explicit slicing methods, with a third general case\n",
+    "# 1. Positional-oriented (Python slicing style : exclusive of end)\n",
+    "# 2. Label-oriented (Non-Python slicing style : inclusive of end)\n",
+    "# 3. General (Either slicing style : depends on if the slice contains labels or positions)\n",
+    "\n",
+    "df.loc[\"bar\":\"kar\"]  # Label\n",
+    "# returns =>\n",
+    "     AAA  BBB  CCC\n",
+    "bar    5   20   50\n",
+    "boo    6   30  -30\n",
+    "kar    7   40  -50\n",
+    "\n",
+    "# Generic\n",
+    "df[0:3]\n",
+    "# returns =>\n",
+    "     AAA  BBB  CCC\n",
+    "foo    4   10  100\n",
+    "bar    5   20   50\n",
+    "boo    6   30  -30\n",
+    "\n",
+    "df[\"bar\":\"kar\"]\n",
+    "# returns =>\n",
+    "     AAA  BBB  CCC\n",
+    "bar    5   20   50\n",
+    "boo    6   30  -30\n",
+    "kar    7   40  -50\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "ccabc137-33d3-47e8-ad09-88a285765380",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 4 vectors> <table><tr><th>index</th><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>foo</td><td>4</td><td>10</td><td>100</td></tr><tr><td>bar</td><td>5</td><td>20</td><td>50</td></tr><tr><td>boo</td><td>6</td><td>30</td><td>-30</td></tr><tr><td>kar</td><td>7</td><td>40</td><td>-50</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 4 Vectors, 0x000000000000fb2c>\n",
+       "  index        AAA     BBB    CCC\n",
+       "  <string> <uint8> <uint8> <int8>\n",
+       "1 foo            4      10    100\n",
+       "2 bar            5      20     50\n",
+       "3 boo            6      30    -30\n",
+       "4 kar            7      40    -50\n"
+      ]
+     },
+     "execution_count": 167,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Red Amber does not have row index. Use a new column as indexes.\n",
+    "labeled = df.assign_left(index: %w[foo bar boo kar])\n",
+    "# labeled = df.assign(index: %w[foo bar boo kar]).pick { [keys[-1], keys[0...-1]] } # until v0.1.8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "id": "f0871131-725e-4e33-a3cc-1fccd610a4b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>index</th><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>bar</td><td>5</td><td>20</td><td>50</td></tr><tr><td>boo</td><td>6</td><td>30</td><td>-30</td></tr><tr><td>kar</td><td>7</td><td>40</td><td>-50</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fb40>\n",
+       "  index        AAA     BBB    CCC\n",
+       "  <string> <uint8> <uint8> <int8>\n",
+       "1 bar            5      20     50\n",
+       "2 boo            6      30    -30\n",
+       "3 kar            7      40    -50\n"
+      ]
+     },
+     "execution_count": 168,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "labeled[1..3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "dffc55f0-481e-4076-aa3f-89f1294655b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>index</th><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>bar</td><td>5</td><td>20</td><td>50</td></tr><tr><td>boo</td><td>6</td><td>30</td><td>-30</td></tr><tr><td>kar</td><td>7</td><td>40</td><td>-50</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fb54>\n",
+       "  index        AAA     BBB    CCC\n",
+       "  <string> <uint8> <uint8> <int8>\n",
+       "1 bar            5      20     50\n",
+       "2 boo            6      30    -30\n",
+       "3 kar            7      40    -50\n"
+      ]
+     },
+     "execution_count": 169,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "labeled.slice do\n",
+    "  v = v(:index)\n",
+    "  v.index(\"bar\")..v.index(\"kar\")\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d72b067c-d15d-499b-8d2a-8b79f5287e97",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Ambiguity arises when an index consists of integers with a non-zero start or non-unit increment.\n",
+    "df2 = pd.DataFrame(data=data, index=[1, 2, 3, 4])  # Note index starts at 1.\n",
+    "\n",
+    "df2.iloc[1:3]  # Position-oriented\n",
+    "# returns =>\n",
+    "   AAA  BBB  CCC\n",
+    "2    5   20   50\n",
+    "3    6   30  -30\n",
+    "\n",
+    "df2.loc[1:3]  # Label-oriented\n",
+    "# returns =>\n",
+    "   AAA  BBB  CCC\n",
+    "1    4   10  100\n",
+    "2    5   20   50\n",
+    "3    6   30  -30\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 170,
+   "id": "f023a23a-ea1d-415c-b395-195801351433",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# RedAmber only have an implicit integer index 0...size,\n",
+    "# does not happen any ambiguity unless you create a new column and use it for indexes :-)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cada26c-a37a-4eff-bfa5-66635d278671",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Using inverse operator (~) to take the complement of a mask\n",
+    "df[~((df.AAA <= 6) & (df.index.isin([0, 2, 4])))]\n",
+    "\n",
+    "# returns =>\n",
+    "   AAA  BBB  CCC\n",
+    "1    5   20   50\n",
+    "3    7   40  -50\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "29b81efe-5b9b-4640-89b1-422ae94cf01d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>5</td><td>20</td><td>50</td></tr><tr><td>7</td><td>40</td><td>-50</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fb68>\n",
+       "      AAA     BBB    CCC\n",
+       "  <uint8> <uint8> <int8>\n",
+       "1       5      20     50\n",
+       "2       7      40    -50\n"
+      ]
+     },
+     "execution_count": 171,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# RedAmber offers #! method for boolean Vector.\n",
+    "df[!((df[:AAA] <= 6) & df.indices.map { |i| [0, 2, 4].include? i })]\n",
+    "\n",
+    "# or\n",
+    "# df[((df[:AAA] <= 6) & df.indices.map { |i| [0, 2, 4].include? i }).invert]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb7103f-00ed-4e74-81e5-7d480004e681",
+   "metadata": {},
+   "source": [
+    "If you have `nil` in your data, consider #primitive_invert for consistent result. See example #26."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1780372-b566-41f5-84d6-6213e3f9efa7",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 56. From the Pandas cookbook (New columns)\n",
+    "\n",
+    "https://pandas.pydata.org/docs/user_guide/cookbook.html#new-columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f5f9d8b-7550-44f6-9f79-64f940f5000a",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Efficiently and dynamically creating new columns using applymap\n",
+    "df = pd.DataFrame({\"AAA\": [1, 2, 1, 3], \"BBB\": [1, 1, 2, 2], \"CCC\": [2, 1, 3, 1]})\n",
+    "df\n",
+    "\n",
+    "# returns =>\n",
+    "   AAA  BBB  CCC\n",
+    "0    1    1    2\n",
+    "1    2    1    1\n",
+    "2    1    2    3\n",
+    "3    3    2    1\n",
+    "\n",
+    "source_cols = df.columns  # Or some subset would work too\n",
+    "new_cols = [str(x) + \"_cat\" for x in source_cols]\n",
+    "categories = {1: \"Alpha\", 2: \"Beta\", 3: \"Charlie\"}\n",
+    "df[new_cols] = df[source_cols].applymap(categories.get)\n",
+    "df\n",
+    "\n",
+    "# returns =>\n",
+    "   AAA  BBB  CCC  AAA_cat BBB_cat  CCC_cat\n",
+    "0    1    1    2    Alpha   Alpha     Beta\n",
+    "1    2    1    1     Beta   Alpha    Alpha\n",
+    "2    1    2    3    Alpha    Beta  Charlie\n",
+    "3    3    2    1  Charlie    Beta    Alpha\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "id": "265d63e6-0c01-4080-8d5b-c3153be595a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>1</td><td>1</td><td>2</td></tr><tr><td>2</td><td>1</td><td>1</td></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>3</td><td>2</td><td>1</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fb7c>\n",
+       "      AAA     BBB     CCC\n",
+       "  <uint8> <uint8> <uint8>\n",
+       "1       1       1       2\n",
+       "2       2       1       1\n",
+       "3       1       2       3\n",
+       "4       3       2       1\n"
+      ]
+     },
+     "execution_count": 172,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# RedAmber\n",
+    "df = DataFrame.new({\"AAA\": [1, 2, 1, 3], \"BBB\": [1, 1, 2, 2], \"CCC\": [2, 1, 3, 1]})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "id": "4be751d7-69a8-4400-b094-9932bf3d577b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 6 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th><th>AAA_cat</th><th>BBB_cat</th><th>CCC_cat</th></tr><tr><td>1</td><td>1</td><td>2</td><td>Alpha</td><td>Alpha</td><td>Beta</td></tr><tr><td>2</td><td>1</td><td>1</td><td>Beta</td><td>Alpha</td><td>Alpha</td></tr><tr><td>1</td><td>2</td><td>3</td><td>Alpha</td><td>Beta</td><td>Charlie</td></tr><tr><td>3</td><td>2</td><td>1</td><td>Charlie</td><td>Beta</td><td>Alpha</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 6 Vectors, 0x000000000000fb90>\n",
+       "      AAA     BBB     CCC AAA_cat  BBB_cat  CCC_cat\n",
+       "  <uint8> <uint8> <uint8> <string> <string> <string>\n",
+       "1       1       1       2 Alpha    Alpha    Beta\n",
+       "2       2       1       1 Beta     Alpha    Alpha\n",
+       "3       1       2       3 Alpha    Beta     Charlie\n",
+       "4       3       2       1 Charlie  Beta     Alpha\n"
+      ]
+     },
+     "execution_count": 173,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "categories = {1 => \"Alpha\", 2 => \"Beta\", 3 => \"Charlie\"}\n",
+    "\n",
+    "# Creating a Hash from keys\n",
+    "df.assign do\n",
+    "  keys.each_with_object({}) do |key, h|\n",
+    "    h[\"#{key}_cat\"] = v(key).to_a.map { |x| categories[x] }\n",
+    "  end\n",
+    "end\n",
+    "\n",
+    "# Creating an Array from vectors, from v0.2.0\n",
+    "df.assign do\n",
+    "  vectors.map do |v|\n",
+    "    [\"#{v.key}_cat\", v.to_a.map { |x| categories[x] } ]\n",
+    "  end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa8214e5-a897-406e-bb5e-95ad9fea0cdd",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Keep other columns when using min() with groupby\n",
+    "df = pd.DataFrame(\n",
+    "    {\"AAA\": [1, 1, 1, 2, 2, 2, 3, 3], \"BBB\": [2, 1, 3, 4, 5, 1, 2, 3]}\n",
+    ")\n",
+    "df\n",
+    "\n",
+    "# returns =>\n",
+    "   AAA  BBB\n",
+    "0    1    2\n",
+    "1    1    1\n",
+    "2    1    3\n",
+    "3    2    4\n",
+    "4    2    5\n",
+    "5    2    1\n",
+    "6    3    2\n",
+    "7    3    3\n",
+    "\n",
+    "# Method 1 : idxmin() to get the index of the minimums\n",
+    "df.loc[df.groupby(\"AAA\")[\"BBB\"].idxmin()]\n",
+    "\n",
+    "# returns =>\n",
+    "   AAA  BBB\n",
+    "1    1    1\n",
+    "5    2    1\n",
+    "6    3    2\n",
+    "\n",
+    "# Method 2 : sort then take first of each\n",
+    "df.sort_values(by=\"BBB\").groupby(\"AAA\", as_index=False).first()\n",
+    "\n",
+    "# returns =>\n",
+    "   AAA  BBB\n",
+    "0    1    1\n",
+    "1    2    1\n",
+    "2    3    2\n",
+    "\n",
+    "# Notice the same results, with the exception of the index.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "id": "5dd5f7dc-21a3-4397-9ef6-c5bc630ff858",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <8 x 2 vectors> <table><tr><th>AAA</th><th>BBB</th></tr><tr><td>1</td><td>2</td></tr><tr><td>1</td><td>1</td></tr><tr><td>1</td><td>3</td></tr><tr><td>2</td><td>4</td></tr><tr><td>2</td><td>5</td></tr><tr><td>2</td><td>1</td></tr><tr><td>3</td><td>2</td></tr><tr><td>3</td><td>3</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 8 x 2 Vectors, 0x000000000000fba4>\n",
+       "      AAA     BBB\n",
+       "  <uint8> <uint8>\n",
+       "1       1       2\n",
+       "2       1       1\n",
+       "3       1       3\n",
+       "4       2       4\n",
+       "5       2       5\n",
+       ":       :       :\n",
+       "7       3       2\n",
+       "8       3       3\n"
+      ]
+     },
+     "execution_count": 174,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# RedAmber\n",
+    "df = DataFrame.new(AAA: [1, 1, 1, 2, 2, 2, 3, 3], BBB: [2, 1, 3, 4, 5, 1, 2, 3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 175,
+   "id": "000c1632-8faf-407f-bb7d-e583ef573442",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>AAA</th><th>min(BBB)</th></tr><tr><td>1</td><td>1</td></tr><tr><td>2</td><td>1</td></tr><tr><td>3</td><td>2</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000fbb8>\n",
+       "      AAA min(BBB)\n",
+       "  <uint8>  <uint8>\n",
+       "1       1        1\n",
+       "2       2        1\n",
+       "3       3        2\n"
+      ]
+     },
+     "execution_count": 175,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.group(:AAA).min\n",
+    "\n",
+    "# Add `.rename { [keys[-1], :BBB] }` if you want."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5aa5b4ab-2fb3-4a22-804e-55d6351dd427",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 57. Summary/describe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "id": "610be94e-b7ce-43f5-a5c1-ddef745d6bac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 9 vectors> <table><tr><th>variables</th><th>count</th><th>mean</th><th>std</th><th>min</th><th>25%</th><th>median</th><th>75%</th><th>max</th></tr><tr><td>bill_length_mm</td><td>342</td><td>43.92192982456141</td><td>5.4595837139265315</td><td>32.1</td><td>39.225</td><td>44.382000000000005</td><td>48.5</td><td>59.6</td></tr><tr><td>bill_depth_mm</td><td>342</td><td>17.151169590643274</td><td>1.9747931568167814</td><td>13.1</td><td>15.6</td><td>17.32</td><td>18.7</td><td>21.5</td></tr><tr><td>flipper_length_mm</td><td>342</td><td>200.91520467836258</td><td>14.061713679356888</td><td>172.0</td><td>190.0</td><td>197.0</td><td>213.0</td><td>231.0</td></tr><tr><td>body_mass_g</td><td>342</td><td>4201.754385964912</td><td>801.9545356980955</td><td>2700.0</td><td>3550.0</td><td>4031.5</td><td>4750.0</td><td>6300.0</td></tr><tr><td>year</td><td>344</td><td>2008.0290697674418</td><td>0.8183559254837041</td><td>2007.0</td><td>2007.0</td><td>2008.0</td><td>2009.0</td><td>2009.0</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 9 Vectors, 0x000000000000fbcc>\n",
+       "  variables            count     mean      std      min      25%   median ...      max\n",
+       "  <dictionary>      <uint16> <double> <double> <double> <double> <double> ... <double>\n",
+       "1 bill_length_mm         342    43.92     5.46     32.1    39.23    44.38 ...     59.6\n",
+       "2 bill_depth_mm          342    17.15     1.97     13.1     15.6    17.32 ...     21.5\n",
+       "3 flipper_length_mm      342   200.92    14.06    172.0    190.0    197.0 ...    231.0\n",
+       "4 body_mass_g            342  4201.75   801.95   2700.0   3550.0   4031.5 ...   6300.0\n",
+       "5 year                   344  2008.03     0.82   2007.0   2007.0   2008.0 ...   2009.0\n"
+      ]
+     },
+     "execution_count": 176,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "penguins.summary\n",
+    "# or\n",
+    "penguins.describe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "982a735e-c887-4c15-be82-4f3a28138fa7",
+   "metadata": {},
+   "source": [
+    "## 58. Quantile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0832e36-7281-4d3c-a35d-5a89aecc341e",
+   "metadata": {},
+   "source": [
+    "`Vector#quantile(prob)` returns quantile at probability `prob`.\n",
+    "\n",
+    "(Since 0.2.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "id": "88c6ed5d-b41e-4c17-b93f-47ce15702974",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "17.3"
+      ]
+     },
+     "execution_count": 177,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "penguins[:bill_depth_mm].quantile # default value is prob = 0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07368c10-65d4-4081-ace7-12bebca493c2",
+   "metadata": {},
+   "source": [
+    "`Vector#quantiles` accepts an Array for multiple quantiles. Returns a DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "id": "3cbac413-fc36-42a2-abd3-1343e3b88467",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 2 vectors> <table><tr><th>probs</th><th>quantiles</th></tr><tr><td>0.05</td><td>13.9</td></tr><tr><td>0.95</td><td>20.0</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x000000000000fbe0>\n",
+       "     probs quantiles\n",
+       "  <double>  <double>\n",
+       "1     0.05      13.9\n",
+       "2     0.95      20.0\n"
+      ]
+     },
+     "execution_count": 178,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "penguins[:bill_depth_mm].quantiles([0.05, 0.95])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54800864-c33d-4fec-818b-1a12a7e4d015",
+   "metadata": {},
+   "source": [
+    "## 59. Transpose"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "517281cf-3f29-4725-816c-5a866e9cc9cc",
+   "metadata": {},
+   "source": [
+    "`DataFrame#transpose` creates transposed DataFrame for wide type dataframe.\n",
+    "\n",
+    "(Since 0.2.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "id": "a2fe66cb-e86d-402e-8724-eced2420e3d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fbf4>\n",
+       "     Year    Audi     BMW BMW_MINI Mercedes-Benz      VW\n",
+       "  <int64> <int64> <int64>  <int64>       <int64> <int64>\n",
+       "1    2021   22535   35905    18211         51722   35215\n",
+       "2    2020   22304   35712    20196         57041   36576\n",
+       "3    2019   24222   46814    23813         66553   46794\n",
+       "4    2018   26473   50982    25984         67554   51961\n",
+       "5    2017   28336   52527    25427         68221   49040\n"
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import_cars = RedAmber::DataFrame.load('../test/entity/import_cars.tsv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "id": "b4ef2b48-33de-4982-b082-1966749fcf65",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>name</th><th>2021</th><th>2020</th><th>2019</th><th>2018</th><th>2017</th></tr><tr><td>Audi</td><td>22535</td><td>22304</td><td>24222</td><td>26473</td><td>28336</td></tr><tr><td>BMW</td><td>35905</td><td>35712</td><td>46814</td><td>50982</td><td>52527</td></tr><tr><td>BMW_MINI</td><td>18211</td><td>20196</td><td>23813</td><td>25984</td><td>25427</td></tr><tr><td>Mercedes-Benz</td><td>51722</td><td>57041</td><td>66553</td><td>67554</td><td>68221</td></tr><tr><td>VW</td><td>35215</td><td>36576</td><td>46794</td><td>51961</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc08>\n",
+       "  name              2021     2020     2019     2018     2017\n",
+       "  <dictionary>  <uint16> <uint16> <uint32> <uint32> <uint32>\n",
+       "1 Audi             22535    22304    24222    26473    28336\n",
+       "2 BMW              35905    35712    46814    50982    52527\n",
+       "3 BMW_MINI         18211    20196    23813    25984    25427\n",
+       "4 Mercedes-Benz    51722    57041    66553    67554    68221\n",
+       "5 VW               35215    36576    46794    51961    49040\n"
+      ]
+     },
+     "execution_count": 180,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import_cars.transpose"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "556e5c2d-bb01-4e16-9bf6-bdfd302d5b2a",
+   "metadata": {},
+   "source": [
+    "You can specify index column by option `:key` even if it is at the middle of the original DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "id": "31edb594-93fb-493f-8036-14e8273596ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Audi</th><th>BMW</th><th>Year</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>22535</td><td>35905</td><td>2021</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>22304</td><td>35712</td><td>2020</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>24222</td><td>46814</td><td>2019</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>26473</td><td>50982</td><td>2018</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>28336</td><td>52527</td><td>2017</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc1c>\n",
+       "     Audi     BMW    Year BMW_MINI Mercedes-Benz      VW\n",
+       "  <int64> <int64> <int64>  <int64>       <int64> <int64>\n",
+       "1   22535   35905    2021    18211         51722   35215\n",
+       "2   22304   35712    2020    20196         57041   36576\n",
+       "3   24222   46814    2019    23813         66553   46794\n",
+       "4   26473   50982    2018    25984         67554   51961\n",
+       "5   28336   52527    2017    25427         68221   49040\n"
+      ]
+     },
+     "execution_count": 181,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = import_cars.pick { [keys[1..2], keys[0], keys[3..]] }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "id": "ffa7cecc-5298-49d6-b483-b2b5cf2e1820",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>name</th><th>2021</th><th>2020</th><th>2019</th><th>2018</th><th>2017</th></tr><tr><td>Audi</td><td>22535</td><td>22304</td><td>24222</td><td>26473</td><td>28336</td></tr><tr><td>BMW</td><td>35905</td><td>35712</td><td>46814</td><td>50982</td><td>52527</td></tr><tr><td>BMW_MINI</td><td>18211</td><td>20196</td><td>23813</td><td>25984</td><td>25427</td></tr><tr><td>Mercedes-Benz</td><td>51722</td><td>57041</td><td>66553</td><td>67554</td><td>68221</td></tr><tr><td>VW</td><td>35215</td><td>36576</td><td>46794</td><td>51961</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc30>\n",
+       "  name              2021     2020     2019     2018     2017\n",
+       "  <dictionary>  <uint16> <uint16> <uint32> <uint32> <uint32>\n",
+       "1 Audi             22535    22304    24222    26473    28336\n",
+       "2 BMW              35905    35712    46814    50982    52527\n",
+       "3 BMW_MINI         18211    20196    23813    25984    25427\n",
+       "4 Mercedes-Benz    51722    57041    66553    67554    68221\n",
+       "5 VW               35215    36576    46794    51961    49040\n"
+      ]
+     },
+     "execution_count": 182,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.transpose(key: :Year)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c0e6fd9-2355-43dc-bfdb-254fdbd405fb",
+   "metadata": {},
+   "source": [
+    "## 60. To_long"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8970bf89-6841-44aa-8faa-8c2e97842a8d",
+   "metadata": {},
+   "source": [
+    "`DataFrame#to_long(*keep_keys)` reshapes wide DataFrame to a longer DataFrame.\n",
+    "\n",
+    "- Parameter `keep_keys` specifies the key names to keep.\n",
+    "\n",
+    "(Since 0.2.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 183,
+   "id": "f188cf35-3364-45aa-ad3c-1e079ed7b1a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc44>\n",
+       "     Year    Audi     BMW BMW_MINI Mercedes-Benz      VW\n",
+       "  <int64> <int64> <int64>  <int64>       <int64> <int64>\n",
+       "1    2021   22535   35905    18211         51722   35215\n",
+       "2    2020   22304   35712    20196         57041   36576\n",
+       "3    2019   24222   46814    23813         66553   46794\n",
+       "4    2018   26473   50982    25984         67554   51961\n",
+       "5    2017   28336   52527    25427         68221   49040\n"
+      ]
+     },
+     "execution_count": 183,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import_cars = RedAmber::DataFrame.load('../test/entity/import_cars.tsv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "id": "bee776ae-7a82-41aa-8a31-c53af6b9ad9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <25 x 3 vectors> <table><tr><th>Year</th><th>name</th><th>value</th></tr><tr><td>2021</td><td>Audi</td><td>22535</td></tr><tr><td>2021</td><td>BMW</td><td>35905</td></tr><tr><td>2021</td><td>BMW_MINI</td><td>18211</td></tr><tr><td>2021</td><td>Mercedes-Benz</td><td>51722</td></tr><tr><td colspan='3'>&#8942;</td></tr><tr><td>2017</td><td>BMW_MINI</td><td>25427</td></tr><tr><td>2017</td><td>Mercedes-Benz</td><td>68221</td></tr><tr><td>2017</td><td>VW</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 25 x 3 Vectors, 0x000000000000fc58>\n",
+       "       Year name             value\n",
+       "   <uint16> <dictionary>  <uint32>\n",
+       " 1     2021 Audi             22535\n",
+       " 2     2021 BMW              35905\n",
+       " 3     2021 BMW_MINI         18211\n",
+       " 4     2021 Mercedes-Benz    51722\n",
+       " 5     2021 VW               35215\n",
+       " :        : :                    :\n",
+       "23     2017 BMW_MINI         25427\n",
+       "24     2017 Mercedes-Benz    68221\n",
+       "25     2017 VW               49040\n"
+      ]
+     },
+     "execution_count": 184,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import_cars.to_long(:Year)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "771aac21-e739-4eea-9d75-cc99f691f87e",
+   "metadata": {},
+   "source": [
+    "- Option `:name` : key of the column which is come **from key names**.\n",
+    "- Option `:value` : key of the column which is come **from values**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "id": "b7f7aeab-d545-4a28-82ce-db844029cc9c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <25 x 3 vectors> <table><tr><th>Year</th><th>Manufacturer</th><th>Num_of_imported</th></tr><tr><td>2021</td><td>Audi</td><td>22535</td></tr><tr><td>2021</td><td>BMW</td><td>35905</td></tr><tr><td>2021</td><td>BMW_MINI</td><td>18211</td></tr><tr><td>2021</td><td>Mercedes-Benz</td><td>51722</td></tr><tr><td colspan='3'>&#8942;</td></tr><tr><td>2017</td><td>BMW_MINI</td><td>25427</td></tr><tr><td>2017</td><td>Mercedes-Benz</td><td>68221</td></tr><tr><td>2017</td><td>VW</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 25 x 3 Vectors, 0x000000000000fc6c>\n",
+       "       Year Manufacturer  Num_of_imported\n",
+       "   <uint16> <dictionary>         <uint32>\n",
+       " 1     2021 Audi                    22535\n",
+       " 2     2021 BMW                     35905\n",
+       " 3     2021 BMW_MINI                18211\n",
+       " 4     2021 Mercedes-Benz           51722\n",
+       " 5     2021 VW                      35215\n",
+       " :        : :                           :\n",
+       "23     2017 BMW_MINI                25427\n",
+       "24     2017 Mercedes-Benz           68221\n",
+       "25     2017 VW                      49040\n"
+      ]
+     },
+     "execution_count": 185,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import_cars.to_long(:Year, name: :Manufacturer, value: :Num_of_imported)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44361299-695f-4aef-8847-9b8a9dddc3d1",
+   "metadata": {},
+   "source": [
+    "## 61. To_wide"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fa18ac8-99e1-4d55-bed4-cc02469496b5",
+   "metadata": {},
+   "source": [
+    "`DataFrame#to_wide(*keep_keys)` reshapes long DataFrame to a wider DataFrame.\n",
+    "\n",
+    "- Option `:name` : key of the column which will be expanded **to key name**.\n",
+    "- Option `:value` : key of the column which will be expanded **to values**.\n",
+    "\n",
+    "(Since 0.2.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 186,
+   "id": "1d59c42f-c5ec-4df2-9fbe-592092ad2f8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc80>\n",
+       "      Year     Audi      BMW BMW_MINI Mercedes-Benz       VW\n",
+       "  <uint16> <uint16> <uint16> <uint16>      <uint32> <uint16>\n",
+       "1     2021    22535    35905    18211         51722    35215\n",
+       "2     2020    22304    35712    20196         57041    36576\n",
+       "3     2019    24222    46814    23813         66553    46794\n",
+       "4     2018    26473    50982    25984         67554    51961\n",
+       "5     2017    28336    52527    25427         68221    49040\n"
+      ]
+     },
+     "execution_count": 186,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import_cars.to_long(:Year).to_wide"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 187,
+   "id": "84b7909a-200c-4aec-b192-25016399a7c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import_cars.to_long(:Year).to_wide(name: :name, value: :value)\n",
+    "# is also OK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c92c2fe0-23a5-4153-bd03-7a07664b4d9e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module RedAmber
-  # data frame class
-  #   @table   : holds Arrow::Table object
+  # Class to represent a data frame.
+  # Variable @table holds an Arrow::Table object.
   class DataFrame
     # mix-in
     include DataFrameDisplayable
@@ -12,6 +12,24 @@ module RedAmber
     include DataFrameVariableOperation
     include Helper
 
+    # Creates a new RedAmber::DataFrame.
+    #
+    # @overload initialize(hash)
+    #
+    #   @params hash [Hash]
+    #
+    # @overload initialize(table)
+    #
+    #   @params table [Arrow::Table]
+    #
+    # @overload initialize(dataframe)
+    #
+    #   @params dataframe [RedAmber::DataFrame, Rover::DataFrame]
+    #
+    # @overload initialize(null)
+    #
+    #   @params null [NilClass] No arguments.
+    #
     def initialize(*args)
       @variables = @keys = @vectors = @types = @data_types = nil
       case args
@@ -50,56 +68,101 @@ module RedAmber
       @table.save(output, options)
     end
 
+    # Returns the number of rows.
+    #
+    # @return [Integer] Number of rows.
     def size
       @table.n_rows
     end
     alias_method :n_rows, :size
     alias_method :n_obs, :size
 
+    # Returns the number of columns.
+    #
+    # @return [Integer] Number of columns.
     def n_keys
       @table.n_columns
     end
     alias_method :n_cols, :n_keys
     alias_method :n_vars, :n_keys
 
+    # Returns the numbers of rows and columns.
+    #
+    # @return [Array]
+    #   Number of rows and number of columns in an array.
+    #   Same as [size, n_keys].
     def shape
       [size, n_keys]
     end
 
+    # Returns a Hash of key and Vector pairs in the columns.
+    #
+    # @return [Hash]
+    #   key => Vector pairs for each columns.
     def variables
       @variables || @variables = init_instance_vars(:variables)
     end
     alias_method :vars, :variables
 
+    # Returns an Array of keys.
+    #
+    # @return [Array]
+    #   Keys in an Array.
     def keys
       @keys || @keys = init_instance_vars(:keys)
     end
     alias_method :column_names, :keys
     alias_method :var_names, :keys
 
+    # Returns true if self has a specified key in the argument.
+    #
+    # @param key [Symbol, String] Key to test.
+    # @return [Boolean]
+    #   Returns true if self has key in Symbol.
     def key?(key)
       keys.include?(key.to_sym)
     end
     alias_method :has_key?, :key?
 
+    # Returns index of specified key in the Array keys.
+    #
+    # @param key [Symbol, String] key to know.
+    # @return [Integer]
+    #   Index of key in the Array keys.
     def key_index(key)
       keys.find_index(key.to_sym)
     end
     alias_method :find_index, :key_index
     alias_method :index, :key_index
 
+    # Returns abbreviated type names in an Array.
+    #
+    # @return [Array]
+    #   Abbreviated Red Arrow data type names.
     def types
       @types || @types = @table.columns.map { |column| column.data.value_type.nick.to_sym }
     end
 
+    # Returns an Array of Classes of data type.
+    #
+    # @return [Array]
+    #   An Array of Red Arrow data type Classes.
     def type_classes
       @data_types || @data_types = @table.columns.map { |column| column.data_type.class }
     end
 
+    # Returns Vectors in an Array.
+    #
+    # @return [Array]
+    #   An Array of RedAmber::Vector s.
     def vectors
       @vectors || @vectors = init_instance_vars(:vectors)
     end
 
+    # Returns row indices (0...size) in an Array.
+    #
+    # @return [Array]
+    #   An Array of all indices of rows.
     def indices
       (0...size).to_a
     end

--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -125,6 +125,8 @@ module RedAmber
     def try_convert_to_hash(array)
       array.to_h
     rescue TypeError
+      [array].to_h
+    rescue TypeError # rubocop:disable Lint/DuplicateRescueException
       raise DataFrameArgumentError, "Invalid argument in Array #{array}"
     end
 

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -3,6 +3,10 @@
 module RedAmber
   # group class
   class Group
+    # Creates a new Group object.
+    #
+    # @param dataframe [DataFrame] dataframe to be grouped.
+    # @param group_keys [Array<>] keys for grouping.
     def initialize(dataframe, *group_keys)
       @dataframe = dataframe
       @table = @dataframe.table

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.1.9-HEAD'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
## Release note for 0.2.0

### 0.1.8 => 0.2.0

This update have many changes and bug fixes from the previous version.
It is still not stable as the major version shows (== 0). API change may happen in some areas (esp. reshaping methods), but I have a good feeling about core API design.

### Support Arrow 9.0.0

- Add Vector#quantile method (#59)
- Add Vector#quantiles (#62)
- Add DataFrame#each_row (#56)

### Refactor to use pattern match in overloaded parameter parsing (#61)

This change causes warning message in Ruby 2.7 . But pattern match simplified the parsing of overloaded params.

- Refine DataFrame.new, DataFrame#assign and DataFrame#rename to use pattern match
- Accept assigner by Arrays in DataFrame#assign
- Accept renamer by Arrays in DataFrame#rename
- Add DataFrame#assign_left method

### Add summary/describe (#62)

Introduced DataFrame#summary and #describe as alias.

### Introduce reshaping methods for DataFrame (#64)
    
- Introduce DataFrame#transpose method
- Introduce DataFrame#to_long method
- Introduce DataFrame#to_wide method

### Update Jupyter notebook '61 Examples of Red Amber' (#65)
