### PR TITLE
Improve DataFrame#join

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos] # windows, if: runner.os == 'Windows'
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ A simple dataframe library for Ruby.
 
 ## Requirements
 
-Supported Ruby version is >= 2.7.
+Supported Ruby version is >= 3.0 (since RedAmber 0.3.0).
 
-Since v0.2.0, this library uses pattern matching which is an experimental feature in 2.7 . It is usable but a warning message will be shown in 2.7 .
-I recommend Ruby 3 for performance.
+I dropped support for Ruby 2.7 because
+- 3.0 has a lot of performance improvements.
+- EOL of 2.7 will coming soon. There are no positive reason to use 2.7 especially for data processing.
+- 2.7 shows warning for pattern matching used frequently in RedAmber.
+- 2.7 can't deal Hash and keyword arguments in join.
+  - API of join is `#join(other, join_key = nil, type: :inner, suffix: '.1')`. While `join_key` may be a Hash of `{ left: :left_key, right: :right_key }`. Also `join_key` may be nil (implicit common key is used).
+  I can't run 2.7 as same manner as over 3.0 in this case, so I decided to drop 2.7 .
 
 ```ruby
 # Libraries required
@@ -108,10 +113,9 @@ include RedAmber
 
 ### Example: diamonds dataset
 
-First do
-    ```
-    gem install red-datasets-arrow
-    ```
+First do (if you do not installed) `
+gem install red-datasets-arrow
+`
 then
 
 ```ruby

--- a/lib/red_amber/data_frame_combinable.rb
+++ b/lib/red_amber/data_frame_combinable.rb
@@ -243,8 +243,16 @@ module RedAmber
       # natural keys (implicit common keys)
       join_keys ||= table_keys.intersection(other_keys)
 
-      left_keys = Array(join_keys).map(&:to_s)
-      right_keys = Array(join_keys).map(&:to_s)
+      # This is not necessary if additional procedure is contributed to Red Arrow.
+      if join_keys.is_a?(Hash)
+        left_keys = join_keys[:left]
+        right_keys = join_keys[:right]
+      else
+        left_keys = join_keys
+        right_keys = join_keys
+      end
+      left_keys = Array(left_keys).map(&:to_s)
+      right_keys = Array(right_keys).map(&:to_s)
 
       case type
       when :full_outer, :left_semi, :left_anti, :right_semi, :right_anti
@@ -289,8 +297,8 @@ module RedAmber
           DataFrame.create(rename_table(joined_table, left_outputs.size, suffix))
         else
           DataFrame.create(joined_table)
-        end.pick do |df|
-          [table_keys, df.keys[-right_outputs.size..].map(&:to_s) - right_keys]
+        end.pick do
+          [right_keys, keys.map(&:to_s) - right_keys]
         end
       end
     end

--- a/lib/red_amber/data_frame_combinable.rb
+++ b/lib/red_amber/data_frame_combinable.rb
@@ -83,23 +83,80 @@ module RedAmber
 
     alias_method :bind_cols, :merge
 
-    # Mutating joins
+    # Mutating joins (#inner_join, #full_join, #left_join, #right_join)
 
