### PR TITLE
Prepare 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,61 @@
+## [0.2.1] - 2022-09-07
+
+-Bug fixes
+
+  - Fix `Vector#each` with block (#66)
+    `Vector#each` will return value of each element with block.
+
+  - Fix table format at size == 9 (#67)
+
+  - Fix to support Vector in `DataFrame#assign` (#77)
+
+  - Add `assert_delta` functionality for `assert_with_NaN` (#78)
+
+  - Fix Vector#is_in when self is chunked (#79)
+
+  - Fix Array type error (uint/int) (#79)
+
+- New features and improvements
+
+  - Refine `DataFrame#indices` method (#67)
+
+  - Update DataFrame reshaping methods (#73)
+
+    - Change default option value of DataFrame reshaping
+
+    - Change the order of import_cars example
+
+  - Add `DataFrame#method_missing` to get column vector by method (#75)
+
+    - Add `DataFrame#method_missing` to get column (#75)
+
+  - Accept both args and block in `DataFrame#assign` (#75)
+
+  - Accept indices in `DataFrame#pick` and `DataFrame#drop` (#76)
+
+  - Add `DataFrame#slice_by` method (#77)
+  
+  - Add new Vector functions (#78)
+
+    - Add inverse trigonometric function for Vector
+      - `acos`
+      - `asin`
+
+    - Add logarithmic function for Vector
+      - `ln`
+      - `log10`
+      - `log1p`
+      - `log2`
+
+    - Add binary function `Vector#logb`
+
+  - Docker image and Jupyter Notebook (Thanks to @mrkn)
+    - Add link to RubyData in README
+    - Add link to interactive README by Binder
+
+  - Update Jupyter Notebook `71 examples of RedAmber`
+
+
 ## [0.2.0] - 2022-08-15
 
 - Bump version up to 0.2.0

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Also you can try the contents of this README interactively by [Binder](https://m
 
 ## `RedAmber::DataFrame`
 
-Represents a set of data in 2D-shape. The entity is a Red Arrow's Table object. 
+It represents a set of data in 2D-shape. The entity is a Red Arrow's Table object. 
+
+![dataframe model of RedAmber](doc/image/dataframe_model.png)
 
 ```ruby
 require 'red_amber' # require 'red-amber' is also OK.
@@ -88,18 +90,15 @@ penguins = RedAmber::DataFrame.new(arrow)
 344 Gentoo   Biscoe              49.9          16.1               213 ...     2009
 ```
 
-### DataFrame model
-![dataframe model of RedAmber](doc/image/dataframe_model.png)
-
-For example, `DataFrame#pick` accepts keys as an argument and returns a sub DataFrame.
+For example, `DataFrame#pick` accepts keys as arguments and returns a sub DataFrame.
 
 ![pick method image](doc/image/dataframe/pick.png)
 
 ```ruby
 penguins.keys
 # =>
-[:species,                                       
- :island,                                        
+[:species,
+ :island,
  :bill_length_mm,
  :bill_depth_mm,
  :flipper_length_mm,
@@ -339,7 +338,7 @@ starwars.group(:species) { [count(:species), mean(:height, :mass)] }
 3 Wookiee        2        231.0      124.0
 4 Gungan         3        208.7       74.0
 5 NA             4        181.3       48.0
-: :              :            :          :
+6 Zabrak         2        173.0       80.0
 7 Twi'lek        2        179.0       55.0
 8 Mirialan       2        168.0       53.1
 9 Kaminoan       2        221.0       88.0 
@@ -389,7 +388,7 @@ See [Vector.md](doc/Vector.md) for details.
 
 ## Jupyter notebook
 
-[61 Examples of Red Amber](doc/examples_of_red_amber.ipynb) shows more examples in jupyter notebook.
+[71 Examples of Red Amber](doc/examples_of_red_amber.ipynb) shows more examples in jupyter notebook.
 
 ## Development
 

--- a/doc/examples_of_red_amber.ipynb
+++ b/doc/examples_of_red_amber.ipynb
@@ -5,7 +5,7 @@
    "id": "e355db8b-ebb6-4ea6-97b5-3b9fdadc302c",
    "metadata": {},
    "source": [
-    "# 61 examples of Red Amber"
+    "# 71 examples of Red Amber"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "f20f4970-db38-4d96-9a36-d4cf9d007596",
    "metadata": {},
    "source": [
-    "Last update: August 14, 2022, for RedAmber Version 0.2.0"
+    "Last update: September 6, 2022, for RedAmber Version 0.2.1"
    ]
   },
   {
@@ -29,11 +29,11 @@
    "id": "85eacfe6-fa11-4749-844f-5914d6cd7dbc",
    "metadata": {},
    "source": [
-    "Install requirements before you install Red Amber.\n",
+    "Install requirements before you install RedAmber.\n",
     "\n",
-    "- Apache Arrow GLib (>= 8.0.0)\n",
+    "- Apache Arrow GLib (>= 9.0.0)\n",
     "\n",
-    "- Apache Parquet GLib (>= 8.0.0)  # if you need IO from/to Parquet resource.\n",
+    "- Apache Parquet GLib (>= 9.0.0)  # if you need IO from/to Parquet resource.\n",
     "\n",
     "  See [Apache Arrow install document](https://arrow.apache.org/install/).\n",
     "  \n",
@@ -72,7 +72,7 @@
     {
      "data": {
       "text/plain": [
-       "{:RedAmber=>\"0.2.0\", :Arrow=>\"9.0.0\"}"
+       "{:RedAmber=>\"0.2.1-HEAD\", :Arrow=>\"9.0.0\"}"
       ]
      },
      "execution_count": 1,
@@ -108,7 +108,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f154>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f794>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -138,7 +138,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f168>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f7a8>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -168,7 +168,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f17c>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f7bc>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -199,7 +199,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>A</td></tr><tr><td>2</td><td>B</td></tr><tr><td>3</td><td>C</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f2a8>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f8e8>\n",
        "        x y\n",
        "  <uint8> <string>\n",
        "1       1 A\n",
@@ -231,7 +231,7 @@
        "RedAmber::DataFrame <344 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
+       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f8fc>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -281,7 +281,7 @@
        "RedAmber::DataFrame <32 x 11 vectors> <table><tr><th>mpg</th><th>cyl</th><th>disp</th><th>hp</th><th>drat</th><th>wt</th><th>qsec</th><th>vs</th><th>am</th><th>gear</th><th>carb</th></tr><tr><td>21.0</td><td>6</td><td>160.0</td><td>110</td><td>3.9</td><td>2.62</td><td>16.46</td><td>0</td><td>1</td><td>4</td><td>4</td></tr><tr><td>21.0</td><td>6</td><td>160.0</td><td>110</td><td>3.9</td><td>2.875</td><td>17.02</td><td>0</td><td>1</td><td>4</td><td>4</td></tr><tr><td>22.8</td><td>4</td><td>108.0</td><td>93</td><td>3.85</td><td>2.32</td><td>18.61</td><td>1</td><td>1</td><td>4</td><td>1</td></tr><tr><td>21.4</td><td>6</td><td>258.0</td><td>110</td><td>3.08</td><td>3.215</td><td>19.44</td><td>1</td><td>0</td><td>3</td><td>1</td></tr><tr><td colspan='11'>&#8942;</td></tr><tr><td>19.7</td><td>6</td><td>145.0</td><td>175</td><td>3.62</td><td>2.77</td><td>15.5</td><td>0</td><td>1</td><td>5</td><td>6</td></tr><tr><td>15.0</td><td>8</td><td>301.0</td><td>335</td><td>3.54</td><td>3.57</td><td>14.6</td><td>0</td><td>1</td><td>5</td><td>8</td></tr><tr><td>21.4</td><td>4</td><td>121.0</td><td>109</td><td>4.11</td><td>2.78</td><td>18.6</td><td>1</td><td>1</td><td>4</td><td>2</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 32 x 11 Vectors, 0x000000000000f2d0>\n",
+       "#<RedAmber::DataFrame : 32 x 11 Vectors, 0x000000000000f910>\n",
        "        mpg     cyl     disp       hp     drat       wt     qsec      vs      am ...    carb\n",
        "   <double> <uint8> <double> <uint16> <double> <double> <double> <uint8> <uint8> ... <uint8>\n",
        " 1     21.0       6    160.0      110      3.9     2.62    16.46       0       1 ...       4\n",
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4203e671-0a0a-405c-8482-53a8cd78a891",
+   "id": "ce9f7237-9196-41a0-ba04-6ef4430a8a0c",
    "metadata": {},
    "outputs": [
     {
@@ -333,7 +333,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f2e4>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f924>\n",
        "  name         age\n",
        "  <string> <int64>\n",
        "1 Yasuko        68\n",
@@ -347,7 +347,17 @@
     }
    ],
    "source": [
-    "DataFrame.load(\"../test/entity/with_header.csv\")"
+    "file = Tempfile.open(['comecome', '.csv']) do |f|\n",
+    "  f.puts(<<~CSV)\n",
+    "    name,age\n",
+    "    Yasuko,68\n",
+    "    Rui,49\n",
+    "    Hinata,28\n",
+    "  CSV\n",
+    "  f\n",
+    "end\n",
+    "\n",
+    "DataFrame.load(file)"
    ]
   },
   {
@@ -370,7 +380,7 @@
        "RedAmber::DataFrame <344 x 7 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>MALE</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>FEMALE</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>FEMALE</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td></td></tr><tr><td colspan='7'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>MALE</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>FEMALE</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>MALE</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 344 x 7 Vectors, 0x000000000000f2f8>\n",
+       "#<RedAmber::DataFrame : 344 x 7 Vectors, 0x000000000000f938>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ... sex\n",
        "    <string> <string>        <double>      <double>           <int64> ... <string>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ... MALE\n",
@@ -456,7 +466,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#<RedAmber::DataFrame : 5 x 4 Vectors, 0x000000000000f30c>\n",
+      "#<RedAmber::DataFrame : 5 x 4 Vectors, 0x000000000000f94c>\n",
       "        x        y s        b\n",
       "  <uint8> <double> <string> <boolean>\n",
       "1       1      1.0 A        true\n",
@@ -487,7 +497,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
+      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f8fc>\n",
       "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
       "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
       "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -524,7 +534,7 @@
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f54b8433320 ptr=0x55d81a4486e0>\n",
+       "#<Arrow::Table:0x10ef3ca28 ptr=0x7fe9548b7310>\n",
        "\tx\t         y\ts\tb\n",
        "0\t1\t  1.000000\tA\ttrue\n",
        "1\t2\t  2.000000\tB\tfalse\n",
@@ -551,7 +561,7 @@
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f54b849dec8 ptr=0x55d81ac6f650>\n",
+       "#<Arrow::Table:0x10f443fa8 ptr=0x7fe9544c4c80>\n",
        "\tspecies\tisland\tbill_length_mm\tbill_depth_mm\tflipper_length_mm\tbody_mass_g\tsex\tyear\n",
        "  0\tAdelie \tTorgersen\t     39.100000\t    18.700000\t              181\t       3750\tmale\t2007\n",
        "  1\tAdelie \tTorgersen\t     39.500000\t    17.400000\t              186\t       3800\tfemale\t2007\n",
@@ -1107,9 +1117,13 @@
   {
    "cell_type": "markdown",
    "id": "1c2513f6-909e-47fd-a543-66c4f424f44e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "## 14. Indices"
+    "## 14. Indices\n",
+    "\n",
+    "Another example of `indices` is [62. Custom index](#62.-Custom-index)."
    ]
   },
   {
@@ -1276,7 +1290,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f960>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1306,7 +1320,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f334>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f974>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1328,7 +1342,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f348>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f988>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1350,7 +1364,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f35c>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f99c>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1372,7 +1386,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f370>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f9b0>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
@@ -1419,13 +1433,13 @@
     {
      "data": {
       "text/plain": [
-       "[#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
+       "[#<RedAmber::Vector(:uint8, size=5):0x000000000000f960>\n",
        "[1, 2, 3, 4, 5]\n",
-       ", #<RedAmber::Vector(:double, size=5):0x000000000000f384>\n",
+       ", #<RedAmber::Vector(:double, size=5):0x000000000000f9c4>\n",
        "[1.0, 2.0, 3.0, NaN, nil]\n",
-       ", #<RedAmber::Vector(:string, size=5):0x000000000000f398>\n",
+       ", #<RedAmber::Vector(:string, size=5):0x000000000000f9d8>\n",
        "[\"A\", \"B\", \"C\", \"D\", nil]\n",
-       ", #<RedAmber::Vector(:boolean, size=5):0x000000000000f3ac>\n",
+       ", #<RedAmber::Vector(:boolean, size=5):0x000000000000f9ec>\n",
        "[true, false, true, false, nil]\n",
        "]"
       ]
@@ -1460,13 +1474,13 @@
     {
      "data": {
       "text/plain": [
-       "{:x=>#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
+       "{:x=>#<RedAmber::Vector(:uint8, size=5):0x000000000000f960>\n",
        "[1, 2, 3, 4, 5]\n",
-       ", :y=>#<RedAmber::Vector(:double, size=5):0x000000000000f384>\n",
+       ", :y=>#<RedAmber::Vector(:double, size=5):0x000000000000f9c4>\n",
        "[1.0, 2.0, 3.0, NaN, nil]\n",
-       ", :s=>#<RedAmber::Vector(:string, size=5):0x000000000000f398>\n",
+       ", :s=>#<RedAmber::Vector(:string, size=5):0x000000000000f9d8>\n",
        "[\"A\", \"B\", \"C\", \"D\", nil]\n",
-       ", :b=>#<RedAmber::Vector(:boolean, size=5):0x000000000000f3ac>\n",
+       ", :b=>#<RedAmber::Vector(:boolean, size=5):0x000000000000f9ec>\n",
        "[true, false, true, false, nil]\n",
        "}"
       ]
@@ -1514,7 +1528,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f3c0>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fa00>\n",
        "        x        y\n",
        "  <uint8> <double>\n",
        "1       1      1.0\n",
@@ -1546,7 +1560,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f3d4>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fa14>\n",
        "        x        y\n",
        "  <uint8> <double>\n",
        "1       1      1.0\n",
@@ -1578,7 +1592,7 @@
        "RedAmber::DataFrame <5 x 3 vectors> <table><tr><th>s</th><th>b</th><th>x</th></tr><tr><td>A</td><td>true</td><td>1</td></tr><tr><td>B</td><td>false</td><td>2</td></tr><tr><td>C</td><td>true</td><td>3</td></tr><tr><td>D</td><td>false</td><td>4</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f3e8>\n",
+       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000fa28>\n",
        "  s        b               x\n",
        "  <string> <boolean> <uint8>\n",
        "1 A        true            1\n",
@@ -1625,7 +1639,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>1</td><td>1.0</td><td>A</td><td>true</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>2</td><td>2.0</td><td>B</td><td>false</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f3fc>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fa3c>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       1      1.0 A        true\n",
@@ -1655,7 +1669,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>2</td><td>2.0</td><td>B</td><td>false</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f410>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fa50>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       2      2.0 B        false\n",
@@ -1686,7 +1700,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>2</td><td>2.0</td><td>B</td><td>false</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f424>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fa64>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       2      2.0 B        false\n",
@@ -1717,7 +1731,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>1</td><td>1.0</td><td>A</td><td>true</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f438>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fa78>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       1      1.0 A        true\n",
@@ -1748,7 +1762,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr><tr><td>4</td><td>NaN</td><td>D</td><td>false</td></tr><tr><td>5</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000f44c>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fa8c>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       3      3.0 C        true\n",
@@ -1777,7 +1791,7 @@
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f3ac>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f9ec>\n",
        "[true, false, true, false, nil]\n"
       ]
      },
@@ -1803,7 +1817,7 @@
        "RedAmber::DataFrame <2 x 4 vectors> <table><tr><th>x</th><th>y</th><th>s</th><th>b</th></tr><tr><td>1</td><td>1.0</td><td>A</td><td>true</td></tr><tr><td>3</td><td>3.0</td><td>C</td><td>true</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 4 Vectors, 0x000000000000f460>\n",
+       "#<RedAmber::DataFrame : 2 x 4 Vectors, 0x000000000000faa0>\n",
        "        x        y s        b\n",
        "  <uint8> <double> <string> <boolean>\n",
        "1       1      1.0 A        true\n",
@@ -1851,27 +1865,6 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "1e09c32f-20a8-4175-827f-cdb98063535a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "true"
-      ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "DataFrame.new.empty?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
    "id": "3f9f8771-87dd-44eb-8aac-6a3ed8b4c183",
    "metadata": {},
    "outputs": [
@@ -1881,13 +1874,34 @@
        "(empty DataFrame)"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "DataFrame.new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "1e09c32f-20a8-4175-827f-cdb98063535a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "DataFrame.new.empty?"
    ]
   },
   {
@@ -1905,7 +1919,9 @@
     "tags": []
    },
    "source": [
-    "`DataFrame#pick` accepts an Array of keys to pick up columns (variables) and creates a new DataFrame. You can change the order of columns at a same time."
+    "`DataFrame#pick` accepts an Array of keys to pick up columns (variables) and creates a new DataFrame. You can change the order of columns at a same time.\n",
+    "\n",
+    "The name `pick` comes from the action to pick variables(columns) according to the label keys."
    ]
   },
   {
@@ -1922,7 +1938,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>s</th><th>y</th></tr><tr><td>A</td><td>1.0</td></tr><tr><td>B</td><td>2.0</td></tr><tr><td>C</td><td>3.0</td></tr><tr><td>D</td><td>NaN</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f474>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fab4>\n",
        "  s               y\n",
        "  <string> <double>\n",
        "1 A             1.0\n",
@@ -1948,7 +1964,7 @@
    "id": "a76dca00-da8f-4959-be18-7a1015a9d13c",
    "metadata": {},
    "source": [
-    "Or use a boolean Array of lengeh `n_key` to `pick`. This style remains the order of variables."
+    "Or use a boolean Array of lengeh `n_key` to `pick`. This style preserves the order of variables."
    ]
   },
   {
@@ -1963,7 +1979,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>y</th><th>s</th></tr><tr><td>1.0</td><td>A</td></tr><tr><td>2.0</td><td>B</td></tr><tr><td>3.0</td><td>C</td></tr><tr><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f488>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fac8>\n",
        "         y s\n",
        "  <double> <string>\n",
        "1      1.0 A\n",
@@ -1981,7 +1997,9 @@
    "source": [
     "df.pick(false, true, true, false)\n",
     "# or\n",
-    "df.pick([false, true, true, false]) # OK"
+    "df.pick([false, true, true, false])\n",
+    "# or\n",
+    "df.pick(Vector.new([false, true, true, false]))"
    ]
   },
   {
@@ -2006,7 +2024,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f49c>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fadc>\n",
        "        x        y\n",
        "  <uint8> <double>\n",
        "1       1      1.0\n",
@@ -2031,10 +2049,43 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e51f07c0-54eb-4114-8cd6-63c7780e7248",
+   "id": "1692e8c3-aafa-4951-84a6-ff26e4f8bbde",
    "metadata": {},
    "source": [
-    "The name `pick` comes from the action to pick variables(columns) according to the label keys."
+    "`pick` also accepts numeric indexes.\n",
+    "\n",
+    "(Since 0.2.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "dd929ef0-8af4-4bb6-963a-b3f1abd73bf0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>b</th></tr><tr><td>1</td><td>true</td></tr><tr><td>2</td><td>false</td></tr><tr><td>3</td><td>true</td></tr><tr><td>4</td><td>false</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000faf0>\n",
+       "        x b\n",
+       "  <uint8> <boolean>\n",
+       "1       1 true\n",
+       "2       2 false\n",
+       "3       3 true\n",
+       "4       4 false\n",
+       "5       5 (nil)\n"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.pick(0, 3)"
    ]
   },
   {
@@ -2052,12 +2103,14 @@
     "tags": []
    },
    "source": [
-    "`DataFrame#drop` accepts an Array keys to drop columns (variables) to create a remainer DataFrame."
+    "`DataFrame#drop` accepts an Array keys to drop columns (variables) to create a remainer DataFrame.\n",
+    "\n",
+    "The name `drop` comes from the pair word of `pick`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 60,
    "id": "7ccace08-62b0-4b0b-93fb-81edf673abf7",
    "metadata": {},
    "outputs": [
@@ -2067,7 +2120,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>y</th><th>s</th></tr><tr><td>1.0</td><td>A</td></tr><tr><td>2.0</td><td>B</td></tr><tr><td>3.0</td><td>C</td></tr><tr><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f4b0>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fb04>\n",
        "         y s\n",
        "  <double> <string>\n",
        "1      1.0 A\n",
@@ -2077,7 +2130,7 @@
        "5    (nil) (nil)\n"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2097,7 +2150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 61,
    "id": "785c02f1-1e16-4722-9961-4b49223c8290",
    "metadata": {},
    "outputs": [
@@ -2107,7 +2160,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>y</th><th>s</th></tr><tr><td>1.0</td><td>A</td></tr><tr><td>2.0</td><td>B</td></tr><tr><td>3.0</td><td>C</td></tr><tr><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f4c4>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fb18>\n",
        "         y s\n",
        "  <double> <string>\n",
        "1      1.0 A\n",
@@ -2117,7 +2170,7 @@
        "5    (nil) (nil)\n"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2139,7 +2192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 62,
    "id": "069932e3-d393-4ede-9eb5-7aac8625e0c0",
    "metadata": {},
    "outputs": [
@@ -2149,7 +2202,7 @@
        "RedAmber::DataFrame <5 x 1 vector> <table><tr><th>x</th></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f4d8>\n",
+       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000fb2c>\n",
        "        x\n",
        "  <uint8>\n",
        "1       1\n",
@@ -2159,7 +2212,7 @@
        "5       5\n"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2178,7 +2231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 63,
    "id": "3003a5c2-0966-4f2c-9643-59e8b546c8aa",
    "metadata": {},
    "outputs": [
@@ -2188,7 +2241,7 @@
        "RedAmber::DataFrame <5 x 1 vector> <table><tr><th>x</th></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f4ec>\n",
+       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000fb40>\n",
        "        x\n",
        "  <uint8>\n",
        "1       1\n",
@@ -2198,7 +2251,7 @@
        "5       5\n"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2209,10 +2262,43 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6fce15c-d4a9-4281-9c07-457e78d3c13e",
+   "id": "e30c2b72-fc05-405c-97dc-7e31b88abebf",
    "metadata": {},
    "source": [
-    "The name `drop` comes from the pair word of `pick`."
+    "`drop` also accepts numeric indexes.\n",
+    "\n",
+    "(Since 0.2.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "0b6eebe0-145d-4660-8be4-e6f09eb656aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>y</th><th>s</th></tr><tr><td>1.0</td><td>A</td></tr><tr><td>2.0</td><td>B</td></tr><tr><td>3.0</td><td>C</td></tr><tr><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fb54>\n",
+       "         y s\n",
+       "  <double> <string>\n",
+       "1      1.0 A\n",
+       "2      2.0 B\n",
+       "3      3.0 C\n",
+       "4      NaN D\n",
+       "5    (nil) (nil)\n"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.drop(0, 3)"
    ]
   },
   {
@@ -2233,7 +2319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 65,
    "id": "7c01fbb4-9bfa-4afc-8e6b-45c97c0beb03",
    "metadata": {},
    "outputs": [
@@ -2243,7 +2329,7 @@
        "true"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2266,18 +2352,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 66,
    "id": "ea352e12-7e8a-43be-b8ac-797adbc47708",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f500>\n",
+       "#<RedAmber::Vector(:boolean, size=4):0x000000000000fb68>\n",
        "[true, true, false, nil]\n"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2296,18 +2382,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 67,
    "id": "596c521f-12bf-4448-9e5d-e1b4a2c3d896",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f514>\n",
+       "#<RedAmber::Vector(:boolean, size=4):0x000000000000fb7c>\n",
        "[false, false, true, nil]\n"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2330,18 +2416,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 68,
    "id": "4dcaba48-1cea-4ce9-b4a9-b079b43af7ec",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=4):0x000000000000f528>\n",
+       "#<RedAmber::Vector(:boolean, size=4):0x000000000000fb90>\n",
        "[false, false, true, true]\n"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2352,7 +2438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 69,
    "id": "c7ae4dad-275a-49e0-a0b0-bf3686248070",
    "metadata": {},
    "outputs": [
@@ -2362,7 +2448,7 @@
        "true"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2389,7 +2475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 70,
    "id": "e13aee24-cac6-41ad-b8a3-0ec26edbe5d1",
    "metadata": {},
    "outputs": [
@@ -2399,7 +2485,7 @@
        "RedAmber::DataFrame <5 x 1 vector> <table><tr><th>x</th></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000f53c>\n",
+       "#<RedAmber::DataFrame : 5 x 1 Vector, 0x000000000000fba4>\n",
        "        x\n",
        "  <uint8>\n",
        "1       1\n",
@@ -2409,7 +2495,7 @@
        "5       5\n"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2429,18 +2515,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 71,
    "id": "60d228be-7357-434d-9d39-ee72c110e6fe",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f320>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f960>\n",
        "[1, 2, 3, 4, 5]\n"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2459,7 +2545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 72,
    "id": "6beefc5a-dc47-42cc-a283-456073c4251e",
    "metadata": {},
    "outputs": [
@@ -2469,7 +2555,7 @@
        "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>1.0</td></tr><tr><td>2</td><td>2.0</td></tr><tr><td>3</td><td>3.0</td></tr><tr><td>4</td><td>NaN</td></tr><tr><td>5</td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000f550>\n",
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000000fbb8>\n",
        "        x        y\n",
        "  <uint8> <double>\n",
        "1       1      1.0\n",
@@ -2479,7 +2565,7 @@
        "5       5    (nil)\n"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2493,7 +2579,9 @@
    "id": "34c9bcb0-889a-4190-b2b8-49765cd059c2",
    "metadata": {},
    "source": [
-    "## 28. Slice"
+    "## 28. Slice\n",
+    "\n",
+    "Another example of `slice` is [#66. Row index label by slice_by](#66.-Row-index-label-by-slice_by)."
    ]
   },
   {
@@ -2514,7 +2602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 73,
    "id": "9cdce2e4-7876-4be6-bd1f-bc8ab6e6c871",
    "metadata": {},
    "outputs": [
@@ -2524,7 +2612,7 @@
        "RedAmber::DataFrame <10 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 10 x 8 Vectors, 0x000000000000f564>\n",
+       "#<RedAmber::DataFrame : 10 x 8 Vectors, 0x000000000000fbcc>\n",
        "   species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "   <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        " 1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -2538,7 +2626,7 @@
        "10 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2550,7 +2638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 74,
    "id": "93c3f6f0-7bc9-4909-8f32-20e8c1ddfd3a",
    "metadata": {},
    "outputs": [
@@ -2560,13 +2648,13 @@
        "RedAmber::DataFrame <1 x 9 vectors> <table><tr><th>index</th><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>113</td><td>Adelie</td><td>Biscoe</td><td>42.2</td><td>19.5</td><td>197</td><td>4275</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 1 x 9 Vectors, 0x000000000000f578>\n",
+       "#<RedAmber::DataFrame : 1 x 9 Vectors, 0x000000000000fbe0>\n",
        "     index species  island   bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "  <uint16> <string> <string>       <double>      <double>           <uint8> ... <uint16>\n",
        "1      113 Adelie   Biscoe             42.2          19.5               197 ...     2009\n"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2599,30 +2687,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 75,
    "id": "f58ca131-7375-4489-90ce-6ba54b898eb5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=344):0x000000000000f58c>\n",
+       "#<RedAmber::Vector(:boolean, size=344):0x000000000000fbf4>\n",
        "[false, false, true, nil, false, false, false, false, false, true, false, false, ... ]\n"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# make booleans to check over 40\n",
+    "# make boolean Vector to check over 40\n",
     "booleans = penguins[:bill_length_mm] > 40"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 76,
    "id": "176ab365-c66a-4712-97b9-4381a536321b",
    "metadata": {},
    "outputs": [
@@ -2632,7 +2720,7 @@
        "RedAmber::DataFrame <242 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>42.0</td><td>20.2</td><td>190</td><td>4250</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>41.1</td><td>17.6</td><td>182</td><td>3200</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>42.5</td><td>20.7</td><td>197</td><td>4500</td><td>male</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 242 x 8 Vectors, 0x000000000000f5a0>\n",
+       "#<RedAmber::DataFrame : 242 x 8 Vectors, 0x000000000000fc08>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           40.3          18.0               195 ...     2007\n",
@@ -2646,7 +2734,7 @@
        "242 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2668,7 +2756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 77,
    "id": "c95d3426-0bbb-430e-8d83-6e22434d99ed",
    "metadata": {},
    "outputs": [
@@ -2678,7 +2766,7 @@
        "RedAmber::DataFrame <204 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.3</td><td>20.6</td><td>190</td><td>3650</td><td>male</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>47.2</td><td>13.7</td><td>214</td><td>4925</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>46.8</td><td>14.3</td><td>215</td><td>4850</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 204 x 8 Vectors, 0x000000000000f5b4>\n",
+       "#<RedAmber::DataFrame : 204 x 8 Vectors, 0x000000000000fc1c>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -2692,7 +2780,7 @@
        "204 Gentoo   Biscoe              45.2          14.8               212 ...     2009\n"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2700,10 +2788,9 @@
    "source": [
     "# return a DataFrame with bill_length_mm is in 2*std range around mean\n",
     "penguins.slice do\n",
-    "  vector = self[:bill_length_mm]\n",
-    "  min = vector.mean - vector.std\n",
-    "  max = vector.mean + vector.std\n",
-    "  vector.to_a.map { |e| (min..max).include? e }\n",
+    "  min = bill_length_mm.mean - bill_length_mm.std\n",
+    "  max = bill_length_mm.mean + bill_length_mm.std\n",
+    "  bill_length_mm.to_a.map { |e| (min..max).include? e }\n",
     "end"
    ]
   },
@@ -2725,20 +2812,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 78,
    "id": "8e4a8108-154b-4621-acd1-704ddf229d61",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f54b8439518 ptr=0x55d81a8f6f30>\n",
+       "#<Arrow::Table:0x10f7d2660 ptr=0x7fe9548a6e10>\n",
        "\t     a\tb\t         c\n",
        "0\t     1\tA\t  1.000000\n",
        "1\t(null)\t(null)\t    (null)\n"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2759,19 +2846,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 79,
    "id": "851c3bf6-b9e9-41bd-92c5-5372ed934549",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<Arrow::Table:0x7f54b83fdf40 ptr=0x55d81abf1a70>\n",
+       "#<Arrow::Table:0x10f7b9430 ptr=0x7fe9548a6a50>\n",
        "\ta\tb\t         c\n",
        "0\t1\tA\t  1.000000\n"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2806,7 +2893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 80,
    "id": "17e38ab8-886b-4114-bcaf-ee18df7d00cd",
    "metadata": {},
    "outputs": [
@@ -2816,7 +2903,7 @@
        "RedAmber::DataFrame <334 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.3</td><td>20.6</td><td>190</td><td>3650</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>38.9</td><td>17.8</td><td>181</td><td>3625</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.2</td><td>19.6</td><td>195</td><td>4675</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>34.1</td><td>18.1</td><td>193</td><td>3475</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>44.5</td><td>15.7</td><td>217</td><td>4875</td><td><i>(nil)</i></td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>48.8</td><td>16.2</td><td>222</td><td>6000</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>47.2</td><td>13.7</td><td>214</td><td>4925</td><td>female</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 334 x 8 Vectors, 0x000000000000f5c8>\n",
+       "#<RedAmber::DataFrame : 334 x 8 Vectors, 0x000000000000fc30>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.3          20.6               190 ...     2007\n",
@@ -2830,7 +2917,7 @@
        "334 Gentoo   Biscoe              47.2          13.7               214 ...     2009\n"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2850,7 +2937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 81,
    "id": "6f169420-7eb2-457f-8d59-7a5c90aa3fa5",
    "metadata": {},
    "outputs": [
@@ -2860,7 +2947,7 @@
        "RedAmber::DataFrame <333 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f5dc>\n",
+       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000fc44>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -2874,7 +2961,7 @@
        "333 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2894,7 +2981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 82,
    "id": "a6807c65-25e5-4ee1-8d1b-6018c46b3999",
    "metadata": {},
    "outputs": [
@@ -2904,7 +2991,7 @@
        "RedAmber::DataFrame <140 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>34.1</td><td>18.1</td><td>193</td><td>3475</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>37.8</td><td>17.1</td><td>186</td><td>3300</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 140 x 8 Vectors, 0x000000000000f5f0>\n",
+       "#<RedAmber::DataFrame : 140 x 8 Vectors, 0x000000000000fc58>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen          (nil)         (nil)             (nil) ...     2007\n",
@@ -2918,7 +3005,7 @@
        "140 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2951,7 +3038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 83,
    "id": "8575614e-f702-4ee4-ac7b-745e9b32e803",
    "metadata": {},
    "outputs": [
@@ -2961,7 +3048,7 @@
        "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td><td>A</td><td>1.0</td></tr><tr><td>2</td><td>B</td><td>2.0</td></tr><tr><td><i>(nil)</i></td><td>C</td><td>3.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000f604>\n",
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fc6c>\n",
        "        a b               c\n",
        "  <uint8> <string> <double>\n",
        "1       1 A             1.0\n",
@@ -2969,7 +3056,7 @@
        "3   (nil) C             3.0\n"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2980,18 +3067,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 84,
    "id": "932a5e71-8cef-44e5-a789-ce97329bc001",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f618>\n",
+       "#<RedAmber::Vector(:boolean, size=3):0x000000000000fc80>\n",
        "[true, false, nil]\n"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3002,7 +3089,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 85,
    "id": "74cf6aa6-8913-433d-97ad-bba2d548afe5",
    "metadata": {},
    "outputs": [
@@ -3012,7 +3099,7 @@
        "[false, true, true]"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3023,7 +3110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 86,
    "id": "5e466a06-cb17-4dc1-a5b0-34bfd3ffb78b",
    "metadata": {},
    "outputs": [
@@ -3033,7 +3120,7 @@
        "true"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3052,18 +3139,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 87,
    "id": "077b216f-0a08-413e-95c9-12789d15a9ba",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f62c>\n",
+       "#<RedAmber::Vector(:boolean, size=3):0x000000000000fc94>\n",
        "[false, true, nil]\n"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3074,7 +3161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 88,
    "id": "b3df62a6-c4a3-44cb-bde6-f6be12b120c8",
    "metadata": {},
    "outputs": [
@@ -3084,14 +3171,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td><td>A</td><td>1.0</td></tr><tr><td><i>(nil)</i></td><td>C</td><td>3.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000f640>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fca8>\n",
        "        a b               c\n",
        "  <uint8> <string> <double>\n",
        "1       1 A             1.0\n",
        "2   (nil) C             3.0\n"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3110,18 +3197,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 89,
    "id": "296ca3cd-a6da-4603-a576-d8c36a810e4f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=3):0x000000000000f654>\n",
+       "#<RedAmber::Vector(:boolean, size=3):0x000000000000fcbc>\n",
        "[false, true, true]\n"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3132,7 +3219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 90,
    "id": "ba5b8c0b-b94e-4209-adcd-258ea3b87bfd",
    "metadata": {},
    "outputs": [
@@ -3142,13 +3229,13 @@
        "RedAmber::DataFrame <1 x 3 vectors> <table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td><td>A</td><td>1.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000f668>\n",
+       "#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000fcd0>\n",
        "        a b               c\n",
        "  <uint8> <string> <double>\n",
        "1       1 A             1.0\n"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3159,7 +3246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 91,
    "id": "2446792f-0b0a-4642-acae-b4fec89261c1",
    "metadata": {},
    "outputs": [
@@ -3169,7 +3256,7 @@
        "true"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3196,7 +3283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 92,
    "id": "de4bb615-d14d-4c90-ab54-db2f375b9f00",
    "metadata": {},
    "outputs": [
@@ -3206,7 +3293,7 @@
        "RedAmber::DataFrame <333 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f67c>\n",
+       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000fce4>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -3220,7 +3307,7 @@
        "333 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3239,7 +3326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 93,
    "id": "27a3da5f-0ea2-4c5d-a6c3-c0e20f2224a3",
    "metadata": {},
    "outputs": [
@@ -3249,7 +3336,7 @@
        "RedAmber::DataFrame <333 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000f690>\n",
+       "#<RedAmber::DataFrame : 333 x 8 Vectors, 0x000000000000fcf8>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -3263,7 +3350,7 @@
        "333 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3298,7 +3385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 94,
    "id": "9396c96d-83d7-4b92-a4ca-27bc9e4d7b9d",
    "metadata": {},
    "outputs": [
@@ -3308,7 +3395,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f6a4>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000fd0c>\n",
        "  name         age\n",
        "  <string> <uint8>\n",
        "1 Yasuko        68\n",
@@ -3316,7 +3403,7 @@
        "3 Hinata        28\n"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3328,7 +3415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 95,
    "id": "fad279c6-1ca0-4493-bd69-0e9ef011bff7",
    "metadata": {},
    "outputs": [
@@ -3338,7 +3425,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age_in_1993</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f6b8>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000fd20>\n",
        "  name     age_in_1993\n",
        "  <string>     <uint8>\n",
        "1 Yasuko            68\n",
@@ -3346,7 +3433,7 @@
        "3 Hinata            28\n"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3386,6 +3473,8 @@
    "id": "99f6787f-2b36-4360-b155-1c2d7874d25e",
    "metadata": {},
    "source": [
+    "Another example of `assign` is [64. Assign revised](#64.-Assign-revised), [#65. Variations of assign](#65.-Variations-of-assign) .\n",
+    "\n",
     "Assign new or updated columns (variables) and create a updated DataFrame.\n",
     "\n",
     "- Columns with new keys will append new variables at right (bottom in TDR).\n",
@@ -3402,7 +3491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 96,
    "id": "56dcfed8-a6f9-4d8c-bac3-e8ce7c0674a7",
    "metadata": {},
    "outputs": [
@@ -3412,7 +3501,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>name</th><th>age</th></tr><tr><td>Yasuko</td><td>68</td></tr><tr><td>Rui</td><td>49</td></tr><tr><td>Hinata</td><td>28</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f6cc>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000fd34>\n",
        "  name         age\n",
        "  <string> <uint8>\n",
        "1 Yasuko        68\n",
@@ -3420,7 +3509,7 @@
        "3 Hinata        28\n"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3431,7 +3520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 97,
    "id": "8da8d282-8798-44d5-bb7b-7fa2df922308",
    "metadata": {},
    "outputs": [
@@ -3441,7 +3530,7 @@
        "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>name</th><th>age</th><th>brother</th></tr><tr><td>Yasuko</td><td>97</td><td>Santa</td></tr><tr><td>Rui</td><td>78</td><td><i>(nil)</i></td></tr><tr><td>Hinata</td><td>57</td><td>Momotaro</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000f6e0>\n",
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fd48>\n",
        "  name         age brother\n",
        "  <string> <uint8> <string>\n",
        "1 Yasuko        97 Santa\n",
@@ -3449,7 +3538,7 @@
        "3 Hinata        57 Momotaro\n"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3470,7 +3559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 98,
    "id": "8d69edd0-7ad7-4318-8033-1785ce2543db",
    "metadata": {},
    "outputs": [
@@ -3480,7 +3569,7 @@
        "RedAmber::DataFrame <5 x 3 vectors> <table><tr><th>index</th><th>float</th><th>string</th></tr><tr><td>0</td><td>0.0</td><td>A</td></tr><tr><td>1</td><td>1.1</td><td>B</td></tr><tr><td>2</td><td>2.2</td><td>C</td></tr><tr><td>3</td><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f6f4>\n",
+       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000fd5c>\n",
        "    index    float string\n",
        "  <uint8> <double> <string>\n",
        "1       0      0.0 A\n",
@@ -3490,7 +3579,7 @@
        "5   (nil)    (nil) (nil)\n"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3504,7 +3593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 99,
    "id": "e884af01-d82b-42e7-8e92-62baf19919cb",
    "metadata": {},
    "outputs": [
@@ -3514,7 +3603,7 @@
        "RedAmber::DataFrame <5 x 3 vectors> <table><tr><th>index</th><th>float</th><th>string</th></tr><tr><td>0</td><td>-0.0</td><td>A</td></tr><tr><td>255</td><td>-1.1</td><td>B</td></tr><tr><td>254</td><td>-2.2</td><td>C</td></tr><tr><td>253</td><td>NaN</td><td>D</td></tr><tr><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000f708>\n",
+       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000000fd70>\n",
        "    index    float string\n",
        "  <uint8> <double> <string>\n",
        "1       0     -0.0 A\n",
@@ -3524,7 +3613,7 @@
        "5   (nil)    (nil) (nil)\n"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3546,7 +3635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 100,
    "id": "9452f8db-5f23-4044-ac87-ac5695fae8ae",
    "metadata": {},
    "outputs": [
@@ -3556,7 +3645,7 @@
        "[:uint8, :double, :string]"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3583,18 +3672,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 101,
    "id": "2bfbe584-be54-486b-af32-e76b37c10e49",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=3):0x000000000000f71c>\n",
+       "#<RedAmber::Vector(:uint8, size=3):0x000000000000fd84>\n",
        "[1, 2, 3]\n"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3605,18 +3694,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 102,
    "id": "ce35d901-38a8-4f13-b2d1-29b83f6c5438",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:int16, size=3):0x000000000000f730>\n",
+       "#<RedAmber::Vector(:int16, size=3):0x000000000000fd98>\n",
        "[-1, -2, -3]\n"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3628,18 +3717,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 103,
    "id": "7d5fc2be-f590-4678-92e9-faa27b618266",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:int16, size=3):0x000000000000f744>\n",
+       "#<RedAmber::Vector(:int16, size=3):0x000000000000fdac>\n",
        "[-1, -2, -3]\n"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3651,18 +3740,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 104,
    "id": "fa90a6af-add7-42f2-9707-7d726575aeb6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=3):0x000000000000f758>\n",
+       "#<RedAmber::Vector(:uint8, size=3):0x000000000000fdc0>\n",
        "[255, 254, 253]\n"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3692,7 +3781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 105,
    "id": "b12bd7c8-2981-426c-8ae3-154504a8ea15",
    "metadata": {},
    "outputs": [
@@ -3702,7 +3791,7 @@
        "[3, 4, 5]"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3713,7 +3802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 106,
    "id": "c0cb5a98-7cdf-43a8-b2f7-f9df1961c761",
    "metadata": {},
    "outputs": [
@@ -3723,7 +3812,7 @@
        "[1, 2, 3, 4, 5]"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3752,18 +3841,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 107,
    "id": "d003b06a-859f-4de0-9e35-803efac85169",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f76c>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000fdd4>\n",
        "[0, 1, 1, 3, 3]\n"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3775,18 +3864,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 108,
    "id": "c5d74006-d364-4e86-8a5e-9e96e87a96e0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000f780>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x000000000000fde8>\n",
        "[0, 1, 3, 3, nil]\n"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3817,7 +3906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 109,
    "id": "ebad37ad-0a09-48b1-ba3a-4e030a917837",
    "metadata": {},
    "outputs": [
@@ -3827,7 +3916,7 @@
        "true"
       ]
      },
-     "execution_count": 107,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3839,7 +3928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 110,
    "id": "97fc24da-03d4-406d-b353-562896775d60",
    "metadata": {},
    "outputs": [
@@ -3849,7 +3938,7 @@
        "true"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3868,7 +3957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 111,
    "id": "3e0e5800-665a-4a05-b2cb-d152f3f077de",
    "metadata": {},
    "outputs": [
@@ -3878,7 +3967,7 @@
        "false"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3889,7 +3978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 112,
    "id": "3e43f0c4-a254-4735-ac28-de14d2670c67",
    "metadata": {},
    "outputs": [
@@ -3899,7 +3988,7 @@
        "true"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3930,7 +4019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 113,
    "id": "2af73e32-1d7e-4f80-b54e-c40ef08b7034",
    "metadata": {},
    "outputs": [
@@ -3940,7 +4029,7 @@
        "3"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3952,7 +4041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 114,
    "id": "fe6d8d85-27b0-438f-b1b4-1b15e9eb05f9",
    "metadata": {},
    "outputs": [
@@ -3962,7 +4051,7 @@
        "2"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3989,7 +4078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 115,
    "id": "0afec200-f377-432b-a260-ae5a0c5ce794",
    "metadata": {},
    "outputs": [
@@ -3999,7 +4088,7 @@
        "0.816496580927726"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4011,7 +4100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 116,
    "id": "2e40ac09-cb7f-4978-87e8-53f84f16f7c7",
    "metadata": {},
    "outputs": [
@@ -4021,7 +4110,7 @@
        "1.0"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4033,7 +4122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 117,
    "id": "e6158e3b-4af8-467c-a355-8e9f2e579548",
    "metadata": {},
    "outputs": [
@@ -4043,7 +4132,7 @@
        "0.6666666666666666"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4054,7 +4143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 118,
    "id": "d64d39f2-d979-49f1-9946-65890f40d646",
    "metadata": {},
    "outputs": [
@@ -4064,7 +4153,7 @@
        "1.0"
       ]
      },
-     "execution_count": 116,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4092,18 +4181,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 119,
    "id": "ab5a357a-e98c-40a1-9b89-0b38645e416f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=3):0x000000000000f794>\n",
+       "#<RedAmber::Vector(:double, size=3):0x000000000000fdfc>\n",
        "[-1.0, 2.0, -3.0]\n"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4115,18 +4204,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 120,
    "id": "8a06c856-d61c-4752-a296-1fa207ffd9a1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=3):0x000000000000f7a8>\n",
+       "#<RedAmber::Vector(:double, size=3):0x000000000000fe10>\n",
        "[-1.0, 2.0, -3.0]\n"
       ]
      },
-     "execution_count": 118,
+     "execution_count": 120,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4159,18 +4248,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 121,
    "id": "e7a069b0-3547-4cd2-a2f0-0740f186b191",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f7bc>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fe24>\n",
        "[15.15, 2.5, 3.5, -4.5, -5.5]\n"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4181,18 +4270,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 122,
    "id": "5ee84b24-8830-4788-a404-d5e1cca22abf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f7d0>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fe38>\n",
        "[15.0, 2.0, 4.0, -4.0, -6.0]\n"
       ]
      },
-     "execution_count": 120,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4203,18 +4292,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 123,
    "id": "20adb1ad-473c-4245-b959-7848c239fb76",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f7e4>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fe4c>\n",
        "[15.0, 2.0, 4.0, -4.0, -6.0]\n"
       ]
      },
-     "execution_count": 121,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4225,18 +4314,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 124,
    "id": "d2777ad8-2c24-48e4-8f5f-77403e3109ea",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f7f8>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fe60>\n",
        "[16.0, 3.0, 4.0, -5.0, -6.0]\n"
       ]
      },
-     "execution_count": 122,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4247,18 +4336,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 125,
    "id": "a8ab2735-74cb-4cfe-a5a2-61bfa90c72ac",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f80c>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fe74>\n",
        "[15.0, 3.0, 4.0, -4.0, -5.0]\n"
       ]
      },
-     "execution_count": 123,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4269,18 +4358,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 126,
    "id": "3575481c-40ed-405f-a69c-7581d4dce2cf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f820>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fe88>\n",
        "[15.0, 2.0, 3.0, -4.0, -5.0]\n"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4291,18 +4380,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 127,
    "id": "a86e4c5c-aced-4a88-b692-4e26b90f1653",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f834>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fe9c>\n",
        "[15.0, 3.0, 4.0, -5.0, -6.0]\n"
       ]
      },
-     "execution_count": 125,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4313,18 +4402,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 128,
    "id": "73f51bab-ff46-4b99-96a5-8c6547ad9d35",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f848>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000feb0>\n",
        "[15.0, 3.0, 3.0, -5.0, -5.0]\n"
       ]
      },
-     "execution_count": 126,
+     "execution_count": 128,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4335,18 +4424,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 129,
    "id": "a12c684c-4a63-4dac-a81b-969978812a24",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f85c>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fec4>\n",
        "[15.0, 2.0, 4.0, -4.0, -6.0]\n"
       ]
      },
-     "execution_count": 127,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4357,18 +4446,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 130,
    "id": "17370f2b-0957-411b-8145-56aa9fc956ac",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f870>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000fed8>\n",
        "[15.2, 2.5, 3.5, -4.5, -5.5]\n"
       ]
      },
-     "execution_count": 128,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4379,18 +4468,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 131,
    "id": "53072cff-b28b-4672-b30a-8ca37562bc21",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f884>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000feec>\n",
        "[20.0, 0.0, 0.0, -0.0, -10.0]\n"
       ]
      },
-     "execution_count": 129,
+     "execution_count": 131,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4419,18 +4508,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 132,
    "id": "2d4f5853-1ed9-4d8b-87a9-b5c1faac5fae",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f898>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000ff00>\n",
        "[true, false, nil, false, false, false, nil, false, nil]\n"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4444,18 +4533,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 133,
    "id": "236c9733-8d45-467e-b288-e6c18b9c39d2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8ac>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000ff14>\n",
        "[true, false, nil, true, false, nil, true, false, nil]\n"
       ]
      },
-     "execution_count": 131,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4467,18 +4556,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 134,
    "id": "4e984a9c-7d9c-465d-bf26-0c685dedd4bf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8c0>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000ff28>\n",
        "[true, false, nil, false, false, nil, nil, nil, nil]\n"
       ]
      },
-     "execution_count": 132,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4490,18 +4579,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 135,
    "id": "0120ebf5-355d-41f5-83d5-49b9802f337b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8d4>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000ff3c>\n",
        "[true, true, true, true, false, nil, true, nil, nil]\n"
       ]
      },
-     "execution_count": 133,
+     "execution_count": 135,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4512,18 +4601,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 136,
    "id": "24ceee23-79df-4fcd-afd8-f3839a087785",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8e8>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000ff50>\n",
        "[true, true, true, false, false, false, nil, nil, nil]\n"
       ]
      },
-     "execution_count": 134,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4535,18 +4624,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 137,
    "id": "c152d04b-71a0-4b18-acd1-b5ab9e413d00",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=9):0x000000000000f8fc>\n",
+       "#<RedAmber::Vector(:boolean, size=9):0x000000000000ff64>\n",
        "[true, true, nil, true, false, nil, nil, nil, nil]\n"
       ]
      },
-     "execution_count": 135,
+     "execution_count": 137,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4574,18 +4663,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 138,
    "id": "19558f9e-fdc4-46e5-90d0-724e4e8fbd8e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000f910>\n",
+       "#<RedAmber::Vector(:double, size=5):0x000000000000ff78>\n",
        "[3.141592653589793, Infinity, -Infinity, NaN, nil]\n"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 138,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4596,18 +4685,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 139,
    "id": "d90a7168-1f87-4363-9589-c1f161babc7d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f924>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000ff8c>\n",
        "[true, false, false, false, nil]\n"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4618,18 +4707,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 140,
    "id": "7d88049b-695f-4b0c-a105-8fb5797a58b1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f938>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000ffa0>\n",
        "[false, true, true, false, nil]\n"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 140,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4640,18 +4729,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 141,
    "id": "7d86a7b5-84bf-4031-9811-4076281920cf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f94c>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000ffb4>\n",
        "[false, false, false, true, true]\n"
       ]
      },
-     "execution_count": 139,
+     "execution_count": 141,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4662,18 +4751,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 142,
    "id": "d562f826-7a37-4c57-8f92-777555987246",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f960>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000ffc8>\n",
        "[false, false, false, false, true]\n"
       ]
      },
-     "execution_count": 140,
+     "execution_count": 142,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4684,18 +4773,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 143,
    "id": "e460dc6b-e48f-4462-9ce8-aa6069ebae27",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:boolean, size=5):0x000000000000f974>\n",
+       "#<RedAmber::Vector(:boolean, size=5):0x000000000000ffdc>\n",
        "[true, true, true, true, false]\n"
       ]
      },
-     "execution_count": 141,
+     "execution_count": 143,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4714,7 +4803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 144,
    "id": "0751e820-a22d-45b5-9005-df523d2353be",
    "metadata": {},
    "outputs": [
@@ -4724,7 +4813,7 @@
        "RedAmber::DataFrame <68 x 9 vectors> <table><tr><th>index</th><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>2</td><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>3</td><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>5</td><td>Adelie</td><td>Torgersen</td><td>36.7</td><td>19.3</td><td>193</td><td>3450</td><td>female</td><td>2007</td></tr><tr><td>7</td><td>Adelie</td><td>Torgersen</td><td>38.9</td><td>17.8</td><td>181</td><td>3625</td><td>female</td><td>2007</td></tr><tr><td colspan='9'>&#8942;</td></tr><tr><td>317</td><td>Gentoo</td><td>Biscoe</td><td>49.4</td><td>15.8</td><td>216</td><td>4925</td><td>male</td><td>2009</td></tr><tr><td>331</td><td>Gentoo</td><td>Biscoe</td><td>50.5</td><td>15.2</td><td>216</td><td>5000</td><td>female</td><td>2009</td></tr><tr><td>337</td><td>Gentoo</td><td>Biscoe</td><td>44.5</td><td>15.7</td><td>217</td><td>4875</td><td><i>(nil)</i></td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 68 x 9 Vectors, 0x000000000000f988>\n",
+       "#<RedAmber::DataFrame : 68 x 9 Vectors, 0x000000000000fff0>\n",
        "      index species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "   <uint16> <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        " 1        2 Adelie   Torgersen           39.5          17.4               186 ...     2007\n",
@@ -4738,7 +4827,7 @@
        "68      337 Gentoo   Biscoe              44.5          15.7               217 ...     2009\n"
       ]
      },
-     "execution_count": 142,
+     "execution_count": 144,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4763,43 +4852,44 @@
    "id": "32dd53a3-a822-4ae1-afe2-b5aa2bfbd3e3",
    "metadata": {},
    "source": [
-    "Slice accepts Enumerator as an option."
+    "Slice accepts Enumerator."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 145,
    "id": "b2a118fa-f3c0-4f31-9b45-6db27ccbebe6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <35 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>37.8</td><td>17.1</td><td>186</td><td>3300</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>Adelie</td><td>Biscoe</td><td>37.8</td><td>18.3</td><td>174</td><td>3400</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Dream</td><td>39.5</td><td>16.7</td><td>178</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>48.5</td><td>15.0</td><td>219</td><td>4850</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.5</td><td>15.2</td><td>216</td><td>5000</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>46.8</td><td>14.3</td><td>215</td><td>4850</td><td>female</td><td>2009</td></tr></table>"
+       "RedAmber::DataFrame <35 x 9 vectors> <table><tr><th>index</th><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>0</td><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>10</td><td>Adelie</td><td>Torgersen</td><td>37.8</td><td>17.1</td><td>186</td><td>3300</td><td><i>(nil)</i></td><td>2007</td></tr><tr><td>20</td><td>Adelie</td><td>Biscoe</td><td>37.8</td><td>18.3</td><td>174</td><td>3400</td><td>female</td><td>2007</td></tr><tr><td>30</td><td>Adelie</td><td>Dream</td><td>39.5</td><td>16.7</td><td>178</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td colspan='9'>&#8942;</td></tr><tr><td>320</td><td>Gentoo</td><td>Biscoe</td><td>48.5</td><td>15.0</td><td>219</td><td>4850</td><td>female</td><td>2009</td></tr><tr><td>330</td><td>Gentoo</td><td>Biscoe</td><td>50.5</td><td>15.2</td><td>216</td><td>5000</td><td>female</td><td>2009</td></tr><tr><td>340</td><td>Gentoo</td><td>Biscoe</td><td>46.8</td><td>14.3</td><td>215</td><td>4850</td><td>female</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 35 x 8 Vectors, 0x000000000000f99c>\n",
-       "   species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
-       "   <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
-       " 1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
-       " 2 Adelie   Torgersen           37.8          17.1               186 ...     2007\n",
-       " 3 Adelie   Biscoe              37.8          18.3               174 ...     2007\n",
-       " 4 Adelie   Dream               39.5          16.7               178 ...     2007\n",
-       " 5 Adelie   Dream               36.5          18.0               182 ...     2007\n",
-       " : :        :                      :             :                 : ...        :\n",
-       "33 Gentoo   Biscoe              48.5          15.0               219 ...     2009\n",
-       "34 Gentoo   Biscoe              50.5          15.2               216 ...     2009\n",
-       "35 Gentoo   Biscoe              46.8          14.3               215 ...     2009\n"
+       "#<RedAmber::DataFrame : 35 x 9 Vectors, 0x0000000000010004>\n",
+       "      index species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
+       "   <uint16> <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
+       " 1        0 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
+       " 2       10 Adelie   Torgersen           37.8          17.1               186 ...     2007\n",
+       " 3       20 Adelie   Biscoe              37.8          18.3               174 ...     2007\n",
+       " 4       30 Adelie   Dream               39.5          16.7               178 ...     2007\n",
+       " 5       40 Adelie   Dream               36.5          18.0               182 ...     2007\n",
+       " :        : :        :                      :             :                 : ...        :\n",
+       "33      320 Gentoo   Biscoe              48.5          15.0               219 ...     2009\n",
+       "34      330 Gentoo   Biscoe              50.5          15.2               216 ...     2009\n",
+       "35      340 Gentoo   Biscoe              46.8          14.3               215 ...     2009\n"
       ]
      },
-     "execution_count": 143,
+     "execution_count": 145,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Select every 10 samples\n",
-    "penguins.slice(0.step by: 10, to: 340)"
+    "penguins.assign_left(index: penguins.indices) # 0.2.0 feature\n",
+    "        .slice(0.step by: 10, to: 340)"
    ]
   },
   {
@@ -4820,7 +4910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 146,
    "id": "a721804b-006e-44c6-8d38-885eae747eaa",
    "metadata": {},
    "outputs": [
@@ -4830,7 +4920,7 @@
        "RedAmber::DataFrame <344 x 8 vectors> <table><tr><th>species</th><th>island</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>sex</th><th>year</th></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.1</td><td>18.7</td><td>181</td><td>3750</td><td>male</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>39.5</td><td>17.4</td><td>186</td><td>3800</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td>40.3</td><td>18.0</td><td>195</td><td>3250</td><td>female</td><td>2007</td></tr><tr><td>Adelie</td><td>Torgersen</td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td><i>(nil)</i></td><td>2007</td></tr><tr><td colspan='8'>&#8942;</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>50.4</td><td>15.7</td><td>222</td><td>5750</td><td>male</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>45.2</td><td>14.8</td><td>212</td><td>5200</td><td>female</td><td>2009</td></tr><tr><td>Gentoo</td><td>Biscoe</td><td>49.9</td><td>16.1</td><td>213</td><td>5400</td><td>male</td><td>2009</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
+       "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f8fc>\n",
        "    species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year\n",
        "    <string> <string>        <double>      <double>           <uint8> ... <uint16>\n",
        "  1 Adelie   Torgersen           39.1          18.7               181 ...     2007\n",
@@ -4844,7 +4934,7 @@
        "344 Gentoo   Biscoe              49.9          16.1               213 ...     2009\n"
       ]
      },
-     "execution_count": 144,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4856,7 +4946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 147,
    "id": "e4c9f70c-a4b1-4a81-bbc4-e9b14a6b6cb0",
    "metadata": {},
    "outputs": [
@@ -4864,7 +4954,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f2bc>\n",
+      "#<RedAmber::DataFrame : 344 x 8 Vectors, 0x000000000000f8fc>\n",
       "Vectors : 5 numeric, 3 strings\n",
       "# key                type   level data_preview\n",
       "1 :species           string     3 {\"Adelie\"=>152, \"Chinstrap\"=>68, \"Gentoo\"=>124}\n",
@@ -4882,7 +4972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 148,
    "id": "2786e9a7-e321-43c5-b56e-9f2ca9d62f8b",
    "metadata": {},
    "outputs": [
@@ -4902,7 +4992,7 @@
        "8 :year              uint16     3 {2007=>110, 2008=>114, 2009=>120}\n"
       ]
      },
-     "execution_count": 146,
+     "execution_count": 148,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4913,7 +5003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 149,
    "id": "b00c858b-b14a-492b-bc22-d6a707bcc1ba",
    "metadata": {},
    "outputs": [
@@ -4923,7 +5013,7 @@
        "\"Table\""
       ]
      },
-     "execution_count": 147,
+     "execution_count": 149,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4954,7 +5044,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 150,
    "id": "13569004-bb23-45fa-8d11-fe5f367641a6",
    "metadata": {},
    "outputs": [
@@ -4964,14 +5054,14 @@
        "RedAmber::DataFrame <2 x 2 vectors> <table><tr><th>unnamed2</th><th>unnamed1</th></tr><tr><td>1</td><td>3</td></tr><tr><td>2</td><td>4</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x000000000000f9b0>\n",
+       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x0000000000010018>\n",
        "  unnamed2 unnamed1\n",
        "   <uint8>  <uint8>\n",
        "1        1        3\n",
        "2        2        4\n"
       ]
      },
-     "execution_count": 148,
+     "execution_count": 150,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5002,18 +5092,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 151,
    "id": "ee602e52-7988-4fab-b5e3-c466acf01c98",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Group:0x000000000000f9c4\n",
+       "#<RedAmber::Group:0x000000000001002c\n",
        "{:species=>{\"Adelie\"=>152, \"Chinstrap\"=>68, \"Gentoo\"=>124}}>"
       ]
      },
-     "execution_count": 149,
+     "execution_count": 151,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5034,7 +5124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 152,
    "id": "20b23ada-b895-4921-b57b-8d46b451e494",
    "metadata": {},
    "outputs": [
@@ -5044,7 +5134,7 @@
        "RedAmber::DataFrame <3 x 8 vectors> <table><tr><th>species</th><th>count(island)</th><th>count(bill_length_mm)</th><th>count(bill_depth_mm)</th><th>count(flipper_length_mm)</th><th>count(body_mass_g)</th><th>count(sex)</th><th>count(year)</th></tr><tr><td>Adelie</td><td>152</td><td>151</td><td>151</td><td>151</td><td>151</td><td>146</td><td>152</td></tr><tr><td>Chinstrap</td><td>68</td><td>68</td><td>68</td><td>68</td><td>68</td><td>68</td><td>68</td></tr><tr><td>Gentoo</td><td>124</td><td>123</td><td>123</td><td>123</td><td>123</td><td>119</td><td>124</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 8 Vectors, 0x000000000000f9d8>\n",
+       "#<RedAmber::DataFrame : 3 x 8 Vectors, 0x0000000000010040>\n",
        "  species   count(island) count(bill_length_mm) count(bill_depth_mm) ... count(year)\n",
        "  <string>        <int64>               <int64>              <int64> ...     <int64>\n",
        "1 Adelie              152                   151                  151 ...         152\n",
@@ -5052,7 +5142,7 @@
        "3 Gentoo              124                   123                  123 ...         124\n"
       ]
      },
