### PR TITLE
Add vector map

### DIFF
--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -61,7 +61,7 @@ Class `RedAmber::Vector` represents a series of data in the DataFrame.
 
 ### `type_class`
 
-### `each`
+### `each`, `map`, `collect`
 
   If block is not given, returns Enumerator.
 

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -106,7 +106,7 @@ array[indices]
 ["A", "E", "A"]
 ```
 
-### `filter(booleans)`, `[](booleans)`
+### `filter(booleans)`, `select(booleans)`, `[](booleans)`
 
 - Acceptable class for booleans:
   - An array of true, false, or nil
@@ -124,6 +124,7 @@ array[booleans]
 #<RedAmber::Vector(:string, size=2):0x000000000000f21c>
 ["A", "E"]
 ```
+`filter` and `select` also accepts a block.
 
 ## Functions
 

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -126,10 +126,19 @@ module RedAmber
       end
     end
 
+    def map(&block)
+      return enum_for(:map) unless block
+
+      Vector.new(to_a.map(&block))
+    end
+    alias_method :collect, :map
+
+    # undocumented
     def chunked?
       @data.is_a? Arrow::ChunkedArray
     end
 
+    # undocumented
     def n_chunks
       chunked? ? @data.n_chunks : 0
     end

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -25,7 +25,13 @@ module RedAmber
     end
 
     # TODO: support for option {null_selection_behavior: :drop}
-    def filter(*booleans)
+    def filter(*booleans, &block)
+      if block
+        raise VectorArgumentError, 'Must not specify both arguments and block.' unless booleans.empty?
+
+        booleans = [yield]
+      end
+
       booleans.flatten!
       return Vector.new([]) if booleans.empty?
 
@@ -46,6 +52,8 @@ module RedAmber
 
       filter_by_array(boolean_array) # returns sub Vector
     end
+    alias_method :select, :filter
+    alias_method :find_all, :filter
 
     #   @param indices
     #   @param booleans

--- a/test/test_vector.rb
+++ b/test/test_vector.rb
@@ -76,6 +76,14 @@ class VectorTest < Test::Unit::TestCase
       vector.each { |x| a << x }
       assert_equal expect, a
     end
+
+    test '#map' do
+      expect, _, _, array = data
+      vector = Vector.new(array)
+      assert_kind_of Enumerator, vector.map
+      assert_kind_of Vector, vector.map(&:to_s)
+      assert_equal expect.map(&:to_s), vector.map(&:to_s).to_a
+    end
   end
 
   sub_test_case('type check') do

--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -70,6 +70,13 @@ class VectorTest < Test::Unit::TestCase
     test '#filter size unmatch' do
       assert_raise(VectorArgumentError) { @string.filter([true]) } # out of lower limit
     end
+
+    test '#filter with a block' do
+      assert_raise(VectorArgumentError) { @string.filter(@booleans) { @booleans } } # with both args and a block
+      assert_equal %w[A E], @string.filter { @booleans }.to_a # primitive Array
+      assert_equal %w[A E], @string.filter { Arrow::BooleanArray.new(@booleans) }.to_a # Arrow::BooleanArray
+      assert_equal %w[A E], @string.filter { Vector.new(@booleans) }.to_a # Vector
+    end
   end
 
   sub_test_case '#[]' do


### PR DESCRIPTION
I will introduce `map` and `select` to Vector.

`map` will be a short hand of `each.map` in current code. But it will return a Vector.

`select` shares existing `filter` and it will accept block.
