### PR TITLE
Bump version up to 0.2.3-HEAD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,5 @@ group :test do
   gem 'yard'
 
   gem 'benchmark_driver'
-  gem 'red-datasets'
+  gem 'red-datasets-arrow'
 end

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gem install red_amber
 
 [RubyData Docker Stacks](https://github.com/RubyData/docker-stacks) is available as a ready-to-run Docker image containing Jupyter and useful data tools as well as RedAmber (Thanks to @mrkn).
 
-Also you can try the contents of this README interactively by [Binder](https://mybinder.org/v2/gh/heronshoes/docker-stacks/RedAmber-binder?filepath=README.ipynb). 
+Also you can try the contents of this README interactively by [Binder](https://mybinder.org/v2/gh/heronshoes/docker-stacks/RedAmber-binder?filepath=red-amber.ipynb). 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/heronshoes/docker-stacks/RedAmber-binder?filepath=red-amber.ipynb)
 
 

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.2.2'
+  VERSION = '0.2.3-HEAD'
 end


### PR DESCRIPTION
- Create 0.2.3-HEAD.
- Change development dependency `red-datasets` to `red-datasets-arrow`.
- Fix bundler link in README.

