### PR TITLE
Update DataFrame#filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RedAmber
 
-[![Gem Version](https://badge.fury.io/rb/red_amber.svg)](https://badge.fury.io/rb/red_amber)
+[![Gem Version](https://img.shields.io/gem/v/red_amber?color=brightgreen)](https://rubygems.org/gems/red_amber)
 [![CI](https://github.com/heronshoes/red_amber/actions/workflows/ci.yml/badge.svg)](https://github.com/heronshoes/red_amber/actions/workflows/ci.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/b8a745047045d2f49daa/maintainability)](https://codeclimate.com/github/heronshoes/red_amber/maintainability)
 [![Test coverage](https://api.codeclimate.com/v1/badges/b8a745047045d2f49daa/test_coverage)](https://codeclimate.com/github/heronshoes/red_amber/test_coverage)
@@ -10,7 +10,7 @@
 A simple dataframe library for Ruby.
 
 - Powered by [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow)
-[![Gitter Chat](https://badges.gitter.im/red-data-tools/en.svg)](https://gitter.im/red-data-tools/en)
+[![Gitter Chat](https://badges.gitter.im/red-data-tools/en.svg)](https://gitter.im/red-data-tools/en) [![Gem Version](https://img.shields.io/gem/v/red-arrow?color=brightgreen)](https://rubygems.org/gems/red-arrow)
 - Inspired by the dataframe library [Rover-df](https://github.com/ankane/rover)
 
 ![screenshot from jupyterlab](https://raw.githubusercontent.com/heronshoes/red_amber/main/doc/image/screenshot.png)
@@ -130,7 +130,7 @@ For example, we can compute mean prices per cut for the data larger than 1 carat
 
 ```ruby
 df = diamonds
-  .slice { carat > 1 }
+  .slice { carat > 1 } # or use #filter instead of #slice
   .group(:cut)
   .mean(:price) # `pick` prior to `group` is not required if `:price` is specified here.
   .sort('-mean(price)')
@@ -179,7 +179,7 @@ starwars
   .drop(0) # delete unnecessary index column
   .remove { species == "NA" } # delete unnecessary rows
   .group(:species) { [count(:species), mean(:height, :mass)] }
-  .slice { count > 1 }
+  .slice { count > 1 } # or use #filter instead of slice
 
 # =>
 #<RedAmber::DataFrame : 8 x 4 Vectors, 0x000000000000f848>

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -572,7 +572,7 @@ penguins.to_rover
   [1, 2, 3]
   ```
 
-### `slice  `  - slice and select records -
+### `slice  `  - cut into slices of records -
 
   Slice and select records (rows) to create a sub DataFrame.
 
@@ -605,11 +605,14 @@ penguins.to_rover
 
 - Booleans as an argument
 
-  `slice(booleans)` accepts booleans as an argument in an Array, a Vector or an Arrow::BooleanArray . Booleans must be same length as `size`.
+  `filter(booleans)` or `slice(booleans)` accepts booleans as an argument in an Array, a Vector or an Arrow::BooleanArray . Booleans must be same length as `size`.
+
+  note: `slice(booleans)` is acceptable for orthogonality of `slice`/`remove`.
 
     ```ruby
     vector = penguins[:bill_length_mm]
-    penguins.slice(vector >= 40)
+    penguins.filter(vector >= 40)
+    # penguins.slice(vector >= 40) is also acceptable
 
     # =>
     #<RedAmber::DataFrame : 242 x 8 Vectors, 0x0000000000043d3c>

--- a/lib/red_amber/data_frame_selectable.rb
+++ b/lib/red_amber/data_frame_selectable.rb
@@ -292,14 +292,16 @@ module RedAmber
       case booleans
       in []
         return remove_all_values
+      in [Vector => v] if v.boolean?
+        filter_by_array(v.data)
+      in [Arrow::ChunkedArray => ca] if ca.boolean?
+        filter_by_array(ca)
       in [Arrow::BooleanArray => b]
         filter_by_array(b)
-      else
-        unless booleans.booleans?
-          raise DataFrameArgumentError, 'Argument is not a boolean.'
-        end
-
+      in Array if booleans.booleans?
         filter_by_array(Arrow::BooleanArray.new(booleans))
+      else
+        raise DataFrameArgumentError, 'Argument is not a boolean.'
       end
     end
 

--- a/lib/red_amber/data_frame_selectable.rb
+++ b/lib/red_amber/data_frame_selectable.rb
@@ -286,6 +286,8 @@ module RedAmber
     # @api private
     #   TODO: support for option `null_selection_behavior: :drop``
     def filter(*booleans)
+      raise DataFrameArgumentError, 'Self is an empty dataframe' if empty?
+
       booleans.flatten!
       case booleans
       in []

--- a/test/test_data_frame_selectable.rb
+++ b/test/test_data_frame_selectable.rb
@@ -557,8 +557,10 @@ class DataFrameSelectableTest < Test::Unit::TestCase
       @hash = { x: [1, nil], y: ['A', nil] }
     end
 
-    test 'empty dataframe' do
-      assert_true DataFrame.new({}, []).filter.empty?
+    test 'Empty dataframe' do
+      df = DataFrame.new
+      assert_raise(DataFrameArgumentError) { df.filter }
+      assert_raise(DataFrameArgumentError) { df.filter(true) }
     end
 
     test '#filter' do

--- a/test/test_data_frame_selectable.rb
+++ b/test/test_data_frame_selectable.rb
@@ -568,6 +568,7 @@ class DataFrameSelectableTest < Test::Unit::TestCase
       assert_equal @hash, @df.filter(*@booleans).to_h # arguments
       assert_equal @hash, @df.filter(@booleans).to_h # primitive Array
       assert_equal @hash, @df.filter(Arrow::BooleanArray.new(@booleans)).to_h # Arrow::BooleanArray
+      assert_equal @hash, @df.filter(Arrow::ChunkedArray.new([@booleans])).to_h
       assert_equal @hash, @df.filter(Vector.new(@booleans)).to_h # Vector
       assert_equal({ x: [], y: [] }, @df.filter([nil] * 5).to_h) # head only dataframe
     end
@@ -578,7 +579,7 @@ class DataFrameSelectableTest < Test::Unit::TestCase
     end
 
     test '#filter size unmatch' do
-      assert_raise(DataFrameArgumentError) { @df.filter([true]) } # out of lower limit
+      assert_raise(DataFrameArgumentError) { @df.filter([true]) }
     end
   end
 

--- a/test/test_data_frame_selectable.rb
+++ b/test/test_data_frame_selectable.rb
@@ -109,6 +109,20 @@ class DataFrameSelectableTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'error in []' do
+    setup do
+      @df = DataFrame.new(x: [1, 2, 3], y: %w[A B C])
+    end
+
+    test 'error by mixed args' do
+      assert_raise(DataFrameArgumentError) { @df[Date.today] }
+    end
+
+    test 'error by invalid args' do
+      assert_raise(DataFrameArgumentError) { @df[:x, -1] }
+    end
+  end
+
   setup do
     @df = DataFrame.new(
       {
@@ -261,27 +275,16 @@ class DataFrameSelectableTest < Test::Unit::TestCase
         2 :string string      2 ["B", "D"]
         3 :bool   boolean     1 {false=>2}
       OUTPUT
-      assert_equal str, @df.slice { [false, true, false, true, false] }.tdr_str
+      booleans = [false, true, false, true, false]
+      assert_equal str, @df.slice { booleans }.tdr_str
+      assert_equal str, @df.slice { Vector.new(booleans) }.tdr_str
+      assert_equal str, @df.slice { Arrow::Array.new(booleans) }.tdr_str
       assert_equal str, @df.slice { indexes.map(&:odd?) }.tdr_str
     end
 
     test 'slice by Enumerator' do
       df = DataFrame.new(x: [*0..10])
       assert_equal_array [1, 4, 7, 10], df.slice(1.step(by: 3, to: 10))[:x]
-    end
-  end
-
-  sub_test_case 'error in []' do
-    setup do
-      @df = DataFrame.new(x: [1, 2, 3], y: %w[A B C])
-    end
-
-    test 'error by mixed args' do
-      assert_raise(DataFrameArgumentError) { @df[Date.today] }
-    end
-
-    test 'error by invalid args' do
-      assert_raise(DataFrameArgumentError) { @df[:x, -1] }
     end
   end
 
@@ -347,6 +350,61 @@ class DataFrameSelectableTest < Test::Unit::TestCase
         3 :bool   boolean     2 {true=>2, false=>1}
       OUTPUT
       assert_equal str, @df.slice_by(:string, keep_key: true) { 0..2 }.tdr_str
+    end
+  end
+
+  sub_test_case '#filter(booleans)' do
+    setup do
+      @df = RedAmber::DataFrame.new(x: [1, 2, 3, 4, nil], y: %w[A B C D] << nil)
+      @booleans = [true, false, nil, false, true]
+      @hash = { x: [1, nil], y: ['A', nil] }
+    end
+
+    test '#filter for an empty dataframe' do
+      df = DataFrame.new
+      assert_raise(DataFrameArgumentError) { df.filter }
+      assert_raise(DataFrameArgumentError) { df.filter(true) }
+    end
+
+    test '#filter with both arguments and a block' do
+      assert_raise(DataFrameArgumentError) { @df.filter(1) { 2 } }
+    end
+
+    test '#filter(booleans)' do
+      assert_equal({ x: [], y: [] }, @df.filter.to_h) # nothing to get
+      assert_equal @hash, @df.filter(*@booleans).to_h # arguments
+      assert_equal @hash, @df.filter(@booleans).to_h # primitive Array
+      assert_equal @hash, @df.filter(Arrow::BooleanArray.new(@booleans)).to_h # Arrow::BooleanArray
+      assert_equal @hash, @df.filter(Arrow::ChunkedArray.new([@booleans])).to_h
+      assert_equal @hash, @df.filter(Vector.new(@booleans)).to_h # Vector
+    end
+
+    test '#filter resulting head only dataframe' do
+      booleans = [false] * 5
+      assert_equal({ x: [], y: [] }, @df.filter(booleans).to_h)
+    end
+
+    test '#filter { booleans }' do
+      booleans = @booleans
+      assert_equal({ x: [], y: [] }, @df.filter { [] }.to_h) # nothing to get
+      assert_equal @hash, @df.filter { booleans }.to_h # boolean Array
+      assert_equal @hash, @df.filter { Arrow::BooleanArray.new(booleans) }.to_h # Arrow::BooleanArray
+      assert_equal @hash, @df.filter { Arrow::ChunkedArray.new([booleans]) }.to_h
+      assert_equal @hash, @df.filter { Vector.new(booleans) }.to_h # Vector
+    end
+
+    test '#filter resulting head only dataframe by block' do
+      booleans = [false] * 5
+      assert_equal({ x: [], y: [] }, @df.filter { booleans }.to_h)
+    end
+
+    test '#filter not booleans' do
+      assert_raise(DataFrameArgumentError) { @df.filter(1) }
+      assert_raise(DataFrameArgumentError) { @df.filter([*1..5]) }
+    end
+
+    test '#filter size unmatch' do
+      assert_raise(DataFrameArgumentError) { @df.filter([true]) }
     end
   end
 
@@ -547,39 +605,6 @@ class DataFrameSelectableTest < Test::Unit::TestCase
       assert_raise(Arrow::Error::Index) { @df.take([-6]) } # out of lower limit
       assert_raise(TypeError) { @df.take(5) } # Not accept scalar
       assert_raise(Arrow::Error::Index) { @df.take([5]) } # out of upper limit
-    end
-  end
-
-  sub_test_case '#filter(booleans)' do
-    setup do
-      @df = RedAmber::DataFrame.new(x: [1, 2, 3, 4, nil], y: %w[A B C D] << nil)
-      @booleans = [true, false, nil, false, true]
-      @hash = { x: [1, nil], y: ['A', nil] }
-    end
-
-    test 'Empty dataframe' do
-      df = DataFrame.new
-      assert_raise(DataFrameArgumentError) { df.filter }
-      assert_raise(DataFrameArgumentError) { df.filter(true) }
-    end
-
-    test '#filter' do
-      assert_equal({ x: [], y: [] }, @df.filter.to_h) # nothing to get
-      assert_equal @hash, @df.filter(*@booleans).to_h # arguments
-      assert_equal @hash, @df.filter(@booleans).to_h # primitive Array
-      assert_equal @hash, @df.filter(Arrow::BooleanArray.new(@booleans)).to_h # Arrow::BooleanArray
-      assert_equal @hash, @df.filter(Arrow::ChunkedArray.new([@booleans])).to_h
-      assert_equal @hash, @df.filter(Vector.new(@booleans)).to_h # Vector
-      assert_equal({ x: [], y: [] }, @df.filter([nil] * 5).to_h) # head only dataframe
-    end
-
-    test '#filter not booleans' do
-      assert_raise(DataFrameArgumentError) { @df.filter(1) }
-      assert_raise(DataFrameArgumentError) { @df.filter([*1..5]) }
-    end
-
-    test '#filter size unmatch' do
-      assert_raise(DataFrameArgumentError) { @df.filter([true]) }
     end
   end
 


### PR DESCRIPTION
For `DataFrame#filter`,
- Fix to return error for empty DataFrame
- Enable to accept block
- Enable to accept Arrow::ChunkedArray
- Primarily use `#filter` rather than `#slice` in filtering in document
  - `#slice` is remain as it is for orthogonality

