### PR TITLE
Prepare 0.3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,8 +8,8 @@ require:
   - rubocop-rake
 
 AllCops:
-  # drop support for < 2.7
-  TargetRubyVersion: 2.7
+  # drop support for 2.7 (since 0.3.0)
+  TargetRubyVersion: 3.0
   # accept new cops if any
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,93 @@
-## [0.2.4] - 2022-12-25 (unleleased)
+## [0.3.0] - 2022-12-18
+
+- Breaking change
+  - Supported Ruby version has changed from 2.7 to 3.0
+    - Upgrade minimum supported/required version of Ruby from 2.7 to 3.0 (#159, #160)
+
+- Bug fixes
+  - Add check with #key? in DataFrame#method_missing (#140)
+  - Delete unnecessary backslash to supress warning in unary functions (#140)
+  - Fix syntax in code_climate.yml (144)
+  - Temporary disable simplecov test report (#149)
+  - Change Vector#[] to return Array or scalar (#148)
+  - Add missing simplecov HTML formatter (#148)
+  - Change return value of DataFrame#save to self (#160)
+    - Originally reported by kojix2.
+
+- New features and improvements
+  - Update Vector#take to accept block (#148)
+  - Add properties of list Vectors (#148)
+  - Add Vector#split, #split_to_column, #split_to_row (#148)
+  - Add Vector#merge (#148)
+
+- Refactoring
+  - Refactor code (#140)
+    - Add DataFrame.create as a faster constructor
+    - Refactor DataFrame.new using refinements and duck typing
+    - Refactor Vector.new using refinements and duck typing
+    - Add Vector.create as a faster constructor
+    - Refactor Group
+    - Refactor DataFrame#pick/#drop by refininig Array
+    - Refactor DataFrame#pick/#drop
+    - Refactor nil treatment in pick/drop
+    - Refactor DataFrame#pick/#drop using new parser
+    - Refactor DataFrame#[]
+    - Refactor Vector#[], #take, #filter by updating parser
+    - Add for_keys option to parse_args
+    - Refactor Vector properties by refinements for Arrow::Array
+    - Refactor DataFrame selectable using Arrow::Array refinements instead of Vector methods
+    - Refactor DataFrame#assign
+  - Refine error message in DataFrame#to_long/to_wide #143)
+  - Refactor Vector#take/filter returns arrow array (#148)
+  - Change LineLength in cop from 120 to 90 (#152)
+  - Refine DataFrame combinable (join) operations (#159)
+    - Refine DataFrame#join effectively using outputs options
+    - Simplify DataFrame set operations
+
+- Improve in tests/CI
+  - Tests
+    - Update benchmark using 0.2.3 (#138)
+    - Update benchmark basic#02/pick by [] (#140)
+    - Update benchmark contexts and loop_count (#140)
+    - Add benchmark for vector (#140)
+    - Add tests for refinements (#140)
+    - Add benchmark for the series of DataFrame operations (#140)
+    - Add missing test for tdr and dictionary (#140)
+    - Add missing test for group#method with foreign key (#152)
+    - Add missing test for set operations and natural join (#152)
+    - Add missing test for DataFrame#[] with selecting by Array of illegal type' (#152)
+    - Add missing test for DataFrame#assign when assigner size is mismatch (#152)
+    - Accept Hash as join keys in DataFrame join methods (#159)
+
+  - Cops
+    - Refactor/clean rubocop.yml (#138)
+
+  - CI
+    - Support Ruby 3.2 in CI test (#141)
+    - Send test coverage report to Code Climate (#144)
+    - Add test on Fedora (#151)
+      - Thanks to Benson Muite.
+
+    - Add workflow to generate document (#153)
+      - Thanks to kojix2.
+
+    - Support Code Climate test coverage report in CI (#155)
+
+- Documentation
+  - Add YARD in data_frame.rb (#140)
+  - Fix YARD document in the code (#140)
+  - Add Code Climate badges of maintainability and coverage (#144)
+  - Add installation for Fedora in README (#147)
+    - Thanks to Benson Muite.
+
+  - Add Vector#split/merge in Vector.md (#148)
+  - Fix codeclimate badges in README (#155)
+  - Update YARD in DataFrame join methods (#159)
+  - Update jupyter notebook '89 examples of Redamber' (#160)
+
+- Thanks
+  - Benson Muite
+  - kojix2
 
 ## [0.2.3] - 2022-11-16
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ See [Vector.md](doc/Vector.md) for details.
 
 ## Jupyter notebook
 
-[83 Examples of Red Amber](https://github.com/heronshoes/docker-stacks/blob/RedAmber-binder/binder/examples_of_red_amber.ipynb)
+[89 Examples of Red Amber](https://github.com/heronshoes/docker-stacks/blob/RedAmber-binder/binder/examples_of_red_amber.ipynb)
 ([raw file](https://raw.githubusercontent.com/heronshoes/docker-stacks/RedAmber-binder/binder/examples_of_red_amber.ipynb)) shows more examples in jupyter notebook.
 
 You can try this notebook on [Binder](https://mybinder.org/v2/gh/heronshoes/docker-stacks/RedAmber-binder?filepath=examples_of_red_amber.ipynb). 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,7 @@ A simple dataframe library for Ruby.
 
 Supported Ruby version is >= 3.0 (since RedAmber 0.3.0).
 
-I dropped support for Ruby 2.7 because
-- 3.0 has a lot of performance improvements.
-- EOL of 2.7 will coming soon. There are no positive reason to use 2.7 especially for data processing.
-- 2.7 shows warning for pattern matching used frequently in RedAmber.
-- 2.7 can't deal Hash and keyword arguments in join.
-  - API of join is `#join(other, join_key = nil, type: :inner, suffix: '.1')`. While `join_key` may be a Hash of `{ left: :left_key, right: :right_key }`. Also `join_key` may be nil (implicit common key is used).
-  I can't run 2.7 as same manner as over 3.0 in this case, so I decided to drop 2.7 .
+- I decided to remove Ruby 2.7 without waiting for EOL because it cannot solve the problem of simultaneous use of Hash and keyword arguments when implementing DataFrame#join.
 
 ```ruby
 # Libraries required

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -1302,7 +1302,10 @@ When the option `keep_key: true` used, the column `key` will be preserved.
   - `join_keys` are keys shared by self and other to match with them.
   - If `join_keys` are empty, common keys in self and other are chosen (natural join).
   - If (common keys) > `join_keys`, duplicated keys are renamed by `suffix`. 
+  - If you want to match the columns with different names,
+    use Hash for `join_keys` such as `{ left: :KEY1, right: KEY2}`.
 
+  These are dataframes to use in the examples of joins.
   ```ruby
   df = DataFrame.new(
     KEY: %w[A B C],

--- a/lib/red_amber/data_frame_loadsave.rb
+++ b/lib/red_amber/data_frame_loadsave.rb
@@ -17,14 +17,17 @@ module RedAmber
     end
 
     # Save DataFrame
+    #
+    # @return [DataFrame] self.
     def save(output, options = {})
       @table.save(output, options)
+      self
     end
 
     # Save and reload to cast automatically
     #   Via tsv format file temporally as default
     #
-    #   experimental feature
+    # @note experimental feature
     def auto_cast(format: :tsv)
       return self if empty?
 

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.3.0-HEAD'
+  VERSION = '0.3.0'
 end

--- a/red_amber.gemspec
+++ b/red_amber.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
                      'inspired by Rover-df and powered by Red Arrow.'
   spec.homepage = 'https://github.com/heronshoes/red_amber'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/heronshoes/red_amber'


### PR DESCRIPTION
This PR will collect final preparations for RedAmber version 0.3.0 .
Including;
- Change return value of DataFrame#save to self (#157 , proposed by @kojix2 in #156)
- Updating CHANGELOG
- Bump version