-    # Join data, leaving only the matching records.
+    # Join another DataFrame or Table, leaving only the matching records.
+    # - Same as `#join` with `type: :inner`
+    # - A kind of mutating join.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
-    # @param join_keys [String, Symbol, ::Array<String, Symbol>] Keys to match.
-    # @return [DataFrame] Joined dataframe.
+    # @!macro join_before
+    #   @param other [DataFrame, Arrow::Table]
+    #     A DataFrame or a Table to be joined with self.
+    #
+    # @!macro join_after
+    #   @param suffix [#succ]
+    #     a suffix to rename keys when key names conflict as a result of join.
+    #     `suffix` must be responsible to `#succ`.
+    #   @return [DataFrame]
+    #     Joined dataframe.
+    #
+    # @!macro join_key_in_array
+    #   @param join_keys [String, Symbol, Array<String, Symbol>]
+    #     A key or keys to match.
+    #
+    # @!macro join_key_in_hash
+    #   @param join_key_pairs [Hash]
+    #     Pairs of a key name or key names to match in left and right.
+    #   @option join_key_pairs [String, Symbol, Array<String, Symbol>] :left
+    #     Join keys in `self`.
+    #   @option join_key_pairs [String, Symbol, Array<String, Symbol>] :right
+    #     Join keys in `other`.
+    #
+    # @overload inner_join(other, suffix: '.1')
+    #   If `join_key` is not specified, common keys in self and other are used
+    #   (natural keys). Returns joined dataframe.
+    #
+    #   @macro join_before
+    #   @macro join_after
+    #
+    # @overload inner_join(other, join_keys, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_array
+    #   @macro join_after
+    #
+    # @overload inner_join(other, join_key_pairs, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_hash
+    #   @macro join_after
     #
     def inner_join(other, join_keys = nil, suffix: '.1')
       join(other, join_keys, type: :inner, suffix: suffix)
     end
 
-    # Join data, leaving all records.
+    # Join another DataFrame or Table, leaving all records.
+    # - Same as `#join` with `type: :full_outer`
+    # - A kind of mutating join.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
-    # @param join_keys [String, Symbol, ::Array<String, Symbol>] Keys to match.
-    # @return [DataFrame] Joined dataframe.
+    # @overload full_join(other, suffix: '.1')
+    #   If `join_key` is not specified, common keys in self and other are used
+    #   (natural keys). Returns joined dataframe.
+    #
+    #   @macro join_before
+    #   @macro join_after
+    #
+    # @overload full_join(other, join_keys, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_array
+    #   @macro join_after
+    #
+    # @overload full_join(other, join_key_pairs, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_hash
+    #   @macro join_after
     #
     def full_join(other, join_keys = nil, suffix: '.1')
       join(other, join_keys, type: :full_outer, suffix: suffix)
@@ -108,52 +165,121 @@ module RedAmber
     alias_method :outer_join, :full_join
 
     # Join matching values to self from other.
+    # - Same as `#join` with `type: :left_outer`
+    # - A kind of mutating join.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
-    # @param join_keys [String, Symbol, ::Array<String, Symbol>] Keys to match.
-    # @return [DataFrame] Joined dataframe.
+    # @overload left_join(other, suffix: '.1')
+    #   If `join_key` is not specified, common keys in self and other are used
+    #   (natural keys). Returns joined dataframe.
+    #
+    #   @macro join_before
+    #   @macro join_after
+    #
+    # @overload left_join(other, join_keys, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_array
+    #   @macro join_after
+    #
+    # @overload left_join(other, join_key_pairs, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_hash
+    #   @macro join_after
     #
     def left_join(other, join_keys = nil, suffix: '.1')
       join(other, join_keys, type: :left_outer, suffix: suffix)
     end
 
     # Join matching values from self to other.
+    # - Same as `#join` with `type: :right_outer`
+    # - A kind of mutating join.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
-    # @param join_keys [String, Symbol, ::Array<String, Symbol>] Keys to match.
-    # @return [DataFrame] Joined dataframe.
+    # @overload right_join(other, suffix: '.1')
+    #   If `join_key` is not specified, common keys in self and other are used
+    #   (natural keys). Returns joined dataframe.
+    #
+    #   @macro join_before
+    #   @macro join_after
+    #
+    # @overload right_join(other, join_keys, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_array
+    #   @macro join_after
+    #
+    # @overload right_join(other, join_key_pairs, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_hash
+    #   @macro join_after
     #
     def right_join(other, join_keys = nil, suffix: '.1')
       join(other, join_keys, type: :right_outer, suffix: suffix)
     end
 
-    # Filtering joins
+    # Filtering joins (#semi_join, #anti_join)
 
     # Return records of self that have a match in other.