-     "execution_count": 150,
+     "execution_count": 152,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5071,7 +5161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 153,
    "id": "e6936488-9f23-47bd-8492-537c5be1afb3",
    "metadata": {},
    "outputs": [
@@ -5081,7 +5171,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>species</th><th>count</th></tr><tr><td>Adelie</td><td>151</td></tr><tr><td>Chinstrap</td><td>68</td></tr><tr><td>Gentoo</td><td>123</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000f9ec>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000010054>\n",
        "  species     count\n",
        "  <string>  <int64>\n",
        "1 Adelie        151\n",
@@ -5089,7 +5179,7 @@
        "3 Gentoo        123\n"
       ]
      },
-     "execution_count": 151,
+     "execution_count": 153,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5128,7 +5218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 154,
    "id": "913f576b-ec86-4e94-af05-7c656ea24cc2",
    "metadata": {},
    "outputs": [
@@ -5138,7 +5228,7 @@
        "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>species</th><th>count</th><th>mean(body_mass_g)</th></tr><tr><td>Adelie</td><td>152</td><td>3700.662251655629</td></tr><tr><td>Chinstrap</td><td>68</td><td>3733.0882352941176</td></tr><tr><td>Gentoo</td><td>124</td><td>5076.016260162602</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fa00>\n",
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x0000000000010068>\n",
        "  species     count mean(body_mass_g)\n",
        "  <string>  <int64>          <double>\n",
        "1 Adelie        152           3700.66\n",
@@ -5146,7 +5236,7 @@
        "3 Gentoo        124           5076.02\n"
       ]
      },
