### PR TITLE
Upgrade to Arrow 10.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,8 @@ jobs:
         wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
         sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
         sudo apt update
-        sudo apt install -y -V libarrow-dev=9.0.0-1
-        sudo apt install -y -V gir1.2-arrow-1.0=9.0.0-1
-        sudo apt install -y -V libarrow-glib-dev=9.0.0-1
+        sudo apt install -y -V libarrow-dev
+        sudo apt install -y -V libarrow-glib-dev
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :test do
   gem 'rake'
 
-  gem 'red-parquet', '~> 9.0.0'
+  gem 'red-parquet', '~> 10.0.0'
   gem 'rover-df', '~> 0.3.0'
 
   gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,6 @@ group :test do
   gem 'yard'
 
   gem 'benchmark_driver'
+  gem 'red-arrow-numo-narray'
   gem 'red-datasets-arrow'
 end

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ A simple dataframe library for Ruby.
 
 ## Requirements
 
-**(26 October 2022) [Arrow 10.0.0 has released](https://arrow.apache.org/release/10.0.0.html) but [red-arrow gem](https://rubygems.org/gems/red-arrow?locale=ja) is not released yet. I will show the temporary procedure for 9.0.0 here.**
-
 Supported Ruby version is >= 2.7.
 
 Since v0.2.0, this library uses pattern matching which is an experimental feature in 2.7 . It is usable but a warning message will be shown in 2.7 .
@@ -22,9 +20,9 @@ I recommend Ruby 3 for performance.
 
 ```ruby
 # Libraries required
-gem 'red-arrow',   '~> 9.0.0' # Requires Apache Arrow (see installation below)
+gem 'red-arrow',   '~> 10.0.0' # Requires Apache Arrow (see installation below)
 
-gem 'red-parquet', '~> 9.0.0' # Optional, if you use IO from/to parquet
+gem 'red-parquet', '~> 10.0.0' # Optional, if you use IO from/to parquet
 gem 'rover-df',    '~> 0.3.0' # Optional, if you use IO from/to Rover::DataFrame
 ```
 
@@ -32,36 +30,40 @@ gem 'rover-df',    '~> 0.3.0' # Optional, if you use IO from/to Rover::DataFrame
 
 Install requirements before you install Red Amber.
 
-- Apache Arrow GLib (~> 9.0.0)
-- Apache Parquet GLib (~> 9.0.0)  # If you use IO from/to parquet
+- Apache Arrow GLib (~> 10.0.0)
+- Apache Parquet GLib (~> 10.0.0)  # If you use IO from/to parquet
 
   See [Apache Arrow install document](https://arrow.apache.org/install/).
   
-  Minimum installation example for the latest Ubuntu is in the ['Prepare the Apache Arrow' section in ci test](https://github.com/heronshoes/red_amber/blob/master/.github/workflows/test.yml) of Red Amber.
+  - Minimum installation example for the latest Ubuntu:
+    ```
+    sudo apt update
+    sudo apt install -y -V ca-certificates lsb-release wget
+    wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+    sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+    sudo apt update
+    sudo apt install -y -V libarrow-dev
+    sudo apt install -y -V libarrow-glib-dev
+    ```
+  - On macOS, you can install Apache Arrow C++ library using Homebrew:
+    
+    ```
+    brew install apache-arrow
+    ```
 
-  ```
-        sudo apt update
-        sudo apt install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        sudo apt update
-        sudo apt install -y -V libarrow-dev=9.0.0-1
-        sudo apt install -y -V gir1.2-arrow-1.0=9.0.0-1
-        sudo apt install -y -V libarrow-glib-dev=9.0.0-1
-  ```
+    and GLib (C) package with:
 
-  Homebrew is now on Arrow 9.0.0 . 
+    ```
+    brew install apache-arrow-glib
+    ```
 
-  ```
-  $ brew info apache-arrow
-  ==> apache-arrow: stable 9.0.0 (bottled), HEAD
-  ```
-  See [Apache Arrow install document](https://arrow.apache.org/install/).
-
-Add this line to your Gemfile:
+If you prepared Apache Arrow, add this line to your Gemfile:
 
 ```ruby
+gem 'red-arrow',   '~> 10.0.0'
 gem 'red_amber'
+gem 'red-parquet', '~> 10.0.0' # Optional, if you use IO from/to parquet
+gem 'rover-df',    '~> 0.3.0' # Optional, if you use IO from/to Rover::DataFrame
 ```
 
 And then execute `bundle install` or install it yourself as `gem install red_amber`.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ Install requirements before you install Red Amber.
     brew install apache-arrow-glib
     ```
 
-If you prepared Apache Arrow, add this line to your Gemfile:
+If you prepared Apache Arrow, add these lines to your Gemfile:
 
 ```ruby
 gem 'red-arrow',   '~> 10.0.0'
 gem 'red_amber'
 gem 'red-parquet', '~> 10.0.0' # Optional, if you use IO from/to parquet
-gem 'rover-df',    '~> 0.3.0' # Optional, if you use IO from/to Rover::DataFrame
+gem 'rover-df',    '~> 0.3.0'  # Optional, if you use IO from/to Rover::DataFrame
+gem 'red-datasets-arrow'       # Optional, recommended if you use Red Datasets
+gem 'red-arrow-numo-narray'    # Optional, recommended if you use inputs from Numo::NArray
 ```
 
 And then execute `bundle install` or install it yourself as `gem install red_amber`.

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -24,6 +24,9 @@ Class `RedAmber::Vector` represents a series of data in the DataFrame.
   vector = Vector.new(1..3)
   # or
   vector = Vector.new(Arrow::Array.new([1, 2, 3])
+  # or
+  require 'arrow-numo-narray'
+  vector = Vector.new(Numo::Int8[1, 2, 3])
 
   # =>
   #<RedAmber::Vector(:uint8, size=3):0x000000000000f514>

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -39,6 +39,11 @@ module RedAmber
     end
 
     attr_reader :data
+
+    def to_arrow_array
+      @data
+    end
+
     attr_accessor :key
 
     def to_s

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -24,6 +24,8 @@ module RedAmber
             a
           in [Arrow::ChunkedArray => ca]
             ca
+          in [arrow_array_like] if arrow_array_like.respond_to?(:to_arrow_array)
+            arrow_array_like.to_arrow_array
           in [Range => r]
             Arrow::Array.new(Array(r))
           else

--- a/red_amber.gemspec
+++ b/red_amber.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'red-arrow', '~> 9.0.0'
+  spec.add_dependency 'red-arrow', '~> 10.0.0'
 
   # Development dependency has gone to the Gemfile (rubygems/bundler#7237)
 

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -206,6 +206,22 @@ class DataFrameTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'red-arrow-numo-narray' do
+    setup do
+      require 'arrow-numo-narray'
+      Numo::NArray.srand(42)
+    end
+
+    test 'new from numo-narray' do
+      assert_equal <<~EXPECTED, DataFrame.new(numo: Numo::DFloat.new(3).rand).tdr_str
+        RedAmber::DataFrame : 3 x 1 Vector
+        Vector : 1 numeric
+        # key   type   level data_preview
+        0 :numo double     3 [0.3206787829442638, 0.2756491628580763, 0.1659554879682396]
+      EXPECTED
+    end
+  end
+
   sub_test_case 'method_missing' do
     setup do
       @df = DataFrame.new(number: [1, 2, 3], 'string.1': %w[Aa Bb Cc])

--- a/test/test_vector.rb
+++ b/test/test_vector.rb
@@ -39,6 +39,11 @@ class VectorTest < Test::Unit::TestCase
       assert_equal [-1, 0, 1], Vector.new(numo).to_a
     end
 
+    test '#to_arrow_array' do
+      _, _, _, array = data
+      assert_true(Vector.new(array).to_arrow_array.any? { [is_a?(Arrow::Array), is_a?(Arrow::ChunkedArray)] })
+    end
+
     test '#size' do
       expect, _, _, array = data
       actual = Vector.new(array)

--- a/test/test_vector.rb
+++ b/test/test_vector.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class VectorTest < Test::Unit::TestCase
   include RedAmber
+  include Helper
 
   sub_test_case('Basic properties') do
     data(keep: true) do
@@ -22,15 +23,20 @@ class VectorTest < Test::Unit::TestCase
       h
     end
 
-    test '.initialize' do
+    test 'initialize' do
       expect, _, _, array = data
       actual = Vector.new(array).to_a
       assert_equal expect, actual
     end
 
-    test '.initialize by an expanded Array' do
+    test 'initialize by an expanded Array' do
       array = [1, 2, 3]
       assert_equal array, Vector.new(*array).to_a
+    end
+
+    test 'initialize by Numo::NArray' do
+      numo = Numo::Int8.new(3).seq(-1)
+      assert_equal [-1, 0, 1], Vector.new(numo).to_a
     end
 
     test '#size' do

--- a/test/test_vector_function.rb
+++ b/test/test_vector_function.rb
@@ -983,7 +983,7 @@ class VectorFunctionTest < Test::Unit::TestCase
         add(x, y): Add the arguments element-wise
         ---
         Results will wrap around on integer overflow.
-        Use function \"add_checked\" if you want overflow
+        Use function "add_checked" if you want overflow
         to return an error.
       OUT
       assert_equal expected.chomp, VectorFunctions.arrow_doc(:add).to_s


### PR DESCRIPTION
Apache Arrow 10.0.0 has released in 26th October :tada:
And Red Arrow gem has successfully released today. This PR enables to use it.
Thanks to @kou for hard work in release management.