+    # - Same as `#join` with `type: :left_semi`
+    # - A kind of filtering join.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
-    # @param join_keys [String, Symbol, ::Array<String, Symbol>] Keys to match.
-    # @return [DataFrame] Joined dataframe.
+    # @overload semi_join(other, suffix: '.1')
+    #   If `join_key` is not specified, common keys in self and other are used
+    #   (natural keys). Returns joined dataframe.
+    #
+    #   @macro join_before
+    #   @macro join_after
+    #
+    # @overload semi_join(other, join_keys, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_array
+    #   @macro join_after
+    #
+    # @overload semi_join(other, join_key_pairs, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_hash
+    #   @macro join_after
     #
     def semi_join(other, join_keys = nil, suffix: '.1')
       join(other, join_keys, type: :left_semi, suffix: suffix)
     end
 
     # Return records of self that do not have a match in other.
+    # - Same as `#join` with `type: :left_anti`
+    # - A kind of filtering join.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
-    # @param join_keys [String, Symbol, ::Array<String, Symbol>] Keys to match.
-    # @return [DataFrame] Joined dataframe.
+    # @overload anti_join(other, suffix: '.1')
+    #   If `join_key` is not specified, common keys in self and other are used
+    #   (natural keys). Returns joined dataframe.
+    #
+    #   @macro join_before
+    #   @macro join_after
+    #
+    # @overload anti_join(other, join_keys, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_array
+    #   @macro join_after
+    #
+    # @overload anti_join(other, join_key_pairs, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_hash
+    #   @macro join_after
     #
     def anti_join(other, join_keys = nil, suffix: '.1')
       join(other, join_keys, type: :left_anti, suffix: suffix)
     end
 
-    # Set operations
+    # Set operations (#intersect, #union, #difference, #set_operable?)
 
     # Check if set operation with self and other is possible.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be checked with self.
+    # @macro join_before
+    #
     # @return [Boolean] true if set operation is possible.
     #
     def set_operable?(other) # rubocop:disable Naming/AccessorMethodName
@@ -162,8 +288,11 @@ module RedAmber
     end
 
     # Select records appearing in both self and other.
+    # - Same as `#join` with `type: :inner` when keys in self are same with other.
+    # - A kind of set operations.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
+    # @macro join_before
+    #
     # @return [DataFrame] Joined dataframe.
     #
     def intersect(other)
@@ -176,8 +305,11 @@ module RedAmber
     end
 
     # Select records appearing in self or other.
+    # - Same as `#join` with `type: :full_outer` when keys in self are same with other.
+    # - A kind of set operations.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
+    # @macro join_before
+    #
     # @return [DataFrame] Joined dataframe.
     #
     def union(other)
@@ -190,8 +322,11 @@ module RedAmber
     end
 
     # Select records appearing in self but not in other.
+    # - Same as `#join` with `type: :left_anti` when keys in self are same with other.
+    # - A kind of set operations.
     #
-    # @param other [DataFrame, Arrow::Table] DataFrame/Table to be joined with self.
+    # @macro join_before
+    #
     # @return [DataFrame] Joined dataframe.
     #
     def difference(other)
@@ -205,26 +340,34 @@ module RedAmber
 
     alias_method :setdiff, :difference
 
-    # Undocumented. It is preferable to call specific methods.
+    # Join another DataFrame or Table to self.
     #
-    # Join another DataFrame or Table.
+    # @overload join(other, type: :inner, suffix: '.1')
     #
-    # @overload join(other, key, type: :inner, suffix: '.1',
-    #                left_outputs: nil, right_outputs: nil)
+    #   If `join_key` is not specified, common keys in self and other are used
+    #   (natural keys). Returns joined dataframe.
     #
-    #   @!macro join_other
-    #   @param other [DataFrame, Arrow::Table] DataFrame or Table to be joined with self.
-    # @param join_keys [String, Symbol, ::Array<String, Symbol>] keys to match.
-    # @return [DataFrame] Joined dataframe.
+    #   @!macro join_common_type
+    #     @param type [:left_semi, :right_semi, :left_anti, :right_anti, :inner,
+    #                  left_outer, :right_outer, :full_outer] type of join.
     #