-     "execution_count": 152,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5165,7 +5255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 155,
    "id": "67c7fc55-7b30-469c-bd0c-cda5732863fe",
    "metadata": {},
    "outputs": [
@@ -5175,7 +5265,7 @@
        "RedAmber::DataFrame <3 x 7 vectors> <table><tr><th>species</th><th>count</th><th>mean(bill_length_mm)</th><th>mean(bill_depth_mm)</th><th>mean(flipper_length_mm)</th><th>mean(body_mass_g)</th><th>mean(year)</th></tr><tr><td>Adelie</td><td>152</td><td>38.79139072847684</td><td>18.346357615894032</td><td>189.95364238410596</td><td>3700.662251655629</td><td>2008.0131578947369</td></tr><tr><td>Chinstrap</td><td>68</td><td>48.83382352941177</td><td>18.420588235294115</td><td>195.8235294117647</td><td>3733.0882352941176</td><td>2007.9705882352941</td></tr><tr><td>Gentoo</td><td>124</td><td>47.504878048780476</td><td>14.982113821138206</td><td>217.1869918699187</td><td>5076.016260162602</td><td>2008.0806451612902</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 7 Vectors, 0x000000000000fa14>\n",
+       "#<RedAmber::DataFrame : 3 x 7 Vectors, 0x000000000001007c>\n",
        "  species     count mean(bill_length_mm) mean(bill_depth_mm) ... mean(year)\n",
        "  <string>  <int64>             <double>            <double> ...   <double>\n",
        "1 Adelie        152                38.79               18.35 ...    2008.01\n",
@@ -5183,7 +5273,7 @@
        "3 Gentoo        124                 47.5               14.98 ...    2008.08\n"
       ]
      },
