### PR TITLE
Add workflow to generate document

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,22 @@
+name: DOC
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 'ruby'
+      - name: Generate document
+        run: gem install -N yard && yard doc
+      - name: Publish Documentation on GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/yard


### PR DESCRIPTION
Hi! @heronshoes

This workflow automatically generates Yard documentation.

The generated Yard documentation is stored in the gh-pages branch and the documentation is automatically uploaded when you set up GitHub Pages. This allows users to see the latest documentation without having to build the documentation themselves.

See https://kojix2.github.io/red_amber/