### PR TITLE
Support to make a data frame from a to_arrow-responsible object

### DIFF
--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -37,6 +37,13 @@ module RedAmber
         # DataFrame.new, DataFrame.new([]), DataFrame.new({}), DataFrame.new(nil)
         #   returns empty DataFrame
         @table = Arrow::Table.new({}, [])
+      in [->(x) { x.respond_to?(:to_arrow) } => arrowable]
+        table = arrowable.to_arrow
+        unless table.is_a?(Arrow::Table)
+          raise DataFrameTypeError,
+                "to_arrow must return an Arrow::Table but #{table.class}: #{arrowable}"
+        end
+        @table = table
       in [Arrow::Table => table]
         @table = table
       in [DataFrame => dataframe]

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -56,6 +56,19 @@ class DataFrameTest < Test::Unit::TestCase
       df = DataFrame.new('': [1, 2], unnamed1: [3, 4])
       assert_equal %i[unnamed2 unnamed1], df.keys
     end
+
+    test 'new from a to_arrow-resposible object' do |(h, _)|
+      table = Arrow::Table.new(h)
+      (o = Object.new).define_singleton_method(:to_arrow) { table }
+
+      df = DataFrame.new(o)
+      assert_equal df.table, table
+    end
+
+    test 'new from a to_arrow-resposible object that returns non-Arrow::Table' do |(_, d)|
+      (o = Object.new).define_singleton_method(:to_arrow) { d }
+      assert_raise(DataFrameTypeError) { DataFrame.new(o) }
+    end
   end
 
   sub_test_case 'Properties' do


### PR DESCRIPTION
This allows us to create a data frame from a Datasets::Dataset object directly like:

```
require "red-amber"
require "datasets-arrow"

df = RedAmber::DataFrame.new(Datasets::Penguins.new)
```