-     "execution_count": 153,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5214,18 +5304,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": 156,
    "id": "013f2db6-3e1d-481f-a908-57605729b51d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000fa28>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x0000000000010090>\n",
        "[nil, 1, 2, 3, 4]\n"
       ]
      },
-     "execution_count": 154,
+     "execution_count": 156,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5237,18 +5327,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": 157,
    "id": "7625acd7-d6a0-4775-b5e0-ca87f95f4f28",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:uint8, size=5):0x000000000000fa3c>\n",
+       "#<RedAmber::Vector(:uint8, size=5):0x00000000000100a4>\n",
        "[3, 4, 5, nil, nil]\n"
       ]
      },
-     "execution_count": 155,
+     "execution_count": 157,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5259,18 +5349,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": 158,
    "id": "34a9ac2a-2e3f-44bc-8ba7-c4487dc3528e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "#<RedAmber::Vector(:double, size=5):0x000000000000fa50>\n",
+       "#<RedAmber::Vector(:double, size=5):0x00000000000100b8>\n",
        "[NaN, 1.0, 2.0, 3.0, 4.0]\n"
       ]
      },
-     "execution_count": 156,
+     "execution_count": 158,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5314,7 +5404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 159,
    "id": "24774ccc-8f0f-4ce4-9ba0-bebed8781c38",
    "metadata": {},
    "outputs": [
@@ -5324,7 +5414,7 @@
        "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>5</td><td>-1</td><td>50</td></tr><tr><td>6</td><td>-1</td><td>-30</td></tr><tr><td>7</td><td>-1</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fa64>\n",
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x00000000000100cc>\n",
        "      AAA    BBB    CCC\n",
        "  <uint8> <int8> <int8>\n",
        "1       4     10    100\n",
@@ -5333,7 +5423,7 @@
        "4       7     -1    -50\n"
       ]
      },
-     "execution_count": 157,
+     "execution_count": 159,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5357,7 +5447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": 160,
    "id": "3f97227b-cbee-4515-b76d-3514401967d9",
    "metadata": {},
    "outputs": [
@@ -5367,7 +5457,7 @@
        "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>5</td><td>-1</td><td>-2</td></tr><tr><td>6</td><td>-1</td><td>-2</td></tr><tr><td>7</td><td>-1</td><td>-2</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fa78>\n",
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x00000000000100e0>\n",
        "      AAA    BBB    CCC\n",
        "  <uint8> <int8> <int8>\n",
        "1       4     10    100\n",
@@ -5376,7 +5466,7 @@
        "4       7     -1     -2\n"
       ]
      },
-     "execution_count": 158,
+     "execution_count": 160,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5432,7 +5522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": 161,
    "id": "b08e74d4-aba8-4fb5-a815-5d5384e92f81",
    "metadata": {},
    "outputs": [
@@ -5442,14 +5532,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>5</td><td>20</td><td>50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fa8c>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x00000000000100f4>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       4      10    100\n",
        "2       5      20     50\n"
       ]
      },
-     "execution_count": 159,
+     "execution_count": 161,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5467,7 +5557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 162,
    "id": "caa72796-ff7e-4275-849f-04698114ee08",
    "metadata": {},
    "outputs": [
@@ -5477,14 +5567,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>6</td><td>30</td><td>-30</td></tr><tr><td>7</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000faa0>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000010108>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       6      30    -30\n",
        "2       7      40    -50\n"
       ]
      },
-     "execution_count": 160,
+     "execution_count": 162,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5540,7 +5630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": 163,
    "id": "46066e96-91e5-4a96-9840-7e4ce6f06818",
    "metadata": {},
    "outputs": [
@@ -5550,14 +5640,14 @@
        "RedAmber::DataFrame <2 x 1 vector> <table><tr><th>AAA</th></tr><tr><td>4</td></tr><tr><td>5</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 1 Vector, 0x000000000000fab4>\n",
+       "#<RedAmber::DataFrame : 2 x 1 Vector, 0x000000000001011c>\n",
        "      AAA\n",
        "  <uint8>\n",
        "1       4\n",
        "2       5\n"
       ]
      },
-     "execution_count": 161,
+     "execution_count": 163,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5574,7 +5664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": 164,
    "id": "dc8304c2-be28-420e-b2d5-a4b636eaac8b",
    "metadata": {},
    "outputs": [
@@ -5584,7 +5674,7 @@
        "RedAmber::DataFrame <4 x 1 vector> <table><tr><th>AAA</th></tr><tr><td>4</td></tr><tr><td>5</td></tr><tr><td>6</td></tr><tr><td>7</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 1 Vector, 0x000000000000fac8>\n",
+       "#<RedAmber::DataFrame : 4 x 1 Vector, 0x0000000000010130>\n",
        "      AAA\n",
        "  <uint8>\n",
        "1       4\n",
@@ -5593,7 +5683,7 @@
        "4       7\n"
       ]
      },
-     "execution_count": 162,
+     "execution_count": 164,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5625,7 +5715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": 165,
    "id": "7ab3b044-5a0f-4a38-8a42-aed1228b6462",
    "metadata": {},
    "outputs": [
@@ -5635,7 +5725,7 @@
        "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>0.1</td><td>10</td><td>100</td></tr><tr><td>5.0</td><td>20</td><td>50</td></tr><tr><td>0.1</td><td>30</td><td>-30</td></tr><tr><td>0.1</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fadc>\n",
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x0000000000010144>\n",
        "       AAA     BBB    CCC\n",
        "  <double> <uint8> <int8>\n",
        "1      0.1      10    100\n",
@@ -5644,7 +5734,7 @@
        "4      0.1      40    -50\n"
       ]
      },
-     "execution_count": 163,
+     "execution_count": 165,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5682,7 +5772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": 166,
    "id": "13cb1d45-2d13-4708-ad76-57efd72e609b",
    "metadata": {},
    "outputs": [
@@ -5692,7 +5782,7 @@
        "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>5</td><td>20</td><td>50</td></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>6</td><td>30</td><td>-30</td></tr><tr><td>7</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000faf0>\n",
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x0000000000010158>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       5      20     50\n",
@@ -5701,7 +5791,7 @@
        "4       7      40    -50\n"
       ]
      },
-     "execution_count": 164,
+     "execution_count": 166,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5742,7 +5832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": 167,
    "id": "40336e62-d411-4655-8ec5-8d30876ada47",
    "metadata": {},
    "outputs": [
@@ -5752,13 +5842,13 @@
        "RedAmber::DataFrame <1 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000fb04>\n",
+       "#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000001016c>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       4      10    100\n"
       ]
      },
-     "execution_count": 165,
+     "execution_count": 167,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5783,8 +5873,8 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "55cee55f-7caf-423c-863a-187f96fa3072",
+   "cell_type": "markdown",
+   "id": "462ce855-6e78-49a6-8b5f-48a5864b6397",
    "metadata": {},
    "source": [
     "```python\n",
@@ -5804,8 +5894,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
-   "id": "272396f6-f689-43d5-ba34-e7c6ac0e1c28",
+   "execution_count": 168,
+   "id": "9da915f1-c772-4071-b6d6-292d8ffea857",
    "metadata": {},
    "outputs": [
     {
@@ -5814,14 +5904,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>4</td><td>10</td><td>100</td></tr><tr><td>6</td><td>30</td><td>-30</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fb18>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000010180>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       4      10    100\n",
        "2       6      30    -30\n"
       ]
      },
-     "execution_count": 166,
+     "execution_count": 168,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5879,7 +5969,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": 169,
    "id": "ccabc137-33d3-47e8-ad09-88a285765380",
    "metadata": {},
    "outputs": [
@@ -5889,7 +5979,7 @@
        "RedAmber::DataFrame <4 x 4 vectors> <table><tr><th>index</th><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>foo</td><td>4</td><td>10</td><td>100</td></tr><tr><td>bar</td><td>5</td><td>20</td><td>50</td></tr><tr><td>boo</td><td>6</td><td>30</td><td>-30</td></tr><tr><td>kar</td><td>7</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 4 Vectors, 0x000000000000fb2c>\n",
+       "#<RedAmber::DataFrame : 4 x 4 Vectors, 0x0000000000010194>\n",
        "  index        AAA     BBB    CCC\n",
        "  <string> <uint8> <uint8> <int8>\n",
        "1 foo            4      10    100\n",
@@ -5898,7 +5988,7 @@
        "4 kar            7      40    -50\n"
       ]
      },
-     "execution_count": 167,
+     "execution_count": 169,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5911,7 +6001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": 170,
    "id": "f0871131-725e-4e33-a3cc-1fccd610a4b2",
    "metadata": {},
    "outputs": [
@@ -5921,7 +6011,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>index</th><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>bar</td><td>5</td><td>20</td><td>50</td></tr><tr><td>boo</td><td>6</td><td>30</td><td>-30</td></tr><tr><td>kar</td><td>7</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fb40>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x00000000000101a8>\n",
        "  index        AAA     BBB    CCC\n",
        "  <string> <uint8> <uint8> <int8>\n",
        "1 bar            5      20     50\n",
@@ -5929,7 +6019,7 @@
        "3 kar            7      40    -50\n"
       ]
      },
-     "execution_count": 168,
+     "execution_count": 170,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5940,7 +6030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 171,
    "id": "dffc55f0-481e-4076-aa3f-89f1294655b9",
    "metadata": {},
    "outputs": [
@@ -5950,7 +6040,7 @@
        "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>index</th><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>bar</td><td>5</td><td>20</td><td>50</td></tr><tr><td>boo</td><td>6</td><td>30</td><td>-30</td></tr><tr><td>kar</td><td>7</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fb54>\n",
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x00000000000101bc>\n",
        "  index        AAA     BBB    CCC\n",
        "  <string> <uint8> <uint8> <int8>\n",
        "1 bar            5      20     50\n",
@@ -5958,7 +6048,7 @@
        "3 kar            7      40    -50\n"
       ]
      },
-     "execution_count": 169,
+     "execution_count": 171,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5968,6 +6058,45 @@
     "  v = v(:index)\n",
     "  v.index(\"bar\")..v.index(\"kar\")\n",
     "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee4f4498-c9d8-4cb9-8b1b-faa19f968f30",
+   "metadata": {},
+   "source": [
+    "`slice_by` returns the same result as above.\n",
+    "\n",
+    "(Since 0.2.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "id": "97c76bdc-6c1b-4b7d-92bf-d5108fe479a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>index</th><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>bar</td><td>5</td><td>20</td><td>50</td></tr><tr><td>boo</td><td>6</td><td>30</td><td>-30</td></tr><tr><td>kar</td><td>7</td><td>40</td><td>-50</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x00000000000101d0>\n",
+       "  index        AAA     BBB    CCC\n",
+       "  <string> <uint8> <uint8> <int8>\n",
+       "1 bar            5      20     50\n",
+       "2 boo            6      30    -30\n",
+       "3 kar            7      40    -50\n"
+      ]
+     },
+     "execution_count": 172,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "labeled.slice_by(:index, keep_key: true) { \"bar\"..\"kar\"}"
    ]
   },
   {
@@ -5997,7 +6126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 173,
    "id": "f023a23a-ea1d-415c-b395-195801351433",
    "metadata": {},
    "outputs": [],
@@ -6025,7 +6154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 174,
    "id": "29b81efe-5b9b-4640-89b1-422ae94cf01d",
    "metadata": {},
    "outputs": [
@@ -6035,14 +6164,14 @@
        "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>5</td><td>20</td><td>50</td></tr><tr><td>7</td><td>40</td><td>-50</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fb68>\n",
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x00000000000101e4>\n",
        "      AAA     BBB    CCC\n",
        "  <uint8> <uint8> <int8>\n",
        "1       5      20     50\n",
        "2       7      40    -50\n"
       ]
      },
-     "execution_count": 171,
+     "execution_count": 174,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6110,7 +6239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 175,
    "id": "265d63e6-0c01-4080-8d5b-c3153be595a5",
    "metadata": {},
    "outputs": [
@@ -6120,7 +6249,7 @@
        "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th></tr><tr><td>1</td><td>1</td><td>2</td></tr><tr><td>2</td><td>1</td><td>1</td></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>3</td><td>2</td><td>1</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fb7c>\n",
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x00000000000101f8>\n",
        "      AAA     BBB     CCC\n",
        "  <uint8> <uint8> <uint8>\n",
        "1       1       1       2\n",
@@ -6129,7 +6258,7 @@
        "4       3       2       1\n"
       ]
      },
-     "execution_count": 172,
+     "execution_count": 175,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6141,7 +6270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 176,
    "id": "4be751d7-69a8-4400-b094-9932bf3d577b",
    "metadata": {},
    "outputs": [
@@ -6151,7 +6280,7 @@
        "RedAmber::DataFrame <4 x 6 vectors> <table><tr><th>AAA</th><th>BBB</th><th>CCC</th><th>AAA_cat</th><th>BBB_cat</th><th>CCC_cat</th></tr><tr><td>1</td><td>1</td><td>2</td><td>Alpha</td><td>Alpha</td><td>Beta</td></tr><tr><td>2</td><td>1</td><td>1</td><td>Beta</td><td>Alpha</td><td>Alpha</td></tr><tr><td>1</td><td>2</td><td>3</td><td>Alpha</td><td>Beta</td><td>Charlie</td></tr><tr><td>3</td><td>2</td><td>1</td><td>Charlie</td><td>Beta</td><td>Alpha</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 4 x 6 Vectors, 0x000000000000fb90>\n",
+       "#<RedAmber::DataFrame : 4 x 6 Vectors, 0x000000000001020c>\n",
        "      AAA     BBB     CCC AAA_cat  BBB_cat  CCC_cat\n",
        "  <uint8> <uint8> <uint8> <string> <string> <string>\n",
        "1       1       1       2 Alpha    Alpha    Beta\n",
@@ -6160,7 +6289,7 @@
        "4       3       2       1 Charlie  Beta     Alpha\n"
       ]
      },
-     "execution_count": 173,
+     "execution_count": 176,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6231,7 +6360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 177,
    "id": "5dd5f7dc-21a3-4397-9ef6-c5bc630ff858",
    "metadata": {},
    "outputs": [
@@ -6241,7 +6370,7 @@
        "RedAmber::DataFrame <8 x 2 vectors> <table><tr><th>AAA</th><th>BBB</th></tr><tr><td>1</td><td>2</td></tr><tr><td>1</td><td>1</td></tr><tr><td>1</td><td>3</td></tr><tr><td>2</td><td>4</td></tr><tr><td>2</td><td>5</td></tr><tr><td>2</td><td>1</td></tr><tr><td>3</td><td>2</td></tr><tr><td>3</td><td>3</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 8 x 2 Vectors, 0x000000000000fba4>\n",
+       "#<RedAmber::DataFrame : 8 x 2 Vectors, 0x0000000000010220>\n",
        "      AAA     BBB\n",
        "  <uint8> <uint8>\n",
        "1       1       2\n",
@@ -6249,12 +6378,12 @@
        "3       1       3\n",
        "4       2       4\n",
        "5       2       5\n",
-       ":       :       :\n",
+       "6       2       1\n",
        "7       3       2\n",
        "8       3       3\n"
       ]
      },
-     "execution_count": 174,
+     "execution_count": 177,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6266,7 +6395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 178,
    "id": "000c1632-8faf-407f-bb7d-e583ef573442",
    "metadata": {},
    "outputs": [
@@ -6276,7 +6405,7 @@
        "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>AAA</th><th>min(BBB)</th></tr><tr><td>1</td><td>1</td></tr><tr><td>2</td><td>1</td></tr><tr><td>3</td><td>2</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000fbb8>\n",
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000010234>\n",
        "      AAA min(BBB)\n",
        "  <uint8>  <uint8>\n",
        "1       1        1\n",
@@ -6284,7 +6413,7 @@
        "3       3        2\n"
       ]
      },
-     "execution_count": 175,
+     "execution_count": 178,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6307,7 +6436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 179,
    "id": "610be94e-b7ce-43f5-a5c1-ddef745d6bac",
    "metadata": {},
    "outputs": [
@@ -6317,7 +6446,7 @@
        "RedAmber::DataFrame <5 x 9 vectors> <table><tr><th>variables</th><th>count</th><th>mean</th><th>std</th><th>min</th><th>25%</th><th>median</th><th>75%</th><th>max</th></tr><tr><td>bill_length_mm</td><td>342</td><td>43.92192982456141</td><td>5.4595837139265315</td><td>32.1</td><td>39.225</td><td>44.382000000000005</td><td>48.5</td><td>59.6</td></tr><tr><td>bill_depth_mm</td><td>342</td><td>17.151169590643274</td><td>1.9747931568167814</td><td>13.1</td><td>15.6</td><td>17.32</td><td>18.7</td><td>21.5</td></tr><tr><td>flipper_length_mm</td><td>342</td><td>200.91520467836258</td><td>14.061713679356888</td><td>172.0</td><td>190.0</td><td>197.0</td><td>213.0</td><td>231.0</td></tr><tr><td>body_mass_g</td><td>342</td><td>4201.754385964912</td><td>801.9545356980955</td><td>2700.0</td><td>3550.0</td><td>4031.5</td><td>4750.0</td><td>6300.0</td></tr><tr><td>year</td><td>344</td><td>2008.0290697674418</td><td>0.8183559254837041</td><td>2007.0</td><td>2007.0</td><td>2008.0</td><td>2009.0</td><td>2009.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 9 Vectors, 0x000000000000fbcc>\n",
+       "#<RedAmber::DataFrame : 5 x 9 Vectors, 0x0000000000010248>\n",
        "  variables            count     mean      std      min      25%   median ...      max\n",
        "  <dictionary>      <uint16> <double> <double> <double> <double> <double> ... <double>\n",
        "1 bill_length_mm         342    43.92     5.46     32.1    39.23    44.38 ...     59.6\n",
@@ -6327,7 +6456,7 @@
        "5 year                   344  2008.03     0.82   2007.0   2007.0   2008.0 ...   2009.0\n"
       ]
      },
