### PR TITLE
Introduce Vector#propagate

### DIFF
--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -182,6 +182,31 @@ boolean.all(skip_nulls: true) #=> true
 boolean.all(skip_nulls: false) #=> false
 ```
 
+### Check if `function` is an aggregation function: `Vector.aggregate?(function)`
+
+Return true if `function` is an unary aggregation function. Otherwise return false.
+
+### Treat aggregation function as an element-wise function: `propagate(function)`
+
+Spread the return value of an aggregate function as if it is a element-wise function.
+
+```ruby
+vec = Vector.new(1, 2, 3, 4)
+vec.propagate(:mean)
+# =>
+#<RedAmber::Vector(:double, size=4):0x000000000001985c>
+[2.5, 2.5, 2.5, 2.5]
+```
+
+`#propagate` also accepts a block to compute with a customized aggregation function yielding a scalar.
+
+```ruby
+vec.propagate { |v| v.mean.round }
+# =>
+#<RedAmber::Vector(:uint8, size=4):0x000000000000cb98>                     
+[3, 3, 3, 3]
+```
+
 ### Unary element-wise: `vector.func => vector`
 
   ![unary element-wise](doc/image/../../image/vector/unary_element_wise.png)

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -20,6 +20,26 @@ module RedAmber
       instance
     end
 
+    # Return true if it is an aggregation function.
+    #
+    # @param function [Symbol] function name to test.
+    # @return [Booleans] true if function is a aggregation function, otherwise false.
+    #
+    # @example
+    #   Vector.aggregate?(:mean) # => true
+    #
+    #   Vector.aggregate?(:round) # => false
+    #   
+    # @since 0.3.1
+    #
+    def self.aggregate?(function)
+      %i[
+        all all? any any? approximate_median count count_distinct count_uniq
+        max mean median min min_max product quantile sd std stddev sum
+        unbiased_variance var variance
+      ].include?(function.to_sym)
+    end
+
     # Create a Vector.
     #
     # @note default is headless Vector and '@key == nil'

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -225,23 +225,33 @@ module RedAmber
     # Spread the return value of an aggregate function as if
     #   it is a element-wise function.
     #
-    # @param function [Symbol] a name of aggregation function for self.
-    #   Return value of the function must be a scalar.
-    # @return [Vector] Returns a Vector that is the same size as self
-    #   and such that all elements are the same as the result of aggregation `function`.
+    # @overload propagate(function)
+    #   Returns a Vector of same size as self spreading the value from function.
     #
-    # @example method name
-    #   vec = Vector.new(1, 2, 3, 4)
-    #   vec.propagate(:mean)
-    #   # =>
-    #   #<RedAmber::Vector(:double, size=4):0x000000000001985c>
-    #   [2.5, 2.5, 2.5, 2.5]
+    #   @param function [Symbol] a name of aggregation function for self.
+    #     Return value of the function must be a scalar.
+    #   @return [Vector] Returns a Vector that is the same size as self
+    #     and such that all elements are the same as the result of aggregation `function`.
+    #   @example propagate by an aggragation function name
+    #     vec = Vector.new(1, 2, 3, 4)
+    #     vec.propagate(:mean)
+    #     # =>
+    #     #<RedAmber::Vector(:double, size=4):0x000000000001985c>
+    #     [2.5, 2.5, 2.5, 2.5]
     #
-    # @example with a block
-    #   vec.propagate { |v| v.mean }
-    #   # =>
-    #   #<RedAmber::Vector(:double, size=4):0x000000000001985c>
-    #   [2.5, 2.5, 2.5, 2.5]
+    # @overload propagate
+    #   Returns a Vector of same size as self spreading the value from block.
+    #
+    #   @yield [self] gives self to the block.
+    #   @yieldparam self [Vector] self.
+    #   @yieldreturn [scalar] a scalar value.
+    #   @return [Vector] Returns a Vector that is the same size as self
+    #     and such that all elements are the same as the yielded value from the block.
+    #   @example propagate by a block
+    #     vec.propagate { |v| v.mean.round }
+    #     # =>
+    #     #<RedAmber::Vector(:uint8, size=4):0x000000000000cb98>                     
+    #     [3, 3, 3, 3]
     #
     # @since 0.3.1
     #

--- a/test/test_vector.rb
+++ b/test/test_vector.rb
@@ -6,6 +6,16 @@ class VectorTest < Test::Unit::TestCase
   include TestHelper
   include RedAmber
 
+  sub_test_case 'self.aggregate?' do
+    test 'self.aggregate?(:mean)' do
+      assert_true Vector.aggregate?(:mean)
+    end
+
+    test 'self.aggregate?(:round)' do
+      assert_false Vector.aggregate?(:round)
+    end
+  end
+
   sub_test_case '#initialize' do
     test 'initialize by empty array' do
       assert_equal_array [], Vector.new([])

--- a/test/test_vector.rb
+++ b/test/test_vector.rb
@@ -249,4 +249,28 @@ class VectorTest < Test::Unit::TestCase
       assert_equal 'RedAmber::Vector(:string, size=16)', @string.inspect
     end
   end
+
+  sub_test_case '#propagate' do
+    setup do
+      @vector = Vector.new(1, 2, 3, 4)
+      @expected = [2.5, 2.5, 2.5, 2.5]
+    end
+
+    test 'propagate mean' do
+      assert_equal_array @expected, @vector.propagate(:mean)
+    end
+
+    test 'propagate by block' do
+      # same as @vector.propagate { |v| v.mean }
+      assert_equal_array @expected, @vector.propagate(&:mean)
+    end
+
+    test 'propagate with element-wise method' do
+      assert_raise(VectorArgumentError) { @vector.propagate(:round) }
+    end
+
+    test 'propagate with argument and block' do
+      assert_raise(VectorArgumentError) { @vector.propagate(:mean) { 2.5 } }
+    end
+  end
 end


### PR DESCRIPTION
Introduce a function of function to convert aggregate function to element-wise function.
## `Vector#propagate`
- Accepts an aggregation function name
- Accepts a block yielding a scalar to use as a customized aggregation function.

## `Vector.aggregate?(function)`
Check if `function` is an aggregation function.
