### PR TITLE
Fix #[], #pick and #drop by Range and Symbol

### DIFF
--- a/lib/red_amber/data_frame_selectable.rb
+++ b/lib/red_amber/data_frame_selectable.rb
@@ -17,7 +17,7 @@ module RedAmber
         raise DataFrameArgumentError, "Size is not match in booleans: #{args}"
       end
       return take_by_array(vector) if vector.numeric?
-      return select_vars_by_keys(vector.to_a.map(&:to_sym)) if vector.string? || vector.type == :dictionary
+      return select_vars_by_keys(vector.to_a.map(&:to_sym)) if vector.string? || vector.dictionary?
 
       raise DataFrameArgumentError, "Invalid argument: #{args}"
     end

--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -23,12 +23,12 @@ module RedAmber
         elsif vec.numeric?
           key_vector.take(*vec).to_a
         elsif vec.string? || vec.dictionary?
-          picker
+          vec.to_a
         else
           raise DataFrameArgumentError, "Invalid argument #{args}"
         end
 
-      # DataFrame#[] creates a Vector with single key is specified.
+      # DataFrame#[] creates a Vector if single key is specified.
       # DataFrame#pick creates a DataFrame with single key.
       DataFrame.new(@table[ary])
     end

--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -52,14 +52,14 @@ module RedAmber
         elsif vec.numeric?
           keys - key_vector.take(*vec).each.map(&:to_sym) # Array
         elsif vec.string? || vec.dictionary?
-          keys - dropper
+          keys - vec.to_a.map { _1&.to_sym } # Array
         else
           raise DataFrameArgumentError, "Invalid argument #{args}"
         end
 
       return DataFrame.new if ary.empty?
 
-      # DataFrame#[] creates a Vector with single key is specified.
+      # DataFrame#[] creates a Vector if single key is specified.
       # DataFrame#drop creates a DataFrame with single key.
       DataFrame.new(@table[ary])
     end

--- a/lib/red_amber/helper.rb
+++ b/lib/red_amber/helper.rb
@@ -39,7 +39,7 @@ module RedAmber
         elsif bg.nil? && en.nil?
           Array(0...vsize)
         else
-          Array[elem]
+          Array(elem)
         end
       when Enumerator
         elem.to_a

--- a/test/test_data_frame_selectable.rb
+++ b/test/test_data_frame_selectable.rb
@@ -21,6 +21,7 @@ class DataFrameSelectableTest < Test::Unit::TestCase
       hash = { a: [1, 2, 3], b: %w[A B C], c: [1.0, 2, 3] }
       df_range = DataFrame.new(hash)
       assert_equal hash, df_range[:a..:c].to_h
+      assert_equal hash, df_range[:a..:b, :c].to_h
       hash.delete(:c)
       assert_equal hash, df_range[:a...:c].to_h
       assert_raise(RangeError) { df_range[:a..] }

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -133,77 +133,87 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
     end
 
     test 'drop by arguments' do
-      assert_raise(DataFrameArgumentError) { @df2.drop(:index) { :block } }
+      assert_raise(DataFrameArgumentError) { @df.drop(:a) { :block } }
 
-      assert_equal @df2, @df2.drop # drop nothing
-      assert_equal @df2, @df2.drop([]) # drop nothing
-      assert_true @df2.drop(@df2.keys).empty? # drop all
+      assert_equal @df, @df.drop # drop nothing
+      assert_equal @df, @df.drop([]) # drop nothing
+      assert_true @df.drop(@df.keys).empty? # drop all
 
-      str = <<~OUTPUT
-        RedAmber::DataFrame : 5 x 2 Vectors
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 2 Vectors
         Vectors : 1 numeric, 1 boolean
-        # key    type    level data_preview
-        0 :index uint8       5 [0, 1, 2, 3, nil], 1 nil
-        1 :bool  boolean     3 {true=>2, false=>2, nil=>1}
-      OUTPUT
-      assert_equal str, @df2.drop(:float, :string).tdr_str
-      assert_equal str, @df2.drop(%i[float string]).tdr_str
-      assert_equal str, @df2.drop(1, -2).tdr_str
-      assert_equal str, @df2.drop(1..2).tdr_str
-      assert_equal str, @df2.drop(1...3).tdr_str
-      assert_true @df2.drop(..3).empty?
-      assert_raise(DataFrameArgumentError) { @df2.drop(0..5) }
+        # key type    level data_preview
+        0 :a  uint8       3 [1, 2, 3]
+        1 :d  boolean     3 [true, false, nil], 1 nil
+      STR
+      assert_equal str, @df.drop(:b, :c).tdr_str
+      assert_equal str, @df.drop(%i[b c]).tdr_str
+      assert_equal str, @df.drop(1, -2).tdr_str
+      assert_equal str, @df.drop(1..2).tdr_str
+      assert_equal str, @df.drop(:b..:c).tdr_str
+      assert_equal str, @df.drop(1...3).tdr_str
+      assert_true @df.drop(..3).empty?
+      # assert_true @df.drop(..:d).empty?
+      assert_raise(DataFrameArgumentError) { @df.drop(0..5) }
     end
 
     test 'drop by endless Range' do