-     "execution_count": 176,
+     "execution_count": 179,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6336,6 +6465,48 @@
     "penguins.summary\n",
     "# or\n",
     "penguins.describe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c06cbb0e-fd75-4567-88df-bd9902fc94e2",
+   "metadata": {},
+   "source": [
+    "If you need a variables in row, use `transpose`. (Since 0.2.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "id": "42406c73-6480-4a30-a940-930bf6804fff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <8 x 6 vectors> <table><tr><th>stats</th><th>bill_length_mm</th><th>bill_depth_mm</th><th>flipper_length_mm</th><th>body_mass_g</th><th>year</th></tr><tr><td>count</td><td>342.0</td><td>342.0</td><td>342.0</td><td>342.0</td><td>344.0</td></tr><tr><td>mean</td><td>43.92192982456141</td><td>17.151169590643274</td><td>200.91520467836258</td><td>4201.754385964912</td><td>2008.0290697674418</td></tr><tr><td>std</td><td>5.4595837139265315</td><td>1.9747931568167814</td><td>14.061713679356888</td><td>801.9545356980955</td><td>0.8183559254837041</td></tr><tr><td>min</td><td>32.1</td><td>13.1</td><td>172.0</td><td>2700.0</td><td>2007.0</td></tr><tr><td>25%</td><td>39.225</td><td>15.6</td><td>190.0</td><td>3550.0</td><td>2007.0</td></tr><tr><td>median</td><td>44.382000000000005</td><td>17.32</td><td>197.0</td><td>4031.5</td><td>2008.0</td></tr><tr><td>75%</td><td>48.5</td><td>18.7</td><td>213.0</td><td>4750.0</td><td>2009.0</td></tr><tr><td>max</td><td>59.6</td><td>21.5</td><td>231.0</td><td>6300.0</td><td>2009.0</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 8 x 6 Vectors, 0x000000000001025c>\n",
+       "  stats        bill_length_mm bill_depth_mm flipper_length_mm body_mass_g     year\n",
+       "  <dictionary>       <double>      <double>          <double>    <double> <double>\n",
+       "1 count                 342.0         342.0             342.0       342.0    344.0\n",
+       "2 mean                  43.92         17.15            200.92     4201.75  2008.03\n",
+       "3 std                    5.46          1.97             14.06      801.95     0.82\n",
+       "4 min                    32.1          13.1             172.0      2700.0   2007.0\n",
+       "5 25%                   39.23          15.6             190.0      3550.0   2007.0\n",
+       "6 median                44.38         17.32             197.0      4031.5   2008.0\n",
+       "7 75%                    48.5          18.7             213.0      4750.0   2009.0\n",
+       "8 max                    59.6          21.5             231.0      6300.0   2009.0\n"
+      ]
+     },
+     "execution_count": 180,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "penguins.summary.transpose(name: :stats)"
    ]
   },
   {
@@ -6358,7 +6529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 181,
    "id": "88c6ed5d-b41e-4c17-b93f-47ce15702974",
    "metadata": {},
    "outputs": [
@@ -6368,13 +6539,13 @@
        "17.3"
       ]
      },
-     "execution_count": 177,
+     "execution_count": 181,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "penguins[:bill_depth_mm].quantile # default value is prob = 0.5"
+    "penguins[:bill_depth_mm].quantile # default　is prob = 0.5"
    ]
   },
   {
@@ -6387,7 +6558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 182,
    "id": "3cbac413-fc36-42a2-abd3-1343e3b88467",
    "metadata": {},
    "outputs": [
@@ -6397,14 +6568,14 @@
        "RedAmber::DataFrame <2 x 2 vectors> <table><tr><th>probs</th><th>quantiles</th></tr><tr><td>0.05</td><td>13.9</td></tr><tr><td>0.95</td><td>20.0</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x000000000000fbe0>\n",
+       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x0000000000010270>\n",
        "     probs quantiles\n",
        "  <double>  <double>\n",
        "1     0.05      13.9\n",
        "2     0.95      20.0\n"
       ]
      },
-     "execution_count": 178,
+     "execution_count": 182,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6433,58 +6604,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 183,
    "id": "a2fe66cb-e86d-402e-8724-eced2420e3d0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fbf4>\n",
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x0000000000010284>\n",
        "     Year    Audi     BMW BMW_MINI Mercedes-Benz      VW\n",
        "  <int64> <int64> <int64>  <int64>       <int64> <int64>\n",
-       "1    2021   22535   35905    18211         51722   35215\n",
-       "2    2020   22304   35712    20196         57041   36576\n",
+       "1    2017   28336   52527    25427         68221   49040\n",
+       "2    2018   26473   50982    25984         67554   51961\n",
        "3    2019   24222   46814    23813         66553   46794\n",
-       "4    2018   26473   50982    25984         67554   51961\n",
-       "5    2017   28336   52527    25427         68221   49040\n"
+       "4    2020   22304   35712    20196         57041   36576\n",
+       "5    2021   22535   35905    18211         51722   35215\n"
       ]
      },
-     "execution_count": 179,
+     "execution_count": 183,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "import_cars = RedAmber::DataFrame.load('../test/entity/import_cars.tsv')"
+    "uri = URI(\"https://raw.githubusercontent.com/heronshoes/red_amber/master/test/entity/import_cars.tsv\")\n",
+    "import_cars = RedAmber::DataFrame.load(uri)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 184,
    "id": "b4ef2b48-33de-4982-b082-1966749fcf65",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>name</th><th>2021</th><th>2020</th><th>2019</th><th>2018</th><th>2017</th></tr><tr><td>Audi</td><td>22535</td><td>22304</td><td>24222</td><td>26473</td><td>28336</td></tr><tr><td>BMW</td><td>35905</td><td>35712</td><td>46814</td><td>50982</td><td>52527</td></tr><tr><td>BMW_MINI</td><td>18211</td><td>20196</td><td>23813</td><td>25984</td><td>25427</td></tr><tr><td>Mercedes-Benz</td><td>51722</td><td>57041</td><td>66553</td><td>67554</td><td>68221</td></tr><tr><td>VW</td><td>35215</td><td>36576</td><td>46794</td><td>51961</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>N</th><th>2017</th><th>2018</th><th>2019</th><th>2020</th><th>2021</th></tr><tr><td>Audi</td><td>28336</td><td>26473</td><td>24222</td><td>22304</td><td>22535</td></tr><tr><td>BMW</td><td>52527</td><td>50982</td><td>46814</td><td>35712</td><td>35905</td></tr><tr><td>BMW_MINI</td><td>25427</td><td>25984</td><td>23813</td><td>20196</td><td>18211</td></tr><tr><td>Mercedes-Benz</td><td>68221</td><td>67554</td><td>66553</td><td>57041</td><td>51722</td></tr><tr><td>VW</td><td>49040</td><td>51961</td><td>46794</td><td>36576</td><td>35215</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc08>\n",
-       "  name              2021     2020     2019     2018     2017\n",
-       "  <dictionary>  <uint16> <uint16> <uint32> <uint32> <uint32>\n",
-       "1 Audi             22535    22304    24222    26473    28336\n",
-       "2 BMW              35905    35712    46814    50982    52527\n",
-       "3 BMW_MINI         18211    20196    23813    25984    25427\n",
-       "4 Mercedes-Benz    51722    57041    66553    67554    68221\n",
-       "5 VW               35215    36576    46794    51961    49040\n"
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x0000000000010298>\n",
+       "  N                 2017     2018     2019     2020     2021\n",
+       "  <dictionary>  <uint32> <uint32> <uint32> <uint16> <uint16>\n",
+       "1 Audi             28336    26473    24222    22304    22535\n",
+       "2 BMW              52527    50982    46814    35712    35905\n",
+       "3 BMW_MINI         25427    25984    23813    20196    18211\n",
+       "4 Mercedes-Benz    68221    67554    66553    57041    51722\n",
+       "5 VW               49040    51961    46794    36576    35215\n"
       ]
      },
-     "execution_count": 180,
+     "execution_count": 184,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6498,69 +6670,107 @@
    "id": "556e5c2d-bb01-4e16-9bf6-bdfd302d5b2a",
    "metadata": {},
    "source": [
-    "You can specify index column by option `:key` even if it is at the middle of the original DataFrame."
+    "You can specify index column by option `:key` even if it is in the middle of the original DataFrame."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 185,
    "id": "31edb594-93fb-493f-8036-14e8273596ed",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Audi</th><th>BMW</th><th>Year</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>22535</td><td>35905</td><td>2021</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>22304</td><td>35712</td><td>2020</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>24222</td><td>46814</td><td>2019</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>26473</td><td>50982</td><td>2018</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>28336</td><td>52527</td><td>2017</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <5 x 5 vectors> <table><tr><th>Audi</th><th>BMW</th><th>Year</th><th>BMW_MINI</th><th>Mercedes-Benz</th></tr><tr><td>28336</td><td>52527</td><td>2017</td><td>25427</td><td>68221</td></tr><tr><td>26473</td><td>50982</td><td>2018</td><td>25984</td><td>67554</td></tr><tr><td>24222</td><td>46814</td><td>2019</td><td>23813</td><td>66553</td></tr><tr><td>22304</td><td>35712</td><td>2020</td><td>20196</td><td>57041</td></tr><tr><td>22535</td><td>35905</td><td>2021</td><td>18211</td><td>51722</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc1c>\n",
-       "     Audi     BMW    Year BMW_MINI Mercedes-Benz      VW\n",
-       "  <int64> <int64> <int64>  <int64>       <int64> <int64>\n",
-       "1   22535   35905    2021    18211         51722   35215\n",
-       "2   22304   35712    2020    20196         57041   36576\n",
-       "3   24222   46814    2019    23813         66553   46794\n",
-       "4   26473   50982    2018    25984         67554   51961\n",
-       "5   28336   52527    2017    25427         68221   49040\n"
+       "#<RedAmber::DataFrame : 5 x 5 Vectors, 0x00000000000102ac>\n",
+       "     Audi     BMW    Year BMW_MINI Mercedes-Benz\n",
+       "  <int64> <int64> <int64>  <int64>       <int64>\n",
+       "1   28336   52527    2017    25427         68221\n",
+       "2   26473   50982    2018    25984         67554\n",
+       "3   24222   46814    2019    23813         66553\n",
+       "4   22304   35712    2020    20196         57041\n",
+       "5   22535   35905    2021    18211         51722\n"
       ]
      },
-     "execution_count": 181,
+     "execution_count": 185,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df = import_cars.pick { [keys[1..2], keys[0], keys[3..]] }"
+    "# locate `:Year` in the middle\n",
+    "df = import_cars.pick(1..2, 0, 3..)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 186,
    "id": "ffa7cecc-5298-49d6-b483-b2b5cf2e1820",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>name</th><th>2021</th><th>2020</th><th>2019</th><th>2018</th><th>2017</th></tr><tr><td>Audi</td><td>22535</td><td>22304</td><td>24222</td><td>26473</td><td>28336</td></tr><tr><td>BMW</td><td>35905</td><td>35712</td><td>46814</td><td>50982</td><td>52527</td></tr><tr><td>BMW_MINI</td><td>18211</td><td>20196</td><td>23813</td><td>25984</td><td>25427</td></tr><tr><td>Mercedes-Benz</td><td>51722</td><td>57041</td><td>66553</td><td>67554</td><td>68221</td></tr><tr><td>VW</td><td>35215</td><td>36576</td><td>46794</td><td>51961</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <4 x 6 vectors> <table><tr><th>N</th><th>2017</th><th>2018</th><th>2019</th><th>2020</th><th>2021</th></tr><tr><td>Audi</td><td>28336</td><td>26473</td><td>24222</td><td>22304</td><td>22535</td></tr><tr><td>BMW</td><td>52527</td><td>50982</td><td>46814</td><td>35712</td><td>35905</td></tr><tr><td>BMW_MINI</td><td>25427</td><td>25984</td><td>23813</td><td>20196</td><td>18211</td></tr><tr><td>Mercedes-Benz</td><td>68221</td><td>67554</td><td>66553</td><td>57041</td><td>51722</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc30>\n",
-       "  name              2021     2020     2019     2018     2017\n",
-       "  <dictionary>  <uint16> <uint16> <uint32> <uint32> <uint32>\n",
-       "1 Audi             22535    22304    24222    26473    28336\n",
-       "2 BMW              35905    35712    46814    50982    52527\n",
-       "3 BMW_MINI         18211    20196    23813    25984    25427\n",
-       "4 Mercedes-Benz    51722    57041    66553    67554    68221\n",
-       "5 VW               35215    36576    46794    51961    49040\n"
+       "#<RedAmber::DataFrame : 4 x 6 Vectors, 0x00000000000102c0>\n",
+       "  N                 2017     2018     2019     2020     2021\n",
+       "  <dictionary>  <uint32> <uint32> <uint32> <uint16> <uint16>\n",
+       "1 Audi             28336    26473    24222    22304    22535\n",
+       "2 BMW              52527    50982    46814    35712    35905\n",
+       "3 BMW_MINI         25427    25984    23813    20196    18211\n",
+       "4 Mercedes-Benz    68221    67554    66553    57041    51722\n"
       ]
      },
-     "execution_count": 182,
+     "execution_count": 186,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df.transpose(key: :Year)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48178c99-6c68-4588-b515-fcddaeb6741b",
+   "metadata": {},
+   "source": [
+    "Name the column from the keys in original by the option `name:`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 187,
+   "id": "31679a91-11b4-42a8-95cc-58644a3003ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 6 vectors> <table><tr><th>Manufacturer</th><th>2017</th><th>2018</th><th>2019</th><th>2020</th><th>2021</th></tr><tr><td>Audi</td><td>28336</td><td>26473</td><td>24222</td><td>22304</td><td>22535</td></tr><tr><td>BMW</td><td>52527</td><td>50982</td><td>46814</td><td>35712</td><td>35905</td></tr><tr><td>BMW_MINI</td><td>25427</td><td>25984</td><td>23813</td><td>20196</td><td>18211</td></tr><tr><td>Mercedes-Benz</td><td>68221</td><td>67554</td><td>66553</td><td>57041</td><td>51722</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 6 Vectors, 0x00000000000102d4>\n",
+       "  Manufacturer      2017     2018     2019     2020     2021\n",
+       "  <dictionary>  <uint32> <uint32> <uint32> <uint16> <uint16>\n",
+       "1 Audi             28336    26473    24222    22304    22535\n",
+       "2 BMW              52527    50982    46814    35712    35905\n",
+       "3 BMW_MINI         25427    25984    23813    20196    18211\n",
+       "4 Mercedes-Benz    68221    67554    66553    57041    51722\n"
+      ]
+     },
+     "execution_count": 187,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.transpose(key: :Year, name: :Manufacturer)"
    ]
   },
   {
@@ -6576,7 +6786,7 @@
    "id": "8970bf89-6841-44aa-8faa-8c2e97842a8d",
    "metadata": {},
    "source": [
-    "`DataFrame#to_long(*keep_keys)` reshapes wide DataFrame to a longer DataFrame.\n",
+    "`DataFrame#to_long(*keep_keys)` reshapes wide DataFrame to the long DataFrame.\n",
     "\n",
     "- Parameter `keep_keys` specifies the key names to keep.\n",
     "\n",
@@ -6585,62 +6795,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 188,
    "id": "f188cf35-3364-45aa-ad3c-1e079ed7b1a3",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc44>\n",
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x00000000000102e8>\n",
        "     Year    Audi     BMW BMW_MINI Mercedes-Benz      VW\n",
        "  <int64> <int64> <int64>  <int64>       <int64> <int64>\n",
-       "1    2021   22535   35905    18211         51722   35215\n",
-       "2    2020   22304   35712    20196         57041   36576\n",
+       "1    2017   28336   52527    25427         68221   49040\n",
+       "2    2018   26473   50982    25984         67554   51961\n",
        "3    2019   24222   46814    23813         66553   46794\n",
-       "4    2018   26473   50982    25984         67554   51961\n",
-       "5    2017   28336   52527    25427         68221   49040\n"
+       "4    2020   22304   35712    20196         57041   36576\n",
+       "5    2021   22535   35905    18211         51722   35215\n"
       ]
      },
-     "execution_count": 183,
+     "execution_count": 188,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "import_cars = RedAmber::DataFrame.load('../test/entity/import_cars.tsv')"
+    "uri = URI(\"https://raw.githubusercontent.com/heronshoes/red_amber/master/test/entity/import_cars.tsv\")\n",
+    "import_cars = RedAmber::DataFrame.load(uri)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 189,
    "id": "bee776ae-7a82-41aa-8a31-c53af6b9ad9f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <25 x 3 vectors> <table><tr><th>Year</th><th>name</th><th>value</th></tr><tr><td>2021</td><td>Audi</td><td>22535</td></tr><tr><td>2021</td><td>BMW</td><td>35905</td></tr><tr><td>2021</td><td>BMW_MINI</td><td>18211</td></tr><tr><td>2021</td><td>Mercedes-Benz</td><td>51722</td></tr><tr><td colspan='3'>&#8942;</td></tr><tr><td>2017</td><td>BMW_MINI</td><td>25427</td></tr><tr><td>2017</td><td>Mercedes-Benz</td><td>68221</td></tr><tr><td>2017</td><td>VW</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <25 x 3 vectors> <table><tr><th>Year</th><th>N</th><th>V</th></tr><tr><td>2017</td><td>Audi</td><td>28336</td></tr><tr><td>2017</td><td>BMW</td><td>52527</td></tr><tr><td>2017</td><td>BMW_MINI</td><td>25427</td></tr><tr><td>2017</td><td>Mercedes-Benz</td><td>68221</td></tr><tr><td colspan='3'>&#8942;</td></tr><tr><td>2021</td><td>BMW_MINI</td><td>18211</td></tr><tr><td>2021</td><td>Mercedes-Benz</td><td>51722</td></tr><tr><td>2021</td><td>VW</td><td>35215</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 25 x 3 Vectors, 0x000000000000fc58>\n",
-       "       Year name             value\n",
+       "#<RedAmber::DataFrame : 25 x 3 Vectors, 0x00000000000102fc>\n",
+       "       Year N                    V\n",
        "   <uint16> <dictionary>  <uint32>\n",
-       " 1     2021 Audi             22535\n",
-       " 2     2021 BMW              35905\n",
-       " 3     2021 BMW_MINI         18211\n",
-       " 4     2021 Mercedes-Benz    51722\n",
-       " 5     2021 VW               35215\n",
+       " 1     2017 Audi             28336\n",
+       " 2     2017 BMW              52527\n",
+       " 3     2017 BMW_MINI         25427\n",
+       " 4     2017 Mercedes-Benz    68221\n",
+       " 5     2017 VW               49040\n",
        " :        : :                    :\n",
-       "23     2017 BMW_MINI         25427\n",
-       "24     2017 Mercedes-Benz    68221\n",
-       "25     2017 VW               49040\n"
+       "23     2021 BMW_MINI         18211\n",
+       "24     2021 Mercedes-Benz    51722\n",
+       "25     2021 VW               35215\n"
       ]
      },