-    #   :type is one of
-    #     :left_semi, :right_semi, :left_anti, :right_anti, :inner,
-    #     :left_outer, :right_outer, :full_outer.
+    #   @macro join_before
+    #   @macro join_common_type
+    #   @macro join_after
     #
-    # @overload join(other, join_keys, )
+    # @overload join(other, join_keys, type: :inner, suffix: '.1')
     #
-    #   @param join_keys [Hash] key assignments to join.
-    #   @option join_keys [Symbol, String]
+    #   @macro join_before
+    #   @macro join_key_in_array
+    #   @macro join_common_type
+    #   @macro join_after
+    #
+    # @overload join(other, join_key_pairs, type: :inner, suffix: '.1')
+    #
+    #   @macro join_before
+    #   @macro join_key_in_hash
+    #   @macro join_common_type
+    #   @macro join_after
     #
     def join(other, join_keys = nil, type: :inner, suffix: '.1')
       case other
@@ -338,6 +481,7 @@ module RedAmber
       Arrow::Table.new(Arrow::Schema.new(fields), joined_table.columns)
     end
 
+    # Merge two Arrow::Arrays
     def merge_array(array1, array2)
       t = Arrow::Function.find(:is_null).execute([array1])
       Arrow::Function.find(:if_else).execute([t, array2, array1]).value

--- a/lib/red_amber/data_frame_combinable.rb
+++ b/lib/red_amber/data_frame_combinable.rb
@@ -283,8 +283,7 @@ module RedAmber
     # @return [Boolean] true if set operation is possible.
     #
     def set_operable?(other) # rubocop:disable Naming/AccessorMethodName
-      other = DataFrame.create(other) if other.is_a?(Arrow::Table)
-      keys == other.keys
+      keys == other.keys.map(&:to_sym)
     end
 
     # Select records appearing in both self and other.
@@ -296,8 +295,7 @@ module RedAmber
     # @return [DataFrame] Joined dataframe.
     #
     def intersect(other)
-      other = DataFrame.create(other) if other.is_a?(Arrow::Table)
-      unless keys == other.keys
+      unless keys == other.keys.map(&:to_sym)
         raise DataFrameArgumentError, 'keys are not same with self and other'
       end
 
@@ -313,8 +311,7 @@ module RedAmber
     # @return [DataFrame] Joined dataframe.
     #
     def union(other)
-      other = DataFrame.create(other) if other.is_a?(Arrow::Table)
-      unless keys == other.keys
+      unless keys == other.keys.map(&:to_sym)
         raise DataFrameArgumentError, 'keys are not same with self and other'
       end
 
@@ -330,8 +327,7 @@ module RedAmber
     # @return [DataFrame] Joined dataframe.
     #
     def difference(other)
-      other = DataFrame.create(other) if other.is_a?(Arrow::Table)
-      unless keys == other.keys
+      unless keys == other.keys.map(&:to_sym)
         raise DataFrameArgumentError, 'keys are not same with self and other'
       end
 

--- a/test/test_data_frame_combinable.rb
+++ b/test/test_data_frame_combinable.rb
@@ -149,7 +149,7 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2]
         )
         assert_equal expected, @df1.join(@right1) # natural join
-        assert_raise(DataFrameArgumentError) { @df1.join(@right1.rename(KEY: :KEY1)) }
+        assert_raise(Arrow::Error::Invalid) { @df1.join(@right1.rename(KEY: :KEY1)) }
       end
 
       test '#inner_join with a join_key' do

--- a/test/test_data_frame_combinable.rb
+++ b/test/test_data_frame_combinable.rb
@@ -163,6 +163,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df1.inner_join(@right1, 'KEY')
         assert_equal expected, @df1.inner_join(@right1, [:KEY])
         assert_equal expected, @df1.inner_join(@right1.table, :KEY)
