### PR TITLE
Support Ruby 3.2 in CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos] # windows, if: runner.os == 'Windows'
-        ruby: ['2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}-latest
 
     steps:
@@ -30,7 +30,7 @@ jobs:
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
           sudo apt install -y -V libarrow-dev
-          sudo apt install -y -V gir1.2-arrow-1.0
+          # sudo apt install -y -V gir1.2-arrow-1.0
           sudo apt install -y -V libarrow-glib-dev
 
       - name: Prepare Apache Arrow on macOS


### PR DESCRIPTION
This PR will enable test with Ruby 3.2.0-preview3.
