### PR TITLE
Refine indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ df = penguins.pick(:species, :island, :body_mass_g)
 df
 
 # =>
-#<RedAmber::DataFrame : 344 x 3 Vectors, 0x000000000003cc1c>                 
-    species  island    body_mass_g                                           
-    <string> <string>     <uint16>                                           
-  1 Adelie   Torgersen        3750                                           
-  2 Adelie   Torgersen        3800                                           
-  3 Adelie   Torgersen        3250                                           
-  4 Adelie   Torgersen       (nil)                                           
-  5 Adelie   Torgersen        3450                                           
-  : :        :                   :                                           
-342 Gentoo   Biscoe           5750                                           
-343 Gentoo   Biscoe           5200                                           
+#<RedAmber::DataFrame : 344 x 3 Vectors, 0x000000000003cc1c>
+    species  island    body_mass_g
+    <string> <string>     <uint16>
+  1 Adelie   Torgersen        3750
+  2 Adelie   Torgersen        3800
+  3 Adelie   Torgersen        3250
+  4 Adelie   Torgersen       (nil)
+  5 Adelie   Torgersen        3450
+  : :        :                   :
+342 Gentoo   Biscoe           5750
+343 Gentoo   Biscoe           5200
 344 Gentoo   Biscoe           5400
 ```
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -155,7 +155,25 @@ Class `RedAmber::DataFrame` represents 2D-data. A `DataFrame` consists with:
 
 ### `indices`, `indexes`
 
-- Returns all indexes in an Array.
+- Returns indexes in an Array.
+  Accepts an option `start` as the first of indexes.
+
+  ```ruby
+  df = RedAmber::DataFrame.new(x: [1, 2, 3, 4, 5])
+  df.indices
+
+  # =>
+  [0, 1, 2, 3, 4]
+
+  df.indices(1)
+
+  # =>
+  [1, 2, 3, 4, 5]
+
+  df.indices(:a)
+  # =>
+  [:a, :b, :c, :d, :e]
+  ```
 
 ### `to_h`
 
@@ -772,10 +790,10 @@ penguins.to_rover
     
     # =>
     #<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000062804>
-      name         age                      
-      <string> <uint8>                      
-    1 Yasuko        68                      
-    2 Rui           49                      
+      name         age
+      <string> <uint8>
+    1 Yasuko        68
+    2 Rui           49
     3 Hinata        28
 
     # update :age and add :brother
@@ -821,13 +839,13 @@ penguins.to_rover
 
     # =>
     #<RedAmber::DataFrame : 5 x 3 Vectors, 0x00000000000dfffc>
-        index    float string             
-      <uint8> <double> <string>           
-    1       0     -0.0 A                  
-    2       1     -1.1 B                  
-    3       2     -2.2 C                  
-    4       3      NaN D                  
-    5   (nil)    (nil) (nil) 
+        index    float string
+      <uint8> <double> <string>
+    1       0     -0.0 A
+    2       1     -1.1 B
+    3       2     -2.2 C
+    4       3      NaN D
+    5   (nil)    (nil) (nil)
 
     # Or we can use assigner by a Hash
     df.assign do
@@ -852,7 +870,7 @@ penguins.to_rover
   `assign_left` method accepts the same parameters and block as `assign`, but append new columns from leftside.
 
   ```ruby
-  df.assign_left(new_index: [1, 2, 3, 4, 5])
+  df.assign_left(new_index: df.indices(1))
   
   # => 
   #<RedAmber::DataFrame : 5 x 4 Vectors, 0x000000000001787c>

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -159,12 +159,19 @@ module RedAmber
       @vectors || @vectors = init_instance_vars(:vectors)
     end
 
-    # Returns row indices (0...size) in an Array.
+    # Returns row indices (start...(size+start)) in an Array.
     #
+    # @param start [Object]
+    #   Object which have #succ method.
     # @return [Array]
-    #   An Array of all indices of rows.
-    def indices
-      (0...size).to_a
+    #   An Array of indices of the row.
+    # @example
+    #   (when self.size == 5)
+    #   - indices #=> [0, 1, 2, 3, 4]
+    #   - indices(1) #=> [1, 2, 3, 4, 5]
+    #   - indices('a') #=> ['a', 'b', 'c', 'd', 'e']
+    def indices(start = 0)
+      (start..).take(size)
     end
     alias_method :indexes, :indices
 

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -154,7 +154,7 @@ module RedAmber
 
     def format_table(width: 80, head: 5, tail: 3, n_digit: 2)
       original = self
-      indices = size > head + tail ? [*0...head, *(size - tail)...size] : [*0...size]
+      indices = size > head + tail ? [*0..head, *(size - tail)...size] : [*0...size]
       df = slice(indices).assign do
         assigner = { INDEX_KEY => indices.map { |i| (i + 1).to_s } }
         vectors.each_with_object(assigner) do |v, a|
@@ -173,12 +173,12 @@ module RedAmber
       end
 
       df = df.pick { [INDEX_KEY, keys - [INDEX_KEY]] }
-      df = size > head + tail ? df[0, 0, 0...head, 0, -tail..-1] : df[0, 0, 0..-1]
+      df = size > head + tail ? df[0, 0, 0..head, -tail..-1] : df[0, 0, 0..-1]
       df = df.assign do
         vectors.each_with_object({}) do |v, assigner|
           vec = v.replace(0, v.key == INDEX_KEY ? '' : v.key.to_s)
                  .replace(1, v.key == INDEX_KEY ? '' : "<#{original[v.key].type}>")
-          assigner[v.key] = size > head + tail ? vec.replace(head + 2, ':') : vec
+          assigner[v.key] = original.size > head + tail + 1 ? vec.replace(head + 2, ':') : vec
         end
       end
 

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -74,6 +74,14 @@ class DataFrameTest < Test::Unit::TestCase
       assert_equal size, df.n_rows
     end
 
+    test 'indices' do
+      hash, df, = data
+      size = hash.empty? ? 0 : hash.values.first.size
+      assert_equal (0...size).to_a, df.indices
+      assert_equal (1..size).to_a, df.indices(1)
+      assert_equal ('a'..).take(size), df.indices('a')
+    end
+
     test 'n_keys' do
       hash, df, = data
       assert_equal hash.keys.size, df.n_keys

--- a/test/test_data_frame_reshaping.rb
+++ b/test/test_data_frame_reshaping.rb
@@ -66,7 +66,7 @@ class DataFrameReshapingTest < Test::Unit::TestCase
         3 name1    Three             3.1
         4 name2    One               1.2
         5 name2    Two               2.2
-        : :        :                   :
+        6 name2    Three             3.2
         7 name3    One               1.3
         8 name3    Two               2.3
         9 name3    Three             3.3


### PR DESCRIPTION
- Refine Vector#indices

Accepts an option `start` as the first one of indexes.

  ```ruby
  df = RedAmber::DataFrame.new(x: [1, 2, 3, 4, 5])
  df.indices

  # =>
  [0, 1, 2, 3, 4]

  df.indices(1)

  # =>
  [1, 2, 3, 4, 5]

  df.indices(:a)
  # =>
  [:a, :b, :c, :d, :e]
  ```