+        assert_equal expected, @df1.inner_join(@right1, { left: :KEY, right: :KEY })
+        assert_equal expected, @df1.inner_join(@right1.rename(KEY: :KEY1),
+                                               { left: :KEY, right: :KEY1 })
       end
 
       test '#full_join with a join_key)' do
@@ -176,6 +179,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df1.full_join(@right1, 'KEY')
         assert_equal expected, @df1.full_join(@right1, [:KEY])
         assert_equal expected, @df1.full_join(@right1.table, :KEY)
+        assert_equal expected, @df1.full_join(@right1, { left: :KEY, right: :KEY })
+        assert_equal expected, @df1.full_join(@right1.rename(KEY: :KEY1),
+                                              { left: :KEY, right: :KEY1 })
       end
 
       test '#left_join with a join_key)' do
@@ -189,6 +195,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df1.left_join(@right1, 'KEY')
         assert_equal expected, @df1.left_join(@right1, [:KEY])
         assert_equal expected, @df1.left_join(@right1.table, :KEY)
+        assert_equal expected, @df1.left_join(@right1, { left: :KEY, right: :KEY })
+        assert_equal expected, @df1.left_join(@right1.rename(KEY: :KEY1),
+                                              { left: :KEY, right: :KEY1 })
       end
 
       test '#right_join with a join_key)' do
@@ -202,6 +211,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df1.right_join(@right1, 'KEY')
         assert_equal expected, @df1.right_join(@right1, [:KEY])
         assert_equal expected, @df1.right_join(@right1.table, :KEY)
+        assert_equal expected, @df1.right_join(@right1, { left: :KEY, right: :KEY })
+        assert_equal expected, @df1.rename(KEY: :KEY1)
+                                   .right_join(@right1,
+                                               { left: :KEY1, right: :KEY })
       end
 
       test '#semi_join with a join_key' do
@@ -214,6 +227,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df1.semi_join(@right1, 'KEY')
         assert_equal expected, @df1.semi_join(@right1, [:KEY])
         assert_equal expected, @df1.semi_join(@right1.table, :KEY)
+        assert_equal expected, @df1.semi_join(@right1, { left: :KEY, right: :KEY })
+        assert_equal expected, @df1.semi_join(@right1.rename(KEY: :KEY1),
+                                              { left: :KEY, right: :KEY1 })
       end
 
       test '#anti_join with a join_key' do
@@ -226,6 +242,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df1.anti_join(@right1, 'KEY')
         assert_equal expected, @df1.anti_join(@right1, [:KEY])
         assert_equal expected, @df1.anti_join(@right1.table, :KEY)
+        assert_equal expected, @df1.anti_join(@right1, { left: :KEY, right: :KEY })
+        assert_equal expected, @df1.anti_join(@right1.rename(KEY: :KEY1),
+                                              { left: :KEY, right: :KEY1 })
       end
 
       test 'right_semi' do
@@ -233,7 +252,15 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           KEY: %w[A B],
           Y: [3, 2]
         )
+        assert_equal expected, @df1.join(@right1, type: :right_semi)
         assert_equal expected, @df1.join(@right1, :KEY, type: :right_semi)
+        assert_equal expected, @df1.join(@right1,
+                                         { left: :KEY, right: :KEY },
+                                         type: :right_semi)
+        assert_equal expected, @df1.rename(KEY: :KEY1)
+                                   .join(@right1,
+                                         { left: :KEY1, right: :KEY },
+                                         type: :right_semi)
       end
 
       test 'right_anti' do
@@ -241,7 +268,15 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           KEY: %w[D],
           Y: [1]
         )
+        assert_equal expected, @df1.join(@right1, type: :right_anti)
         assert_equal expected, @df1.join(@right1, :KEY, type: :right_anti)