-      str = <<~OUTPUT
-        RedAmber::DataFrame : 5 x 2 Vectors
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 2 Vectors
         Vectors : 2 numeric
-        # key    type   level data_preview
-        0 :index uint8      5 [0, 1, 2, 3, nil], 1 nil
-        1 :float double     5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
-      OUTPUT
-      assert_equal str, @df2.drop(2..).tdr_str
-      assert_equal str, @df2.drop(-2..).tdr_str
-      assert_equal str, @df2.drop(2...).tdr_str
-      assert_equal str, @df2.drop(2..-1).tdr_str
+        # key type   level data_preview
+        0 :a  uint8      3 [1, 2, 3]
+        1 :b  double     3 [0.0, NaN, nil], 1 NaN, 1 nil
+      STR
+      assert_equal str, @df.drop(2..).tdr_str
+      # assert_equal str, @df.drop(:c..).tdr_str
+      assert_equal str, @df.drop(-2..).tdr_str
+      assert_equal str, @df.drop(2...).tdr_str
+      assert_equal str, @df.drop(2..-1).tdr_str
     end
 
     test 'drop by block' do
-      str = <<~OUTPUT
-        RedAmber::DataFrame : 5 x 3 Vectors
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 3 Vectors
         Vectors : 2 numeric, 1 string
-        # key     type   level data_preview
-        0 :index  uint8      5 [0, 1, 2, 3, nil], 1 nil
-        1 :float  double     5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
-        2 :string string     5 ["A", "B", "C", "D", nil], 1 nil
-      OUTPUT
-      assert_equal(@df2, @df2.drop { nil }) # drop nothing
-      assert_equal str, @df2.drop { :bool }.tdr_str
-      assert_equal str, @df2.drop { vectors.map(&:boolean?) }.tdr_str
-      assert_equal str, @df2.drop { -1 }.tdr_str
+        # key type   level data_preview
+        0 :a  uint8      3 [1, 2, 3]
+        1 :b  double     3 [0.0, NaN, nil], 1 NaN, 1 nil
+        2 :c  string     3 ["A", "B", "C"]
+      STR
+      assert_equal(@df, @df.drop { nil }) # drop nothing
+      assert_equal str, @df.drop { 3 }.tdr_str
+      assert_equal str, @df.drop { [3] }.tdr_str
+      assert_equal str, @df.drop { :d }.tdr_str
+      assert_equal str, @df.drop { [:d] }.tdr_str
+      assert_equal str, @df.drop { vectors.map(&:boolean?) }.tdr_str
+      assert_equal str, @df.drop { -1 }.tdr_str
 
-      str = <<~OUTPUT
-        RedAmber::DataFrame : 5 x 2 Vectors
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 2 Vectors
         Vectors : 1 string, 1 boolean
-        # key     type    level data_preview
-        0 :string string      5 ["A", "B", "C", "D", nil], 1 nil
-        1 :bool   boolean     3 {true=>2, false=>2, nil=>1}
-      OUTPUT
-      assert_equal str, @df2.drop { %i[index float] }.tdr_str
-      assert_equal str, @df2.drop { vectors.map(&:numeric?) }.tdr_str
-      assert_equal str, @df2.drop { [0, 1] }.tdr_str
+        # key type    level data_preview
+        0 :c  string      3 ["A", "B", "C"]
+        1 :d  boolean     3 [true, false, nil], 1 nil
+      STR
+      assert_equal str, @df.drop { [0, 1] }.tdr_str
+      assert_equal str, @df.drop { vectors.map(&:numeric?) }.tdr_str
+      assert_equal str, @df.drop { [1, 0] }.tdr_str
+      assert_equal str, @df.drop { %i[b a] }.tdr_str
+      assert_equal str, @df.drop { [:a..:b] }.tdr_str
     end
 
     test 'drop by mixed args' do
-      str = <<~OUTPUT
-        RedAmber::DataFrame : 5 x 1 Vector
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 1 Vector
         Vector : 1 numeric
-        # key    type  level data_preview
-        0 :index uint8     5 [0, 1, 2, 3, nil], 1 nil
-      OUTPUT
-      assert_equal str, @df2.drop(2..-1, 1).tdr_str
-      assert_equal str, @df2.drop { [2..-1, 1] }.tdr_str
+        # key type  level data_preview
+        0 :a  uint8     3 [1, 2, 3]
+      STR
+      assert_equal str, @df.drop(2..-1, 1).tdr_str
+      assert_equal str, @df.drop(:c..:d, :b).tdr_str
+      assert_equal str, @df.drop { [2..-1, 1] }.tdr_str
+      assert_equal str, @df.drop { [:b, :c..:d] }.tdr_str
     end
   end
 


### PR DESCRIPTION
Fix bugs for `DataFrame#[]`, `#pick` and `#drop` with Range of Symbols and Symbol.

```ruby
dataframe[:a..:c, :d]
dataframe.pick(:a..:c, :d)
dataframe.drop(:a..:c, :d)
```