-     "execution_count": 184,
+     "execution_count": 189,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6654,37 +6865,37 @@
    "id": "771aac21-e739-4eea-9d75-cc99f691f87e",
    "metadata": {},
    "source": [
-    "- Option `:name` : key of the column which is come **from key names**.\n",
-    "- Option `:value` : key of the column which is come **from values**."
+    "- Option `:name` specify the key of the column which is come **from key names**. Default is `:N`.\n",
+    "- Option `:value` specify the key of the column which is come **from values**. Default is `:V`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 190,
    "id": "b7f7aeab-d545-4a28-82ce-db844029cc9c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <25 x 3 vectors> <table><tr><th>Year</th><th>Manufacturer</th><th>Num_of_imported</th></tr><tr><td>2021</td><td>Audi</td><td>22535</td></tr><tr><td>2021</td><td>BMW</td><td>35905</td></tr><tr><td>2021</td><td>BMW_MINI</td><td>18211</td></tr><tr><td>2021</td><td>Mercedes-Benz</td><td>51722</td></tr><tr><td colspan='3'>&#8942;</td></tr><tr><td>2017</td><td>BMW_MINI</td><td>25427</td></tr><tr><td>2017</td><td>Mercedes-Benz</td><td>68221</td></tr><tr><td>2017</td><td>VW</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <25 x 3 vectors> <table><tr><th>Year</th><th>Manufacturer</th><th>Num_of_imported</th></tr><tr><td>2017</td><td>Audi</td><td>28336</td></tr><tr><td>2017</td><td>BMW</td><td>52527</td></tr><tr><td>2017</td><td>BMW_MINI</td><td>25427</td></tr><tr><td>2017</td><td>Mercedes-Benz</td><td>68221</td></tr><tr><td colspan='3'>&#8942;</td></tr><tr><td>2021</td><td>BMW_MINI</td><td>18211</td></tr><tr><td>2021</td><td>Mercedes-Benz</td><td>51722</td></tr><tr><td>2021</td><td>VW</td><td>35215</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 25 x 3 Vectors, 0x000000000000fc6c>\n",
+       "#<RedAmber::DataFrame : 25 x 3 Vectors, 0x0000000000010310>\n",
        "       Year Manufacturer  Num_of_imported\n",
        "   <uint16> <dictionary>         <uint32>\n",
-       " 1     2021 Audi                    22535\n",
-       " 2     2021 BMW                     35905\n",
-       " 3     2021 BMW_MINI                18211\n",
-       " 4     2021 Mercedes-Benz           51722\n",
-       " 5     2021 VW                      35215\n",
+       " 1     2017 Audi                    28336\n",
+       " 2     2017 BMW                     52527\n",
+       " 3     2017 BMW_MINI                25427\n",
+       " 4     2017 Mercedes-Benz           68221\n",
+       " 5     2017 VW                      49040\n",
        " :        : :                           :\n",
-       "23     2017 BMW_MINI                25427\n",
-       "24     2017 Mercedes-Benz           68221\n",
-       "25     2017 VW                      49040\n"
+       "23     2021 BMW_MINI                18211\n",
+       "24     2021 Mercedes-Benz           51722\n",
+       "25     2021 VW                      35215\n"
       ]
      },
-     "execution_count": 185,
+     "execution_count": 190,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6706,37 +6917,37 @@
    "id": "7fa18ac8-99e1-4d55-bed4-cc02469496b5",
    "metadata": {},
    "source": [
-    "`DataFrame#to_wide(*keep_keys)` reshapes long DataFrame to a wider DataFrame.\n",
+    "`DataFrame#to_wide(*keep_keys)` reshapes long DataFrame to a wide DataFrame.\n",
     "\n",
-    "- Option `:name` : key of the column which will be expanded **to key name**.\n",
-    "- Option `:value` : key of the column which will be expanded **to values**.\n",
+    "- Option `:name` specify the key of the column which will be expanded **to key name**. Default is `:N`.\n",
+    "- Option `:value` specify the key of the column which will be expanded **to values**. Default is `:V`.\n",
     "\n",
     "(Since 0.2.0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 191,
    "id": "1d59c42f-c5ec-4df2-9fbe-592092ad2f8b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr></table>"
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr></table>"
       ],
       "text/plain": [
-       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x000000000000fc80>\n",
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x0000000000010324>\n",
        "      Year     Audi      BMW BMW_MINI Mercedes-Benz       VW\n",
        "  <uint16> <uint16> <uint16> <uint16>      <uint32> <uint16>\n",
-       "1     2021    22535    35905    18211         51722    35215\n",
-       "2     2020    22304    35712    20196         57041    36576\n",
+       "1     2017    28336    52527    25427         68221    49040\n",
+       "2     2018    26473    50982    25984         67554    51961\n",
        "3     2019    24222    46814    23813         66553    46794\n",
-       "4     2018    26473    50982    25984         67554    51961\n",
-       "5     2017    28336    52527    25427         68221    49040\n"
+       "4     2020    22304    35712    20196         57041    36576\n",
+       "5     2021    22535    35905    18211         51722    35215\n"
       ]
      },
-     "execution_count": 186,
+     "execution_count": 191,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6747,27 +6958,2012 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 192,
    "id": "84b7909a-200c-4aec-b192-25016399a7c4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 6 vectors> <table><tr><th>Year</th><th>Audi</th><th>BMW</th><th>BMW_MINI</th><th>Mercedes-Benz</th><th>VW</th></tr><tr><td>2017</td><td>28336</td><td>52527</td><td>25427</td><td>68221</td><td>49040</td></tr><tr><td>2018</td><td>26473</td><td>50982</td><td>25984</td><td>67554</td><td>51961</td></tr><tr><td>2019</td><td>24222</td><td>46814</td><td>23813</td><td>66553</td><td>46794</td></tr><tr><td>2020</td><td>22304</td><td>35712</td><td>20196</td><td>57041</td><td>36576</td></tr><tr><td>2021</td><td>22535</td><td>35905</td><td>18211</td><td>51722</td><td>35215</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 6 Vectors, 0x0000000000010338>\n",
+       "      Year     Audi      BMW BMW_MINI Mercedes-Benz       VW\n",
+       "  <uint16> <uint16> <uint16> <uint16>      <uint32> <uint16>\n",
+       "1     2017    28336    52527    25427         68221    49040\n",
+       "2     2018    26473    50982    25984         67554    51961\n",
+       "3     2019    24222    46814    23813         66553    46794\n",
+       "4     2020    22304    35712    20196         57041    36576\n",
+       "5     2021    22535    35905    18211         51722    35215\n"
+      ]
+     },
+     "execution_count": 192,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# import_cars.to_long(:Year).to_wide(name: :name, value: :value)\n",
+    "import_cars.to_long(:Year).to_wide(name: :N, value: :V)\n",
     "# is also OK"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c92c2fe0-23a5-4153-bd03-7a07664b4d9e",