+        assert_equal expected, @df1.join(@right1,
+                                         { left: :KEY, right: :KEY },
+                                         type: :right_anti)
+        assert_equal expected, @df1.rename(KEY: :KEY1)
+                                   .join(@right1,
+                                         { left: :KEY1, right: :KEY },
+                                         type: :right_anti)
       end
     end
 
@@ -271,6 +306,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df2.inner_join(@right2, %i[KEY1 KEY2])
         assert_equal expected, @df2.inner_join(@right2, %w[KEY1 KEY2])
         assert_equal expected, @df2.inner_join(@right2.table, %i[KEY1 KEY2])
+        assert_equal expected, @df2.inner_join(@right2,
+                                               { left: %i[KEY1 KEY2], right: %w[KEY1 KEY2] })
+        assert_equal expected, @df2.inner_join(@right2.rename(KEY1: :KEY3),
+                                               { left: %i[KEY1 KEY2], right: %w[KEY3 KEY2] })
       end
 
       test '#inner_join with join_keys, partial join_key/rename' do
@@ -282,6 +321,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2]
         )
         assert_equal expected, @df2.inner_join(@right2, :KEY2)
+        assert_equal expected, @df2.inner_join(@right2,
+                                               { left: :KEY2, right: 'KEY2' })
       end
 
       test '#full_join with join_keys' do
@@ -295,6 +336,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df2.full_join(@right2, %i[KEY1 KEY2])
         assert_equal expected, @df2.full_join(@right2, %w[KEY1 KEY2])
         assert_equal expected, @df2.full_join(@right2.table, %i[KEY1 KEY2])
+        assert_equal expected, @df2.full_join(@right2,
+                                              { left: %i[KEY1 KEY2], right: %w[KEY1 KEY2] })
+        assert_equal expected, @df2.full_join(@right2.rename(KEY1: :KEY3),
+                                              { left: %i[KEY1 KEY2], right: %w[KEY3 KEY2] })
       end
 
       test '#full_join with join_keys, partial join_key/rename' do
@@ -306,6 +351,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2, nil, 1]
         )
         assert_equal expected, @df2.full_join(@right2, :KEY2)
+        assert_equal expected, @df2.full_join(@right2,
+                                              { left: :KEY2, right: 'KEY2' })
       end
 
       test '#left_join with join_keys' do
@@ -319,6 +366,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df2.left_join(@right2, %i[KEY1 KEY2])
         assert_equal expected, @df2.left_join(@right2, %w[KEY1 KEY2])
         assert_equal expected, @df2.left_join(@right2.table, %i[KEY1 KEY2])
+        assert_equal expected, @df2.left_join(@right2,
+                                              { left: %i[KEY1 KEY2], right: %w[KEY1 KEY2] })
+        assert_equal expected, @df2.left_join(@right2.rename(KEY1: :KEY3),
+                                              { left: %i[KEY1 KEY2], right: %w[KEY3 KEY2] })
       end
 
       test '#left_join with join_keys, partial join_key/rename' do
@@ -330,6 +381,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2, nil]
         )
         assert_equal expected, @df2.left_join(@right2, :KEY2)
+        assert_equal expected, @df2.left_join(@right2,
+                                              { left: :KEY2, right: 'KEY2' })
       end
 
       test '#right_join with join_keys' do
@@ -343,17 +396,24 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df2.right_join(@right2, %i[KEY1 KEY2])
         assert_equal expected, @df2.right_join(@right2, %w[KEY1 KEY2])
         assert_equal expected, @df2.right_join(@right2.table, %i[KEY1 KEY2])
+        assert_equal expected, @df2.right_join(@right2,
+                                               { left: %i[KEY1 KEY2], right: %w[KEY1 KEY2] })
+        assert_equal expected, @df2.rename(KEY1: :KEY3)
+                                   .right_join(@right2,
+                                               { left: %i[KEY3 KEY2], right: %w[KEY1 KEY2] })
       end
 
       test '#right_join with join_keys, partial join_key/rename' do
         expected = DataFrame.new(
-          KEY1: ['A', 'C', nil],
           KEY2: %w[s u v],
+          KEY1: ['A', 'C', nil],
           X: [1, 3, nil],
           'KEY1.1': %w[A B D],
           Y: [3, 2, 1]
         )
         assert_equal expected, @df2.right_join(@right2, :KEY2)
