### PR TITLE
Update benchmarks to set 0.3.0 as reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,13 @@ jobs:
 
       - name: Prepare Apache Arrow on macOS
         if: runner.os == 'macOS'
+        shell: bash
         run: |
+          rm -f /usr/local/bin/2to3 || :
+          rm -f /usr/local/bin/idle3 || :
+          rm -f /usr/local/bin/pydoc3 || :
+          rm -f /usr/local/bin/python3 || :
+          rm -f /usr/local/bin/python3-config || :
           brew update
           brew install apache-arrow
           brew install gobject-introspection

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Fedora
 on:
   push:
     branches:

--- a/benchmark/basic.yml
+++ b/benchmark/basic.yml
@@ -4,9 +4,9 @@ contexts:
   - name: HEAD
     prelude: |
       $LOAD_PATH.unshift(File.expand_path('lib'))
-  - name: 0.2.3
+  - name: 0.3.0
     gems:
-      red_amber: 0.2.3
+      red_amber: 0.3.0
   - name: 0.2.0
     gems:
       red_amber: 0.2.0

--- a/benchmark/combine.yml
+++ b/benchmark/combine.yml
@@ -4,9 +4,9 @@ contexts:
   - name: HEAD
     prelude: |
       $LOAD_PATH.unshift(File.expand_path('lib'))
-  - name: 0.2.3
+  - name: 0.3.0
     gems:
-      red_amber: 0.2.3
+      red_amber: 0.3.0
 
 prelude: |
   require 'red_amber'

--- a/benchmark/dataframe.yml
+++ b/benchmark/dataframe.yml
@@ -4,9 +4,9 @@ contexts:
   - name: HEAD
     prelude: |
       $LOAD_PATH.unshift(File.expand_path('lib'))
-  - name: 0.2.3
+  - name: 0.3.0
     gems:
-      red_amber: 0.2.3
+      red_amber: 0.3.0
   - name: 0.2.0
     gems:
       red_amber: 0.2.0

--- a/benchmark/group.yml
+++ b/benchmark/group.yml
@@ -4,9 +4,9 @@ contexts:
   - name: HEAD
     prelude: |
       $LOAD_PATH.unshift(File.expand_path('lib'))
-  - name: 0.2.3
+  - name: 0.3.0
     gems:
-      red_amber: 0.2.3
+      red_amber: 0.3.0
   - name: 0.2.2
     gems:
       red_amber: 0.2.2

--- a/benchmark/reshape.yml
+++ b/benchmark/reshape.yml
@@ -4,9 +4,9 @@ contexts:
   - name: HEAD
     prelude: |
       $LOAD_PATH.unshift(File.expand_path('lib'))
-  - name: 0.2.3
+  - name: 0.3.0
     gems:
-      red_amber: 0.2.3
+      red_amber: 0.3.0
   - name: 0.2.2
     gems:
       red_amber: 0.2.2

--- a/benchmark/vector.yml
+++ b/benchmark/vector.yml
@@ -4,6 +4,9 @@ contexts:
   - name: HEAD
     prelude: |
       $LOAD_PATH.unshift(File.expand_path('lib'))
+  - name: 0.3.0
+    gems:
+      red_amber: 0.3.0
   - name: 0.2.0
     gems:
       red_amber: 0.2.0

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RedAmber
-  VERSION = '0.3.0'
+  VERSION = '0.3.1-HEAD'
 end


### PR DESCRIPTION
- Set version 0.3.1-HEAD
- Benchmark is updated to compare;
  - basic.yml : HEAD, 0.3.0, 0.2.0, 0.1.5
  - combine.yml : HEAD, 0.3.0
  - dataframe.yml : HEAD, 0.3.0, 0.2.0
  - group.yml : HEAD, 0.3.0, 0.2.2
  - reshape.yml : HEAD, 0.3.0, 0.2.2
  - vector.yml : HEAD, 0.3.0, 0.2.0