+   "cell_type": "markdown",
+   "id": "f2919aae-12ba-448b-a370-7910845fa470",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## 62. Custom index\n",
+    "\n",
+    "Another example of `indices` is [14. Indices](#14.-Indices)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a623030-3aad-459d-a04b-23dc52ea4088",
+   "metadata": {},
+   "source": [
+    "We can set the start of indices by the option.\n",
+    "\n",
+    "(Since 0.2.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 193,
+   "id": "c33c39f6-b48c-45d7-a755-43c33da21b9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 1, 2, 3, 4]"
+      ]
+     },
+     "execution_count": 193,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = DataFrame.new(x: [0, 1, 2, 3, 4])\n",
+    "df.indices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "id": "fe797234-3759-4cd6-a9fc-02919afb9fed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 2, 3, 4, 5]"
+      ]
+     },
+     "execution_count": 194,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.indices(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
+   "id": "ab17dad0-de80-412d-a890-d0f85ee630ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"a\", \"b\", \"c\", \"d\", \"e\"]"
+      ]
+     },
+     "execution_count": 195,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.indices(\"a\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 196,
+   "id": "200f96e1-b2d4-451b-ac0a-34ab7aa0cec0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>x</th><th>date</th></tr><tr><td>0</td><td>2022-09-04</td></tr><tr><td>1</td><td>2022-09-05</td></tr><tr><td>2</td><td>2022-09-06</td></tr><tr><td>3</td><td>2022-09-07</td></tr><tr><td>4</td><td>2022-09-08</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x000000000001034c>\n",
+       "        x date\n",
+       "  <uint8> <date32>\n",
+       "1       0 2022-09-04\n",
+       "2       1 2022-09-05\n",
+       "3       2 2022-09-06\n",
+       "4       3 2022-09-07\n",
+       "5       4 2022-09-08\n"
+      ]
+     },
+     "execution_count": 196,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.assign(:date) { indices(Date.parse(\"2022/9/4\")) }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3e52c9f-704a-4032-bde9-a834b2a3e3f2",
+   "metadata": {},
+   "source": [
+    "You can put the first value which accepts `#succ` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cda03584-a0f3-4e16-bc34-b33bf83bf156",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 63. Method missing\n",
+    "\n",
+    "`RedAmber::DataFrame` has `#method_missing` to enable to call key names as methods.\n",
+    "\n",
+    "This feature is limited to what can be called as a method (`:key` is OK, not allowed for the keys `:Key`, `:\"key.1\"`, `:\"1key\"`, etc. ). But it will be convenient in many cases.\n",
+    "\n",
+    "(Since 0.2.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 197,
+   "id": "1e12170d-73d9-4adc-acca-a0d4ea697f24",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 197,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = DataFrame.new(x: [1, 2, 3])\n",
+    "df.x.sum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 198,
+   "id": "b80ea144-b668-4df1-a28a-2c19728f4365",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "#<RedAmber::Vector(:uint8, size=3):0x0000000000010360>\n",
+       "[1, 2, 3]\n"
+      ]
+     },
+     "execution_count": 198,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Some ways to pull a Vector\n",
+    "df[:x] # Formal style\n",
+    "\n",
+    "df.v(:x) # #v method\n",
+    "\n",
+    "df.x # method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 199,
+   "id": "c8dca8e8-ccef-4485-a871-a251a0809d16",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 199,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.x.sum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cea71378-f0af-4c00-a7a9-6d5e1160ebe6",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 64. Assign revised\n",
+    "\n",
+    "Another example of `assign` is [#34. Assign](#34.-Assign), [#65. Variations of assign](#65.-Variations-of-assign) ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 200,
+   "id": "6a395669-0b37-4bbf-9852-fcc434dbfbeb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>0.1</td></tr><tr><td>2</td><td>0.2</td></tr><tr><td>3</td><td>0.3</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000010374>\n",
+       "        x        y\n",
+       "  <uint8> <double>\n",
+       "1       1      0.1\n",
+       "2       2      0.2\n",
+       "3       3      0.3\n"
+      ]
+     },
+     "execution_count": 200,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = DataFrame.new(x: [1, 2, 3])\n",
+    "\n",
+    "# Assign by a Hash\n",
+    "df.assign(y: df.x / 10.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 201,
+   "id": "3099b006-9a9a-4f27-9286-e00affcf1f2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>x</th><th>y</th></tr><tr><td>1</td><td>0.1</td></tr><tr><td>2</td><td>0.2</td></tr><tr><td>3</td><td>0.3</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000010388>\n",
+       "        x        y\n",
+       "  <uint8> <double>\n",
+       "1       1      0.1\n",
+       "2       2      0.2\n",
+       "3       3      0.3\n"
+      ]
+     },
+     "execution_count": 201,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Assign by separated key and value\n",
+    "df.assign(:y) { x / 10.0 }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 202,
+   "id": "aa14333d-0fd0-43a9-ad3c-1a694b03d91e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>x</th><th>y</th><th>z</th></tr><tr><td>1</td><td>10</td><td>0.1</td></tr><tr><td>2</td><td>20</td><td>0.2</td></tr><tr><td>3</td><td>30</td><td>0.3</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000001039c>\n",
+       "        x       y        z\n",
+       "  <uint8> <uint8> <double>\n",
+       "1       1      10      0.1\n",
+       "2       2      20      0.2\n",
+       "3       3      30      0.3\n"
+      ]
+     },
+     "execution_count": 202,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Separated keys and values\n",
+    "df.assign(:y, :z) { [x * 10, x / 10.0] }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a33a9394-3d89-4855-a2bc-4a2a95ad3f08",
+   "metadata": {},
+   "source": [
+    "## 65. Variations of assign\n",
+    "\n",
+    "Another example of `assign` is [#34. Assign](#34.-Assign), [#64. Assign revised](#64.-Assign-revised) ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 203,
+   "id": "59013a14-8c0d-4dec-b936-5a997ae4ca95",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 1 vector> <table><tr><th>x</th></tr><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 1 Vector, 0x00000000000103b0>\n",
+       "        x\n",
+       "  <uint8>\n",
+       "1       1\n",
+       "2       2\n",
+       "3       3\n"
+      ]
+     },
+     "execution_count": 203,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = DataFrame.new(x: [1, 2, 3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 204,
+   "id": "c30ba70a-0185-4b23-826d-56f810baad93",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 3 vectors> <table><tr><th>x</th><th>y</th><th>z</th></tr><tr><td>1</td><td>10</td><td>0.1</td></tr><tr><td>2</td><td>20</td><td>0.2</td></tr><tr><td>3</td><td>30</td><td>0.3</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 3 Vectors, 0x00000000000103c4>\n",
+       "        x       y        z\n",
+       "  <uint8> <uint8> <double>\n",
+       "1       1      10      0.1\n",
+       "2       2      20      0.2\n",
+       "3       3      30      0.3\n"
+      ]
+     },
+     "execution_count": 204,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Hash args\n",
+    "df.assign(y: df[:x] * 10, z: df[:x] / 10.0)\n",
+    "\n",
+    "# Hash\n",
+    "hash = {y: df[:x] * 10, z: df[:x] / 10.0}\n",
+    "df.assign(hash)\n",
+    "\n",
+    "# Array\n",
+    "array = [[:y, df[:x] * 10], [:z, df[:x] / 10.0]]\n",
+    "df.assign(array)\n",
+    "\n",
+    "# Array\n",
+    "df.assign [\n",
+    "  [:y, df[:x] * 10],\n",
+    "  [:z, df[:x] / 10.0]\n",
+    "]\n",
+    "\n",
+    "# Hash\n",
+    "df.assign({\n",
+    "  y: df[:x] * 10,\n",
+    "  z: df[:x] / 10.0\n",
+    "})\n",
+    "\n",
+    "# Block, Hash\n",
+    "df.assign { {y: df[:x] * 10, z: df[:x] / 10.0} }\n",
+    "\n",
+    "# Block, Array\n",
+    "df.assign { [[:y, df[:x] * 10], [:z, df[:x] / 10.0]] }\n",
+    "\n",
+    "# Block, Array, method\n",
+    "#df.assign { [:y, x * 10], [:z, x / 10.0]] }\n",
+    "\n",
+    "# Separated\n",
+    "#df.assign(:y, :z) { [x * 10, x / 10.0] }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0472a570-c0e5-4ec8-bd26-23914a48f23d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 66. Row index label by slice_by\n",
+    "\n",
+    "Another example of `slice` is [#28. Slice](#28.-Slice).\n",
+    "\n",
+    "(Since 0.2.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 205,
+   "id": "d7a6cb36-53e7-4503-88c0-301531d8b877",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 2 vectors> <table><tr><th>label</th><th>num</th></tr><tr><td>a</td><td>1.1</td></tr><tr><td>b</td><td>2.2</td></tr><tr><td>c</td><td>3.3</td></tr><tr><td>d</td><td>4.4</td></tr><tr><td>e</td><td>5.5</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 2 Vectors, 0x00000000000103d8>\n",
+       "  label         num\n",
+       "  <string> <double>\n",
+       "1 a             1.1\n",
+       "2 b             2.2\n",
+       "3 c             3.3\n",
+       "4 d             4.4\n",
+       "5 e             5.5\n"
+      ]
+     },
+     "execution_count": 205,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = DataFrame.new(num: [1.1, 2.2, 3.3, 4.4, 5.5])\n",
+    "              .assign_left(:label) { indices(\"a\") }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86377e12-acf7-4529-baf6-46e54a86aa5a",
+   "metadata": {},
+   "source": [
+    "`slice_by(key) { row_selector }` selects rows in column `key` with `row_selector`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 206,
+   "id": "2455da80-64af-4a4e-936f-4b7651dcf5ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 1 vector> <table><tr><th>num</th></tr><tr><td>2.2</td></tr><tr><td>3.3</td></tr><tr><td>4.4</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 1 Vector, 0x00000000000103ec>\n",
+       "       num\n",
+       "  <double>\n",
+       "1      2.2\n",
+       "2      3.3\n",
+       "3      4.4\n"
+      ]
+     },
+     "execution_count": 206,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice_by(:label) { \"b\"..\"d\" }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 207,
+   "id": "366587f4-0fde-4204-bdea-c3dc5c58b155",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 1 vector> <table><tr><th>num</th></tr><tr><td>3.3</td></tr><tr><td>2.2</td></tr><tr><td>5.5</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 1 Vector, 0x0000000000010400>\n",
+       "       num\n",
+       "  <double>\n",
+       "1      3.3\n",
+       "2      2.2\n",
+       "3      5.5\n"
+      ]
+     },
+     "execution_count": 207,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice_by(:label) { [\"c\", \"b\", \"e\"] }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c074498f-6e27-45e3-9f9a-f1c0d92fb742",
+   "metadata": {},
+   "source": [
+    "If the option `keep_key:` set to `true`, index label column is preserved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 208,
+   "id": "115b01f9-3722-4a2e-a6d0-7feadb058659",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>label</th><th>num</th></tr><tr><td>b</td><td>2.2</td></tr><tr><td>c</td><td>3.3</td></tr><tr><td>d</td><td>4.4</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000010414>\n",
+       "  label         num\n",
+       "  <string> <double>\n",
+       "1 b             2.2\n",
+       "2 c             3.3\n",
+       "3 d             4.4\n"
+      ]
+     },
+     "execution_count": 208,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice_by(:label, keep_key: true) { \"b\"..\"d\" }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8285cb78-5ef5-4fd4-baa1-d862f92418d5",
+   "metadata": {},
+   "source": [
+    "## 67. Simpson's paradox in COVID-19 data\n",
+    "\n",
+    "https://www.rdocumentation.org/packages/openintro/versions/2.3.0/topics/simpsons_paradox_covid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 209,
+   "id": "47e2d348-6a36-4dfb-8697-959ef1442c11",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <268166 x 3 vectors> <table><tr><th>age_group</th><th>vaccine_status</th><th>outcome</th></tr><tr><td>under 50</td><td>vaccinated</td><td>death</td></tr><tr><td>under 50</td><td>vaccinated</td><td>death</td></tr><tr><td>under 50</td><td>vaccinated</td><td>death</td></tr><tr><td>under 50</td><td>vaccinated</td><td>death</td></tr><tr><td colspan='3'>&#8942;</td></tr><tr><td>50 +</td><td>unvaccinated</td><td>survived</td></tr><tr><td>50 +</td><td>unvaccinated</td><td>survived</td></tr><tr><td>50 +</td><td>unvaccinated</td><td>survived</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 268166 x 3 Vectors, 0x0000000000010428>\n",
+       "       age_group vaccine_status outcome\n",
+       "       <string>  <string>       <string>\n",
+       "     1 under 50  vaccinated     death\n",
+       "     2 under 50  vaccinated     death\n",
+       "     3 under 50  vaccinated     death\n",
+       "     4 under 50  vaccinated     death\n",
+       "     5 under 50  vaccinated     death\n",
+       "     : :         :              :\n",
+       "268164 50 +      unvaccinated   survived\n",
+       "268165 50 +      unvaccinated   survived\n",
+       "268166 50 +      unvaccinated   survived\n"
+      ]
+     },
+     "execution_count": 209,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "require 'datasets-arrow'\n",
+    "\n",
+    "ds = Datasets::Rdatasets.new('openintro', 'simpsons_paradox_covid')\n",
+    "df = RedAmber::DataFrame.new(ds.to_arrow)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d28b955-a57e-42fb-ae2f-647ee760ad47",
+   "metadata": {},
+   "source": [
+    "Create group and count by vaccine status and outcome."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 210,
+   "id": "1b5d9c45-a749-4e04-9f8a-5eeb0652771b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <4 x 3 vectors> <table><tr><th>vaccine_status</th><th>outcome</th><th>count(age_group)</th></tr><tr><td>vaccinated</td><td>death</td><td>481</td></tr><tr><td>unvaccinated</td><td>death</td><td>253</td></tr><tr><td>vaccinated</td><td>survived</td><td>116633</td></tr><tr><td>unvaccinated</td><td>survived</td><td>150799</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000001043c>\n",
+       "  vaccine_status outcome  count(age_group)\n",
+       "  <string>       <string>          <int64>\n",
+       "1 vaccinated     death                 481\n",
+       "2 unvaccinated   death                 253\n",
+       "3 vaccinated     survived           116633\n",
+       "4 unvaccinated   survived           150799\n"
+      ]
+     },
+     "execution_count": 210,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "count = df.group(:vaccine_status, :outcome).count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b6f501-f795-4fbf-b135-17609c5faebb",
+   "metadata": {},
+   "source": [
+    "Reshape to human readable wide table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 211,
+   "id": "fcec849e-4144-4035-9ce6-45d4bc124f11",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 3 vectors> <table><tr><th>outcome</th><th>vaccinated</th><th>unvaccinated</th></tr><tr><td>death</td><td>481</td><td>253</td></tr><tr><td>survived</td><td>116633</td><td>150799</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000010450>\n",
+       "  outcome  vaccinated unvaccinated\n",
+       "  <string>   <uint32>     <uint32>\n",
+       "1 death           481          253\n",
+       "2 survived     116633       150799\n"
+      ]
+     },
+     "execution_count": 211,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_count = count.to_wide(name: :vaccine_status, value: :\"count(age_group)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caccb2cc-64a3-4b89-b604-eca4780c3c52",
+   "metadata": {},
+   "source": [
+    "Compute death or survived ratio for vaccine status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 212,
+   "id": "de42a142-38f5-426b-b9ed-706dba19015c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 5 vectors> <table><tr><th>outcome</th><th>vaccinated</th><th>unvaccinated</th><th>vaccinated_%</th><th>unvaccinated_%</th></tr><tr><td>death</td><td>481</td><td>253</td><td>0.4107109312294004</td><td>0.167491989513545</td></tr><tr><td>survived</td><td>116633</td><td>150799</td><td>99.5892890687706</td><td>99.83250801048645</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 5 Vectors, 0x0000000000010464>\n",
+       "  outcome  vaccinated unvaccinated vaccinated_% unvaccinated_%\n",
+       "  <string>   <uint32>     <uint32>     <double>       <double>\n",
+       "1 death           481          253         0.41           0.17\n",
+       "2 survived     116633       150799        99.59          99.83\n"
+      ]
+     },
+     "execution_count": 212,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_count.assign do\n",
+    "  {\n",
+    "    \"vaccinated_%\": 100.0 * vaccinated / vaccinated.sum,\n",
+    "    \"unvaccinated_%\": 100.0 * unvaccinated / unvaccinated.sum\n",
+    "  }\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a18599a7-a21e-45a5-aa55-0170414ba3d0",
+   "metadata": {},
+   "source": [
+    "Death ratio for vaccinated is higher than unvaccinated. Is it true?\n",
+    "\n",
+    "Next, do the same thing above for each age group. Temporally create methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 213,
+   "id": "296b4570-7746-4444-8c0a-3bc4a7bdf929",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       ":make_covid_table"
+      ]
+     },
+     "execution_count": 213,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def make_covid_table(df)\n",
+    "  df.group(:vaccine_status, :outcome)\n",
+    "    .count\n",
+    "    .to_wide(name: :vaccine_status, value: :\"count(age_group)\")\n",
+    "    .assign do\n",
+    "      {\n",
+    "        \"vaccinated_%\": (100.0 * vaccinated / vaccinated.sum).round(n_digits: 3),\n",
+    "        \"unvaccinated_%\": (100.0 * unvaccinated / unvaccinated.sum).round(n_digits: 3)\n",
+    "      }\n",
+    "     end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 214,
+   "id": "0443fe4f-e023-4496-9538-3d8772debfb6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 5 vectors> <table><tr><th>outcome</th><th>vaccinated</th><th>unvaccinated</th><th>vaccinated_%</th><th>unvaccinated_%</th></tr><tr><td>death</td><td>21</td><td>48</td><td>0.023</td><td>0.033</td></tr><tr><td>survived</td><td>89786</td><td>147564</td><td>99.977</td><td>99.967</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 5 Vectors, 0x0000000000010478>\n",
+       "  outcome  vaccinated unvaccinated vaccinated_% unvaccinated_%\n",
+       "  <string>   <uint32>     <uint32>     <double>       <double>\n",
+       "1 death            21           48         0.02           0.03\n",
+       "2 survived      89786       147564        99.98          99.97\n"
+      ]
+     },
+     "execution_count": 214,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# under 50\n",
+    "make_covid_table(df[df[:age_group] == \"under 50\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "id": "3c451727-5d61-495d-aae9-fb8486b6067f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 5 vectors> <table><tr><th>outcome</th><th>vaccinated</th><th>unvaccinated</th><th>vaccinated_%</th><th>unvaccinated_%</th></tr><tr><td>death</td><td>460</td><td>205</td><td>1.685</td><td>5.959</td></tr><tr><td>survived</td><td>26847</td><td>3235</td><td>98.315</td><td>94.041</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 5 Vectors, 0x000000000001048c>\n",
+       "  outcome  vaccinated unvaccinated vaccinated_% unvaccinated_%\n",
+       "  <string>   <uint16>     <uint16>     <double>       <double>\n",
+       "1 death           460          205         1.69           5.96\n",
+       "2 survived      26847         3235        98.32          94.04\n"
+      ]
+     },
+     "execution_count": 215,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 50 +\n",
+    "make_covid_table(df[df[:age_group] == \"50 +\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78c3c909-5abf-4989-bd27-e86543a14431",
+   "metadata": {},
+   "source": [
+    "Death ratio for vaccinated is lower than unvaccinated for grouped subset by age. This is an exaple of \"Simpson's paradox\" ."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "184a5b21-dabd-4428-84d4-aa3e3f8d4666",
+   "metadata": {},
+   "source": [
+    "## 68. Clean up dirty data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 216,
+   "id": "3f34f465-7cdc-4bea-bffc-1ba2f741820d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <8 x 2 vectors> <table><tr><th>height</th><th>weight</th></tr><tr><td>154.9</td><td>52.2</td></tr><tr><td>156.8cm</td><td>51.1kg</td></tr><tr><td>152</td><td>49</td></tr><tr><td>148.5cm</td><td>45.4kg</td></tr><tr><td>155cm</td><td></td></tr><tr><td></td><td>49.9kg</td></tr><tr><td>1.58m</td><td>49.8kg</td></tr><tr><td>166.8cm</td><td>53.6kg</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 8 x 2 Vectors, 0x00000000000104a0>\n",
+       "  height   weight\n",
+       "  <string> <string>\n",
+       "1 154.9    52.2\n",
+       "2 156.8cm  51.1kg\n",
+       "3 152      49\n",
+       "4 148.5cm  45.4kg\n",
+       "5 155cm\n",
+       "6          49.9kg\n",
+       "7 1.58m    49.8kg\n",
+       "8 166.8cm  53.6kg\n"
+      ]
+     },
+     "execution_count": 216,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = RedAmber::DataFrame.load(\"../test/entity/dirty_data.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7704f5e-8e8d-439c-bbd5-535d6e9f8911",
+   "metadata": {},
+   "source": [
+    "It was loaded as String datatypes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 217,
+   "id": "e7abb6f9-8ca3-4868-aa0a-80f721475235",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{:height=>:string, :weight=>:string}"
+      ]
+     },
+     "execution_count": 217,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.schema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7bc2ef6-7d08-4d65-8439-b02fb9c6e5dc",
+   "metadata": {},
+   "source": [
+    "First for the `:weight` column. Replacing \"\" to NaN causes casting to Float."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 218,
+   "id": "6435e95f-db41-4d26-84bd-4880de3fbd32",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <8 x 2 vectors> <table><tr><th>height</th><th>weight</th></tr><tr><td>154.9</td><td>52.2</td></tr><tr><td>156.8cm</td><td>51.1</td></tr><tr><td>152</td><td>49.0</td></tr><tr><td>148.5cm</td><td>45.4</td></tr><tr><td>155cm</td><td>NaN</td></tr><tr><td></td><td>49.9</td></tr><tr><td>1.58m</td><td>49.8</td></tr><tr><td>166.8cm</td><td>53.6</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 8 x 2 Vectors, 0x00000000000104b4>\n",
+       "  height     weight\n",
+       "  <string> <double>\n",
+       "1 154.9        52.2\n",
+       "2 156.8cm      51.1\n",
+       "3 152          49.0\n",
+       "4 148.5cm      45.4\n",
+       "5 155cm         NaN\n",
+       "6              49.9\n",
+       "7 1.58m        49.8\n",
+       "8 166.8cm      53.6\n"
+      ]
+     },
+     "execution_count": 218,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.assign do\n",
+    "  {\n",
+    "    weight: weight.replace(weight == \"\", Float::NAN)\n",
+    "  }\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcc1cd2b-7ff1-4e64-a6a9-0026209455cb",
+   "metadata": {},
+   "source": [
+    "Apply same conversion for `:height` followed by unit conversion by `if_else`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 219,
+   "id": "c88379f4-b063-42e9-8f76-676f364a79af",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <8 x 2 vectors> <table><tr><th>height</th><th>weight</th></tr><tr><td>154.9</td><td>52.2</td></tr><tr><td>156.8</td><td>51.1</td></tr><tr><td>152.0</td><td>49.0</td></tr><tr><td>148.5</td><td>45.4</td></tr><tr><td>155.0</td><td>NaN</td></tr><tr><td>NaN</td><td>49.9</td></tr><tr><td>158.0</td><td>49.8</td></tr><tr><td>166.8</td><td>53.6</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 8 x 2 Vectors, 0x00000000000104c8>\n",
+       "    height   weight\n",
+       "  <double> <double>\n",
+       "1    154.9     52.2\n",
+       "2    156.8     51.1\n",
+       "3    152.0     49.0\n",
+       "4    148.5     45.4\n",
+       "5    155.0      NaN\n",
+       "6      NaN     49.9\n",
+       "7    158.0     49.8\n",
+       "8    166.8     53.6\n"
+      ]
+     },
+     "execution_count": 219,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = df.assign do\n",
+    "  {\n",
+    "    weight: weight.replace(weight == '', Float::NAN),\n",
+    "    height: height.replace(height == '', Float::NAN)\n",
+    "                  .then { |h| (h < 10).if_else(h * 100, h) }\n",
+    "  }\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f16dc4c-2ecd-4f36-b7ba-8a05487b1a26",
+   "metadata": {},
+   "source": [
+    "We got clean data, then compute BMI as a new column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 220,
+   "id": "bb061dab-008c-431c-9f7d-c74aa33e5f5a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <8 x 3 vectors> <table><tr><th>height</th><th>weight</th><th>BMI</th></tr><tr><td>154.9</td><td>52.2</td><td>21.8</td></tr><tr><td>156.8</td><td>51.1</td><td>20.8</td></tr><tr><td>152.0</td><td>49.0</td><td>21.2</td></tr><tr><td>148.5</td><td>45.4</td><td>20.6</td></tr><tr><td>155.0</td><td>NaN</td><td>NaN</td></tr><tr><td>NaN</td><td>49.9</td><td>NaN</td></tr><tr><td>158.0</td><td>49.8</td><td>19.9</td></tr><tr><td>166.8</td><td>53.6</td><td>19.3</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 8 x 3 Vectors, 0x00000000000104dc>\n",
+       "    height   weight      BMI\n",
+       "  <double> <double> <double>\n",
+       "1    154.9     52.2     21.8\n",
+       "2    156.8     51.1     20.8\n",
+       "3    152.0     49.0     21.2\n",
+       "4    148.5     45.4     20.6\n",
+       "5    155.0      NaN      NaN\n",
+       "6      NaN     49.9      NaN\n",
+       "7    158.0     49.8     19.9\n",
+       "8    166.8     53.6     19.3\n"
+      ]
+     },
+     "execution_count": 220,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.assign(:BMI) { (weight / height ** 2 * 10000).round(n_digits: 1) }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fe6cc1a-530d-4883-8641-7aebd97ebd16",
+   "metadata": {},
+   "source": [
+    "## 69. From the Pandas cookbook (Multiindexing)\n",
+    "\n",
+    "https://pandas.pydata.org/docs/user_guide/cookbook.html#multiindexing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a451139d-9b7a-4cbd-b1f1-4b99ac6f81b8",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Efficiently and dynamically creating new columns using applymap\n",
+    "\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"row\": [0, 1, 2],\n",
+    "        \"One_X\": [1.1, 1.1, 1.1],\n",
+    "        \"One_Y\": [1.2, 1.2, 1.2],\n",
+    "        \"Two_X\": [1.11, 1.11, 1.11],\n",
+    "        \"Two_Y\": [1.22, 1.22, 1.22],\n",
+    "    }\n",
+    ")\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "   row  One_X  One_Y  Two_X  Two_Y\n",
+    "0    0    1.1    1.2   1.11   1.22\n",
+    "1    1    1.1    1.2   1.11   1.22\n",
+    "2    2    1.1    1.2   1.11   1.22\n",
+    "\n",
+    "# As Labelled Index\n",
+    "df = df.set_index(\"row\")\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "     One_X  One_Y  Two_X  Two_Y\n",
+    "row                            \n",
+    "0      1.1    1.2   1.11   1.22\n",
+    "1      1.1    1.2   1.11   1.22\n",
+    "2      1.1    1.2   1.11   1.22\n",
+    "\n",
+    "# With Hierarchical Columns\n",
+    "df.columns = pd.MultiIndex.from_tuples([tuple(c.split(\"_\")) for c in df.columns])\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "     One        Two      \n",
+    "       X    Y     X     Y\n",
+    "row                      \n",
+    "0    1.1  1.2  1.11  1.22\n",
+    "1    1.1  1.2  1.11  1.22\n",
+    "2    1.1  1.2  1.11  1.22\n",
+    "\n",
+    "# Now stack & Reset\n",
+    "df = df.stack(0).reset_index(1)\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "    level_1     X     Y\n",
+    "row                    \n",
+    "0       One  1.10  1.20\n",
+    "0       Two  1.11  1.22\n",
+    "1       One  1.10  1.20\n",
+    "1       Two  1.11  1.22\n",
+    "2       One  1.10  1.20\n",
+    "2       Two  1.11  1.22\n",
+    "\n",
+    "# And fix the labels (Notice the label 'level_1' got added automatically)\n",
+    "df.columns = [\"Sample\", \"All_X\", \"All_Y\"]\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "    Sample  All_X  All_Y\n",
+    "row                     \n",
+    "0      One   1.10   1.20\n",
+    "0      Two   1.11   1.22\n",
+    "1      One   1.10   1.20\n",
+    "1      Two   1.11   1.22\n",
+    "2      One   1.10   1.20\n",
+    "2      Two   1.11   1.22\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6af6de4e-3875-4e05-8642-20d07bf3a363",
+   "metadata": {},
+   "source": [
+    "This is a tentative example. This work may be refined by the coming feature such as splitting column and combining DataFrames."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 221,
+   "id": "1193c48a-528b-4e22-a8f7-24dba63e3fa7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 5 vectors> <table><tr><th>row</th><th>One_X</th><th>One_Y</th><th>Two_X</th><th>Two_Y</th></tr><tr><td>0</td><td>1.1</td><td>1.2</td><td>1.11</td><td>1.22</td></tr><tr><td>1</td><td>1.1</td><td>1.2</td><td>1.11</td><td>1.22</td></tr><tr><td>2</td><td>1.1</td><td>1.2</td><td>1.11</td><td>1.22</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 5 Vectors, 0x00000000000104f0>\n",
+       "      row    One_X    One_Y    Two_X    Two_Y\n",
+       "  <uint8> <double> <double> <double> <double>\n",
+       "1       0      1.1      1.2     1.11     1.22\n",
+       "2       1      1.1      1.2     1.11     1.22\n",
+       "3       2      1.1      1.2     1.11     1.22\n"
+      ]
+     },
+     "execution_count": 221,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = RedAmber::DataFrame.new(\n",
+    "        \"row\": [0, 1, 2],\n",
+    "        \"One_X\": [1.1, 1.1, 1.1],\n",
+    "        \"One_Y\": [1.2, 1.2, 1.2],\n",
+    "        \"Two_X\": [1.11, 1.11, 1.11],\n",
+    "        \"Two_Y\": [1.22, 1.22, 1.22],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 222,
+   "id": "9a9bcbd1-112f-4e58-b065-90fec7270a0d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <6 x 3 vectors> <table><tr><th>row</th><th>Sample</th><th>All_X</th></tr><tr><td>0</td><td>One_X</td><td>1.1</td></tr><tr><td>0</td><td>Two_X</td><td>1.11</td></tr><tr><td>1</td><td>One_X</td><td>1.1</td></tr><tr><td>1</td><td>Two_X</td><td>1.11</td></tr><tr><td>2</td><td>One_X</td><td>1.1</td></tr><tr><td>2</td><td>Two_X</td><td>1.11</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 6 x 3 Vectors, 0x0000000000010504>\n",
+       "      row Sample          All_X\n",
+       "  <uint8> <dictionary> <double>\n",
+       "1       0 One_X             1.1\n",
+       "2       0 Two_X            1.11\n",
+       "3       1 One_X             1.1\n",
+       "4       1 Two_X            1.11\n",
+       "5       2 One_X             1.1\n",
+       "6       2 Two_X            1.11\n"
+      ]
+     },
+     "execution_count": 222,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = df.pick(:row, :One_X, :Two_X)\n",
+    "  .to_long(:row, name: :Sample, value: :All_X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 223,
+   "id": "949e64a9-5f45-481b-b4b4-dc3bc4da4326",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <6 x 3 vectors> <table><tr><th>row</th><th>Sample</th><th>All_Y</th></tr><tr><td>0</td><td>One_Y</td><td>1.2</td></tr><tr><td>0</td><td>Two_Y</td><td>1.22</td></tr><tr><td>1</td><td>One_Y</td><td>1.2</td></tr><tr><td>1</td><td>Two_Y</td><td>1.22</td></tr><tr><td>2</td><td>One_Y</td><td>1.2</td></tr><tr><td>2</td><td>Two_Y</td><td>1.22</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 6 x 3 Vectors, 0x0000000000010518>\n",
+       "      row Sample          All_Y\n",
+       "  <uint8> <dictionary> <double>\n",
+       "1       0 One_Y             1.2\n",
+       "2       0 Two_Y            1.22\n",
+       "3       1 One_Y             1.2\n",
+       "4       1 Two_Y            1.22\n",
+       "5       2 One_Y             1.2\n",
+       "6       2 Two_Y            1.22\n"
+      ]
+     },
+     "execution_count": 223,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y = df.pick(:row, :One_Y, :Two_Y)\n",
+    "  .to_long(:row, name: :Sample, value: :All_Y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
+   "id": "d2f5959c-c490-45fe-bcbd-3b8325760f6d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <6 x 4 vectors> <table><tr><th>row</th><th>Sample</th><th>All_X</th><th>All_Y</th></tr><tr><td>0</td><td>One</td><td>1.1</td><td>1.2</td></tr><tr><td>0</td><td>Two</td><td>1.11</td><td>1.22</td></tr><tr><td>1</td><td>One</td><td>1.1</td><td>1.2</td></tr><tr><td>1</td><td>Two</td><td>1.11</td><td>1.22</td></tr><tr><td>2</td><td>One</td><td>1.1</td><td>1.2</td></tr><tr><td>2</td><td>Two</td><td>1.11</td><td>1.22</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 6 x 4 Vectors, 0x000000000001052c>\n",
+       "      row Sample      All_X    All_Y\n",
+       "  <uint8> <string> <double> <double>\n",
+       "1       0 One           1.1      1.2\n",
+       "2       0 Two          1.11     1.22\n",
+       "3       1 One           1.1      1.2\n",
+       "4       1 Two          1.11     1.22\n",
+       "5       2 One           1.1      1.2\n",
+       "6       2 Two          1.11     1.22\n"
+      ]
+     },
+     "execution_count": 224,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x.pick(:row)\n",
+    " .assign [\n",
+    "   [:Sample, x[:Sample].each.map { |x| x.split(\"_\").first }],\n",
+    "   [:All_X, x[:All_X]],\n",
+    "   [:All_Y, y[:All_Y]]\n",
+    " ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e65c417-692c-4145-96dd-deef12f46ed4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 70. From the Pandas cookbook (Arithmetic)\n",
+    "\n",
+    "https://pandas.pydata.org/docs/user_guide/cookbook.html#arithmetic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47c3ac27-37f4-4e6b-a5f7-95d818e21cdc",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "cols = pd.MultiIndex.from_tuples(\n",
+    "    [(x, y) for x in [\"A\", \"B\", \"C\"] for y in [\"O\", \"I\"]]\n",
+    ")\n",
+    "\n",
+    "df = pd.DataFrame(np.random.randn(2, 6), index=[\"n\", \"m\"], columns=cols)\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "          A                   B                   C          \n",
+    "          O         I         O         I         O         I\n",
+    "n  0.469112 -0.282863 -1.509059 -1.135632  1.212112 -0.173215\n",
+    "m  0.119209 -1.044236 -0.861849 -2.104569 -0.494929  1.071804\n",
+    "\n",
+    "df = df.div(df[\"C\"], level=1)\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "          A                   B              C     \n",
+    "          O         I         O         I    O    I\n",
+    "n  0.387021  1.633022 -1.244983  6.556214  1.0  1.0\n",
+    "m -0.240860 -0.974279  1.741358 -1.963577  1.0  1.0\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56ce988f-7d7d-4bbd-8919-be3eb4242b77",
+   "metadata": {},
+   "source": [
+    "This is a tentative example. This work may be refined by the coming feature which treats multiple key header easily."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 225,
+   "id": "a9e14b16-c7d8-4539-90f9-25eb89f4789f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[-0.5812548058448793, -0.16835433970036223], [0.5868954392364965, -0.5951422503374125], [-0.8028018065626139, -0.32610562028036544], [0.28292153294248895, 1.6842676580208051], [0.9184993853758983, -0.048538359637834545], [-0.46445256370104565, -0.9921944543521136]]"
+      ]
+     },
+     "execution_count": 225,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "require \"Numo/NArray\"\n",
+    "\n",
+    "values = Numo::DFloat.new(6, 2).rand_norm.to_a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03aa2096-4411-4665-9bfc-dfedc41e75af",
+   "metadata": {},
+   "source": [
+    "For consistency with the pandas result, we will use same data of them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 226,
+   "id": "a470ced5-dadb-48cb-a43f-8161ac3df769",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[0.469112, 0.119209], [-0.282863, -1.044236], [-1.509059, -0.861849], [-1.135632, -2.104569], [1.212112, -0.494929], [-0.173215, 1.071804]]"
+      ]
+     },
+     "execution_count": 226,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "values = [\n",
+    "  [0.469112, -0.282863, -1.509059, -1.135632,  1.212112, -0.173215],\n",
+    "  [0.119209, -1.044236, -0.861849, -2.104569, -0.494929,  1.071804]\n",
+    "].transpose"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 227,
+   "id": "4288a84f-c3db-4fa7-b73e-9e21077304c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"AO\", \"AI\", \"BO\", \"BI\", \"CO\", \"CI\"]"
+      ]
+     },
+     "execution_count": 227,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "keys = %w[A B C].product(%w[O I]).map(&:join)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 228,
+   "id": "a1199c40-1508-4573-a427-cd7f7d580701",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 7 vectors> <table><tr><th>index</th><th>AO</th><th>AI</th><th>BO</th><th>BI</th><th>CO</th><th>CI</th></tr><tr><td>n</td><td>0.469112</td><td>-0.282863</td><td>-1.509059</td><td>-1.135632</td><td>1.212112</td><td>-0.173215</td></tr><tr><td>m</td><td>0.119209</td><td>-1.044236</td><td>-0.861849</td><td>-2.104569</td><td>-0.494929</td><td>1.071804</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 7 Vectors, 0x0000000000010540>\n",
+       "  index          AO       AI       BO       BI       CO       CI\n",
+       "  <string> <double> <double> <double> <double> <double> <double>\n",
+       "1 n            0.47    -0.28    -1.51    -1.14     1.21    -0.17\n",
+       "2 m            0.12    -1.04    -0.86     -2.1    -0.49     1.07\n"
+      ]
+     },
+     "execution_count": 228,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = RedAmber::DataFrame.new(index: %w[n m])\n",
+    "                        .assign(*keys) { values }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 229,
+   "id": "bab052e6-5b26-40ba-95b6-c87ac444cb80",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 7 vectors> <table><tr><th>index</th><th>AO</th><th>AI</th><th>BO</th><th>BI</th><th>CO</th><th>CI</th></tr><tr><td>n</td><td>0.38702034135459423</td><td>1.6330167710648613</td><td>-1.24498313687184</td><td>6.556198943509511</td><td>1.0</td><td>1.0</td></tr><tr><td>m</td><td>-0.24086081033845258</td><td>-0.9742788793473434</td><td>1.7413588615740843</td><td>-1.96357636284246</td><td>1.0</td><td>1.0</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 7 Vectors, 0x0000000000010554>\n",
+       "  index          AO       AI       BO       BI       CO       CI\n",
+       "  <string> <double> <double> <double> <double> <double> <double>\n",
+       "1 n            0.39     1.63    -1.24     6.56      1.0      1.0\n",
+       "2 m           -0.24    -0.97     1.74    -1.96      1.0      1.0\n"
+      ]
+     },
+     "execution_count": 229,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.assign do\n",
+    "  assigner = {}\n",
+    "  %w[A B C].each do |abc|\n",
+    "    %w[O I].each do |oi|\n",
+    "      key = \"#{abc}#{oi}\".to_sym\n",
+    "      assigner[key] = v(key) / v(\"C#{oi}\".to_sym)\n",
+    "    end\n",
+    "  end\n",
+    "  assigner\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7b483a4-5d68-492f-836f-1105420d859f",
+   "metadata": {},
+   "source": [
+    "## 71. From the Pandas cookbook (Slicing)\n",
+    "\n",
+    "https://pandas.pydata.org/docs/user_guide/cookbook.html#slicing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "282fe127-5b0b-45a6-9f04-0309495b0d7a",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "coords = [(\"AA\", \"one\"), (\"AA\", \"six\"), (\"BB\", \"one\"), (\"BB\", \"two\"), (\"BB\", \"six\")]\n",
+    "index = pd.MultiIndex.from_tuples(coords)\n",
+    "df = pd.DataFrame([11, 22, 33, 44, 55], index, [\"MyData\"])\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "        MyData\n",
+    "AA one      11\n",
+    "   six      22\n",
+    "BB one      33\n",
+    "   two      44\n",
+    "   six      55\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 230,
+   "id": "24de5e41-c775-472d-ab93-24ef9981febe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <5 x 3 vectors> <table><tr><th>label1</th><th>label2</th><th>MyData</th></tr><tr><td>AA</td><td>one</td><td>11</td></tr><tr><td>AA</td><td>six</td><td>22</td></tr><tr><td>BB</td><td>one</td><td>33</td></tr><tr><td>BB</td><td>two</td><td>44</td></tr><tr><td>BB</td><td>six</td><td>55</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 5 x 3 Vectors, 0x0000000000010568>\n",
+       "  label1   label2    MyData\n",
+       "  <string> <string> <uint8>\n",
+       "1 AA       one           11\n",
+       "2 AA       six           22\n",
+       "3 BB       one           33\n",
+       "4 BB       two           44\n",
+       "5 BB       six           55\n"
+      ]
+     },
+     "execution_count": 230,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "coords = [[\"AA\", \"one\"], [\"AA\", \"six\"], [\"BB\", \"one\"], [\"BB\", \"two\"], [\"BB\", \"six\"]].transpose\n",
+    "df = RedAmber::DataFrame.new(MyData: [11, 22, 33, 44, 55])\n",
+    "                        .assign_left(:label1, :label2) { coords }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5876deb1-8574-48c0-af6a-00447ba5ebe7",
+   "metadata": {},
+   "source": [
+    "To take the cross section of the 1st level and 1st axis the index:\n",
+    "\n",
+    "```python\n",
+    "# by Python Pandas\n",
+    "# Note : level and axis are optional, and default to zero\n",
+    "df.xs(\"BB\", level=0, axis=0)\n",
+    "\n",
+    "# =>\n",
+    "     MyData\n",
+    "one      33\n",
+    "two      44\n",
+    "six      55\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 231,
+   "id": "6941b8ef-6e40-4103-ab93-bf370d80ebf8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 2 vectors> <table><tr><th>label2</th><th>MyData</th></tr><tr><td>one</td><td>33</td></tr><tr><td>two</td><td>44</td></tr><tr><td>six</td><td>55</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000001057c>\n",
+       "  label2    MyData\n",
+       "  <string> <uint8>\n",
+       "1 one           33\n",
+       "2 two           44\n",
+       "3 six           55\n"
+      ]
+     },
+     "execution_count": 231,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice { label1 == \"BB\" }.drop(:label1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf62d474-5a15-4af3-a0fc-99455bf0a205",
+   "metadata": {},
+   "source": [
+    "…and now the 2nd level of the 1st axis.\n",
+    "\n",
+    "```python\n",
+    "# by Python Pandas\n",
+    "df.xs(\"six\", level=1, axis=0)\n",
+    "\n",
+    "# =>\n",
+    "    MyData\n",
+    "AA      22\n",
+    "BB      55\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 232,
+   "id": "9968d610-cadc-4b0a-8364-8c95e6ed6b0d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 2 vectors> <table><tr><th>label1</th><th>MyData</th></tr><tr><td>AA</td><td>22</td></tr><tr><td>BB</td><td>55</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 2 Vectors, 0x0000000000010590>\n",
+       "  label1    MyData\n",
+       "  <string> <uint8>\n",
+       "1 AA            22\n",
+       "2 BB            55\n"
+      ]
+     },
+     "execution_count": 232,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice { label2 == \"six\" }.drop(:label2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7d9d33d-6959-492d-b24f-9952b36cf9f6",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "import itertools\n",
+    "\n",
+    "index = list(itertools.product([\"Ada\", \"Quinn\", \"Violet\"], [\"Comp\", \"Math\", \"Sci\"]))\n",
+    "headr = list(itertools.product([\"Exams\", \"Labs\"], [\"I\", \"II\"]))\n",
+    "indx = pd.MultiIndex.from_tuples(index, names=[\"Student\", \"Course\"])\n",
+    "cols = pd.MultiIndex.from_tuples(headr)  # Notice these are un-named\n",
+    "data = [[70 + x + y + (x * y) % 3 for x in range(4)] for y in range(9)]\n",
+    "df = pd.DataFrame(data, indx, cols)\n",
+    "df\n",
+    "\n",
+    "# =>\n",
+    "               Exams     Labs    \n",
+    "                   I  II    I  II\n",
+    "Student Course                   \n",
+    "Ada     Comp      70  71   72  73\n",
+    "        Math      71  73   75  74\n",
+    "        Sci       72  75   75  75\n",
+    "Quinn   Comp      73  74   75  76\n",
+    "        Math      74  76   78  77\n",
+    "        Sci       75  78   78  78\n",
+    "Violet  Comp      76  77   78  79\n",
+    "        Math      77  79   81  80\n",
+    "        Sci       78  81   81  81\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 233,
+   "id": "78e5753a-8d9c-4132-9671-6b09b3a06a20",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <9 x 6 vectors> <table><tr><th>Student</th><th>Course</th><th>Exams/I</th><th>Exams/II</th><th>Labs/I</th><th>Labs/II</th></tr><tr><td>Ada</td><td>Comp</td><td>70</td><td>71</td><td>72</td><td>73</td></tr><tr><td>Ada</td><td>Math</td><td>71</td><td>73</td><td>75</td><td>74</td></tr><tr><td>Ada</td><td>Sci</td><td>72</td><td>75</td><td>75</td><td>75</td></tr><tr><td>Quinn</td><td>Comp</td><td>73</td><td>74</td><td>75</td><td>76</td></tr><tr><td colspan='6'>&#8942;</td></tr><tr><td>Violet</td><td>Comp</td><td>76</td><td>77</td><td>78</td><td>79</td></tr><tr><td>Violet</td><td>Math</td><td>77</td><td>79</td><td>81</td><td>80</td></tr><tr><td>Violet</td><td>Sci</td><td>78</td><td>81</td><td>81</td><td>81</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 9 x 6 Vectors, 0x00000000000105a4>\n",
+       "  Student  Course   Exams/I Exams/II  Labs/I Labs/II\n",
+       "  <string> <string> <uint8>  <uint8> <uint8> <uint8>\n",
+       "1 Ada      Comp          70       71      72      73\n",
+       "2 Ada      Math          71       73      75      74\n",
+       "3 Ada      Sci           72       75      75      75\n",
+       "4 Quinn    Comp          73       74      75      76\n",
+       "5 Quinn    Math          74       76      78      77\n",
+       "6 Quinn    Sci           75       78      78      78\n",
+       "7 Violet   Comp          76       77      78      79\n",
+       "8 Violet   Math          77       79      81      80\n",
+       "9 Violet   Sci           78       81      81      81\n"
+      ]
+     },
+     "execution_count": 233,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "indexes = %w[Ada Quinn Violet].product(%w[Comp Math Sci]).transpose\n",
+    "df = RedAmber::DataFrame.new(%w[Student Course].zip(indexes))\n",
+    "                        .assign do\n",
+    "                          assigner = {}\n",
+    "                          keys = %w[Exams Labs].product(%w[I II]).map { |a| a.join(\"/\") } \n",
+    "                          keys.each.with_index do |key, x|\n",
+    "                            assigner[key] = (0...9).map { |y| 70 + x + y + (x * y) % 3 }\n",
+    "                          end\n",
+    "                          assigner\n",
+    "                        end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fc29a2d-fbe8-42f9-83dc-1ddfb7563ce0",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "All = slice(None)\n",
+    "\n",
+    "df.loc[\"Violet\"]\n",
+    "\n",
+    "# =>\n",
+    "       Exams     Labs    \n",
+    "           I  II    I  II\n",
+    "Course                   \n",
+    "Comp      76  77   78  79\n",
+    "Math      77  79   81  80\n",
+    "Sci       78  81   81  81\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 234,
+   "id": "1c7662a7-3208-40ee-9f64-235c68ef57b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 5 vectors> <table><tr><th>Course</th><th>Exams/I</th><th>Exams/II</th><th>Labs/I</th><th>Labs/II</th></tr><tr><td>Comp</td><td>76</td><td>77</td><td>78</td><td>79</td></tr><tr><td>Math</td><td>77</td><td>79</td><td>81</td><td>80</td></tr><tr><td>Sci</td><td>78</td><td>81</td><td>81</td><td>81</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 5 Vectors, 0x00000000000105b8>\n",
+       "  Course   Exams/I Exams/II  Labs/I Labs/II\n",
+       "  <string> <uint8>  <uint8> <uint8> <uint8>\n",
+       "1 Comp          76       77      78      79\n",
+       "2 Math          77       79      81      80\n",
+       "3 Sci           78       81      81      81\n"
+      ]
+     },
+     "execution_count": 234,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice(df[:Student] == \"Violet\").drop(:Student)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af5bb6db-cf2d-4887-9d73-7da651f9a3ea",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "df.loc[(All, \"Math\"), All]\n",
+    "\n",
+    "# =>\n",
+    "               Exams     Labs    \n",
+    "                   I  II    I  II\n",
+    "Student Course                   \n",
+    "Ada     Math      71  73   75  74\n",
+    "Quinn   Math      74  76   78  77\n",
+    "Violet  Math      77  79   81  80\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "id": "28baea84-76c8-4473-b1ff-0d8f6fde2cca",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 6 vectors> <table><tr><th>Student</th><th>Course</th><th>Exams/I</th><th>Exams/II</th><th>Labs/I</th><th>Labs/II</th></tr><tr><td>Ada</td><td>Math</td><td>71</td><td>73</td><td>75</td><td>74</td></tr><tr><td>Quinn</td><td>Math</td><td>74</td><td>76</td><td>78</td><td>77</td></tr><tr><td>Violet</td><td>Math</td><td>77</td><td>79</td><td>81</td><td>80</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 6 Vectors, 0x00000000000105cc>\n",
+       "  Student  Course   Exams/I Exams/II  Labs/I Labs/II\n",
+       "  <string> <string> <uint8>  <uint8> <uint8> <uint8>\n",
+       "1 Ada      Math          71       73      75      74\n",
+       "2 Quinn    Math          74       76      78      77\n",
+       "3 Violet   Math          77       79      81      80\n"
+      ]
+     },
+     "execution_count": 235,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice(df[:Course] == \"Math\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e12bcd4f-be10-4ee4-b55e-dc57e3de9698",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "df.loc[(slice(\"Ada\", \"Quinn\"), \"Math\"), All]\n",
+    "\n",
+    "# =>\n",
+    "               Exams     Labs    \n",
+    "                   I  II    I  II\n",
+    "Student Course                   \n",
+    "Ada     Math      71  73   75  74\n",
+    "Quinn   Math      74  76   78  77\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
+   "id": "11387d5b-a470-4ebf-8260-55db8f5f829a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <2 x 6 vectors> <table><tr><th>Student</th><th>Course</th><th>Exams/I</th><th>Exams/II</th><th>Labs/I</th><th>Labs/II</th></tr><tr><td>Ada</td><td>Math</td><td>71</td><td>73</td><td>75</td><td>74</td></tr><tr><td>Quinn</td><td>Math</td><td>74</td><td>76</td><td>78</td><td>77</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 2 x 6 Vectors, 0x00000000000105e0>\n",
+       "  Student  Course   Exams/I Exams/II  Labs/I Labs/II\n",
+       "  <string> <string> <uint8>  <uint8> <uint8> <uint8>\n",
+       "1 Ada      Math          71       73      75      74\n",
+       "2 Quinn    Math          74       76      78      77\n"
+      ]
+     },
+     "execution_count": 236,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice(df[:Course] == \"Math\")\n",
+    "  .slice { (v(:Student) == \"Ada\") | (v(:Student) == \"Quinn\") }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61270946-535c-4a42-a155-a1c0ca025416",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "df.loc[(All, \"Math\"), (\"Exams\")]\n",
+    "\n",
+    "# =>\n",
+    "                 I  II\n",
+    "Student Course        \n",
+    "Ada     Math    71  73\n",
+    "Quinn   Math    74  76\n",
+    "Violet  Math    77  79\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 237,
+   "id": "7dbdd733-6cbb-48e1-ab8d-45587d455b8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>Student</th><th>Course</th><th>Exams/I</th><th>Exams/II</th></tr><tr><td>Ada</td><td>Math</td><td>71</td><td>73</td></tr><tr><td>Quinn</td><td>Math</td><td>74</td><td>76</td></tr><tr><td>Violet</td><td>Math</td><td>77</td><td>79</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x00000000000105f4>\n",
+       "  Student  Course   Exams/I Exams/II\n",
+       "  <string> <string> <uint8>  <uint8>\n",
+       "1 Ada      Math          71       73\n",
+       "2 Quinn    Math          74       76\n",
+       "3 Violet   Math          77       79\n"
+      ]
+     },
+     "execution_count": 237,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice(df[:Course] == \"Math\")\n",
+    "  .pick {\n",
+    "    [:Student, :Course].concat keys.select { |key| key.to_s.start_with?(\"Exams\") }\n",
+    "  }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54be92ae-32b8-44f8-926c-190ab7592364",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# by Python Pandas\n",
+    "df.loc[(All, \"Math\"), (All, \"II\")]\n",
+    "\n",
+    "# =>\n",
+    "               Exams Labs\n",
+    "                  II   II\n",
+    "Student Course           \n",
+    "Ada     Math      73   74\n",
+    "Quinn   Math      76   77\n",
+    "Violet  Math      79   80\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 238,
+   "id": "5323da02-4dbe-43ac-89b8-3f9de0ae25c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "RedAmber::DataFrame <3 x 4 vectors> <table><tr><th>Student</th><th>Course</th><th>Exams/II</th><th>Labs/II</th></tr><tr><td>Ada</td><td>Math</td><td>73</td><td>74</td></tr><tr><td>Quinn</td><td>Math</td><td>76</td><td>77</td></tr><tr><td>Violet</td><td>Math</td><td>79</td><td>80</td></tr></table>"
+      ],
+      "text/plain": [
+       "#<RedAmber::DataFrame : 3 x 4 Vectors, 0x0000000000010608>\n",
+       "  Student  Course   Exams/II Labs/II\n",
+       "  <string> <string>  <uint8> <uint8>\n",
+       "1 Ada      Math           73      74\n",
+       "2 Quinn    Math           76      77\n",
+       "3 Violet   Math           79      80\n"
+      ]
+     },
+     "execution_count": 238,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.slice(df[:Course] == \"Math\")\n",
+    "  .pick {\n",
+    "    [:Student, :Course].concat keys.select { |key| key.to_s.end_with?(\"II\") }\n",
+    "  }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 239,
+   "id": "e89cde6e-9c79-4dc6-856e-d44a6cc1025c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 2, 3, [4, 5]]"
+      ]
+     },
+     "execution_count": 239,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[1,2,3] << [4,5]"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Ruby 3.1.2",
+   "display_name": "Ruby 3.1.1",
    "language": "ruby",
    "name": "ruby"
   },