+        assert_equal expected, @df2.right_join(@right2,
+                                               { left: :KEY2, right: 'KEY2' })
       end
 
       test '#semi_join with join_keys' do
@@ -366,6 +426,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df2.semi_join(@right2, %i[KEY1 KEY2])
         assert_equal expected, @df2.semi_join(@right2, %w[KEY1 KEY2])
         assert_equal expected, @df2.semi_join(@right2.table, %i[KEY1 KEY2])
+        assert_equal expected, @df2.semi_join(@right2,
+                                              { left: %i[KEY1 KEY2], right: %w[KEY1 KEY2] })
+        assert_equal expected, @df2.semi_join(@right2.rename(KEY1: :KEY3),
+                                              { left: %i[KEY1 KEY2], right: %w[KEY3 KEY2] })
       end
 
       test '#semi_join with join_keys, partial join_key' do
@@ -375,6 +439,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           X: [1, 3]
         )
         assert_equal expected, @df2.semi_join(@right2, :KEY2)
+        assert_equal expected, @df2.semi_join(@right2,
+                                              { left: :KEY2, right: 'KEY2' })
       end
 
       test '#anti_join with join_keys' do
@@ -387,6 +453,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df2.anti_join(@right2, %i[KEY1 KEY2])
         assert_equal expected, @df2.anti_join(@right2, %w[KEY1 KEY2])
         assert_equal expected, @df2.anti_join(@right2.table, %i[KEY1 KEY2])
+        assert_equal expected, @df2.anti_join(@right2,
+                                              { left: %i[KEY1 KEY2], right: %w[KEY1 KEY2] })
+        assert_equal expected, @df2.anti_join(@right2.rename(KEY1: :KEY3),
+                                              { left: %i[KEY1 KEY2], right: %w[KEY3 KEY2] })
       end
 
       test '#anti_join with join_keys, partial join_key' do
@@ -396,6 +466,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           X: [2]
         )
         assert_equal expected, @df2.anti_join(@right2, :KEY2)
+        assert_equal expected, @df2.anti_join(@right2,
+                                              { left: :KEY2, right: 'KEY2' })
       end
     end
 
@@ -423,6 +495,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2]
         )
         assert_equal expected, @df3.inner_join(@right3, :'KEY.1')
+        assert_equal expected, @df3.inner_join(@right3,
+                                               { left: :'KEY.1', right: 'KEY.1' })
       end
 
       test '#full_join with rename and collision' do
@@ -434,6 +508,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2, nil, 1]
         )
         assert_equal expected, @df3.full_join(@right3, :'KEY.1')
+        assert_equal expected, @df3.full_join(@right3,
+                                              { left: :'KEY.1', right: 'KEY.1' })
       end
 
       test '#left_join with rename and collision' do
@@ -445,6 +521,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2, nil]
         )
         assert_equal expected, @df3.left_join(@right3, :'KEY.1')
+        assert_equal expected, @df3.left_join(@right3,
+                                              { left: :'KEY.1', right: 'KEY.1' })
       end
 
       test '#right_join with rename and collision' do
@@ -456,6 +534,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
           Y: [3, 2, 1]
         )
         assert_equal expected, @df3.right_join(@right3, :'KEY.1')
+        assert_equal expected, @df3.right_join(@right3,
+                                               { left: :'KEY.1', right: 'KEY.1' })
       end
 
       test 'invalid suffix' do


### PR DESCRIPTION
This PR will refine whole code of DataFrame#join method (#158).

- Refine `DataFrame#join` effectively using left_outputs/right_outputs options in `Arrow::Table#join`.