@@ -6775,7 +8971,7 @@
    "file_extension": ".rb",
    "mimetype": "application/x-ruby",
    "name": "ruby",
-   "version": "3.1.2"
+   "version": "3.1.1"
   }
  },
  "nbformat": 4,

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.2.1-HEAD'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
## Release note for v0.2.1

### Bug fixes

  - Fix `Vector#each` with block (#66)
    `Vector#each` will return value of each element with block.

  - Fix table format at size == 9 (#67)

  - Fix to support Vector in `DataFrame#assign` (#77)

  - Add `assert_delta` functionality for `assert_with_NaN` (#78)

  - Fix Vector#is_in when self is chunked (#79)

  - Fix Array type error (uint/int) (#79)

### New features and improvements

  - Refine `DataFrame#indices` method (#67)
    Accepts an option start as the first one of indexes.

  - Update DataFrame reshaping methods (#73)

    - Change default option value of DataFrame reshaping
      Change the default key name to` :N` or `:V`, and option name has unified.

    - Change the order of import_cars example

  - Add `DataFrame#method_missing` to get column vector by method (#75)

    - Add `DataFrame#method_missing` to get column (#75)
      When a key name is simple enough to use as a method name,
      DataFrame may have a method of it and return a Vector.
      It is same as `df[:number]` or `df.v(:number)` but we can write simpler in the block.

      We cannot use this for the key names like `Number`, `number.1` or `1number` 
      because these names are not able to use as a method name.

  - Accept both args and block in `DataFrame#assign` (#75)

  - Accept indices in `DataFrame#pick` and `DataFrame#drop` (#76)

  - Add `DataFrame#slice_by` method (#77)
  
  - Add new Vector functions (#78)

    - Add inverse trigonometric function for Vector
      - `acos`
      - `asin`

    - Add logarithmic function for Vector
      - `ln`
      - `log10`
      - `log1p`
      - `log2`

    - Add binary function `Vector#logb`

  - Docker image and Jupyter Notebook (Thanks to @mrkn)
    - Add link to RubyData in README
    - Add link to interactive README by Binder

  - Update Jupyter Notebook `71 examples of RedAmber`