### PR TITLE
Introduce Vector#sample

### DIFF
--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -749,3 +749,25 @@ v.sample(2.0)
 #<RedAmber::Vector(:string, size=16):0x00000000000233e8>
 ["H", "B", "C", "B", "C", "A", "F", "A", "E", "C", "H", "F", "F", "A", ... ]
 ```
+
+### `sort(integer_or_proportion)`
+
+Arrange values in Vector.
+
+- `:+`, `:ascending` or without argument will sort in increasing order.
+- `:-` or `:descending` will sort in decreasing order.
+
+```ruby
+Vector.new(%w[B D A E C]).sort
+# same as #sort(:+)
+# same as #sort(:ascending)
+# =>
+#<RedAmber::Vector(:string, size=5):0x000000000000c134>
+["A", "B", "C", "D", "E"]
+
+Vector.new(%w[B D A E C]).sort(:-)
+# same as #sort(:descending)
+# =>
+#<RedAmber::Vector(:string, size=5):0x000000000000c148>
+["E", "D", "C", "B", "A"]
+```

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -663,3 +663,89 @@ sv.rank
 #<RedAmber::Vector(:uint64, size=5):0x0000000000003868>
 [0, 2, 4, 1, 3]
 ```
+
+### `sample(integer_or_proportion)`
+
+Pick up elements at random.
+
+#### `sample` : without agrument
+
+Return a randomly selected element.
+This is one of an aggregation function.
+
+```ruby
+v = Vector.new('A'..'H'); v
+# =>
+#<RedAmber::Vector(:string, size=8):0x0000000000011b20>
+["A", "B", "C", "D", "E", "F", "G", "H"]
+
+v.sample
+# =>
+"C"
+```
+
+#### `sample(n)` : n as a Integer
+
+Pick up n elements at random.
+
+- Param `n` is number of elements to pick.
+- `n` is a positive Integer
+- If `n` is smaller or equal to size, elements are picked by non-repeating.
+- If `n` is greater than `size`, elements are picked repeatedly.
+@return [Vector] sampled elements.
+- If `n == 1` (in case of `sample(1)`), it returns a Vector of `size == 1` not a scalar.
+
+```ruby
+v.sample(1)
+# =>
+#<RedAmber::Vector(:string, size=1):0x000000000001a3b0>
+["H"]
+```
+
+Sample same size of self: every element is picked in random order.
+
+```ruby
+v.sample(8)
+# =>
+#<RedAmber::Vector(:string, size=8):0x000000000001bda0>
+["H", "D", "B", "F", "E", "A", "G", "C"]
+```
+
+Over sampling: "E" and "A" are sampled repeatedly.
+
+```ruby
+v.sample(9)
+# =>
+#<RedAmber::Vector(:string, size=9):0x000000000001d790>
+["E", "E", "A", "D", "H", "C", "A", "F", "H"]
+```
+
+#### `sample(prop)` : prop as a Float
+
+Pick up elements by proportion `prop` at random.
+
+- `prop` is proportion of elements to pick.
+- `prop` is a positive Float.
+- Absolute number of elements to pick:`prop*size` is rounded (by `half: :up`).
+- If `prop` is smaller or equal to 1.0, elements are picked by non-repeating.
+- If `prop` is greater than 1.0, some elements are picked repeatedly.
+- Returns sampled elements by a Vector.
+- If picked element is only one, it returns a Vector of `size == 1` not a scalar.
+
+Sample same size of self: every element is picked in random order.
+
+```ruby
+v.sample(1.0)
+# =>
+#<RedAmber::Vector(:string, size=8):0x000000000001bda0>
+["D", "H", "F", "C", "A", "B", "E", "G"]
+```
+
+2 times over sampling.
+
+```ruby
+v.sample(2.0)
+# =>
+#<RedAmber::Vector(:string, size=16):0x00000000000233e8>
+["H", "B", "C", "B", "C", "A", "F", "A", "E", "C", "H", "F", "F", "A", ... ]
+```

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -626,3 +626,40 @@ vector.merge(other, sep: '')
 #<RedAmber::Vector(:string, size=3):0x0000000000038b80>
 ["ab", "cd", "ef"]
 ```
+
+### `rank`
+
+Returns numerical rank of self.
+- Nil values are considered greater than any value.
+- NaN values are considered greater than any value but smaller than nil values.
+- Tiebreakers are ranked in order of appearance.
+- `RankOptions` in C++ function is not implemented in C GLib yet.
+  This method is currently fixed to the default behavior.
+
+Returns 0-based rank of self (0...size in range) as a Vector.
+
+Rank of float Vector
+```ruby
+fv = Vector.new(0.1, nil, Float::NAN, 0.2, 0.1); fv
+# =>
+#<RedAmber::Vector(:double, size=5):0x000000000000c65c>
+[0.1, nil, NaN, 0.2, 0.1]
+
+fv.rank
+# =>
+#<RedAmber::Vector(:uint64, size=5):0x0000000000003868>
+[0, 4, 3, 2, 1]
+```
+
+Rank of string Vector
+```ruby
+sv = Vector.new("A", "B", nil, "A", "C"); sv
+# =>
+#<RedAmber::Vector(:string, size=5):0x0000000000003854>
+["A", "B", nil, "A", "C"]
+
+sv.rank
+# =>
+#<RedAmber::Vector(:uint64, size=5):0x0000000000003868>
+[0, 2, 4, 1, 3]
+```

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -144,6 +144,42 @@ module RedAmber
       Vector.create(datum.value)
     end
 
+    # Arrange values in Vector.
+    #
+    # @param order [Symbol] sort order.
+    #   - `:+`, `:ascending` or without argument will sort in increasing order.
+    #   - `:-` or `:descending` will sort in decreasing order.
+    # @return [Vector] sorted Vector.
+    # @example sort in increasing order (default)
+    #   Vector.new(%w[B D A E C]).sort
+    #   # same as #sort(:+)
+    #   # same as #sort(:ascending)
+    #   # =>
+    #   #<RedAmber::Vector(:string, size=5):0x000000000000c134>
+    #   ["A", "B", "C", "D", "E"]
+    #
+    # @example sort in decreasing order
+    #   Vector.new(%w[B D A E C]).sort(:-)
+    #   # same as #sort(:descending)
+    #   # =>
+    #   #<RedAmber::Vector(:string, size=5):0x000000000000c148>
+    #   ["E", "D", "C", "B", "A"]
+    #
+    # @since 0.3.1
+    #
+    def sort(order = :ascending)
+      order =
+        case order.to_sym
+        when :+, :ascending, :increasing
+          :ascending
+        when :-, :descending, :decreasing
+          :descending
+        else
+          raise VectorArgumentError, "illegal order option: #{order}"
+        end
+      take(sort_indices(order: order))
+    end
+
     # Returns numerical rank of self.
     #   - Nil values are considered greater than any value.
     #   - NaN values are considered greater than any value but smaller than nil values.

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -144,6 +144,43 @@ module RedAmber
       Vector.create(datum.value)
     end
 
+    # Returns numerical rank of self.
+    #   - Nil values are considered greater than any value.
+    #   - NaN values are considered greater than any value but smaller than nil values.
+    #   - Tiebreakers are ranked in order of appearance.
+    #   - `RankOptions` in C++ function is not implemented in C GLib yet.
+    #     This method is currently fixed to the default behavior.
+    #
+    # @return [Vector] 0-based rank of self (0...size in range).
+    # @example rank of float Vector
+    #   fv = Vector.new(0.1, nil, Float::NAN, 0.2, 0.1); fv
+    #   # =>
+    #   #<RedAmber::Vector(:double, size=5):0x000000000000c65c>
+    #   [0.1, nil, NaN, 0.2, 0.1]
+    #
+    #   fv.rank
+    #   # =>
+    #   #<RedAmber::Vector(:uint64, size=5):0x0000000000003868>
+    #   [0, 4, 3, 2, 1]
+    #
+    # @example rank of string Vector
+    #   sv = Vector.new("A", "B", nil, "A", "C"); sv
+    #   # =>
+    #   #<RedAmber::Vector(:string, size=5):0x0000000000003854>
+    #   ["A", "B", nil, "A", "C"]
+    #
+    #   sv.rank
+    #   # =>
+    #   #<RedAmber::Vector(:uint64, size=5):0x0000000000003868>
+    #   [0, 2, 4, 1, 3]
+    #
+    # @since 0.3.1
+    #
+    def rank
+      datum = Arrow::Function.find(:rank).execute([data])
+      Vector.create(datum.value) - 1
+    end
+
     private
 
     # Accepts indices by numeric Vector

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -181,6 +181,103 @@ module RedAmber
       Vector.create(datum.value) - 1
     end
 
+    # Pick up elements at random.
+    #
+    # @overload sample()
+    #   Return a randomly selected element.
+    #   This is one of an aggregation function.
+    #
+    #   @return [scalar] one of an element in self.
+    #   @example sample a element
+    #     v = Vector.new('A'..'H'); v
+    #     # =>
+    #     #<RedAmber::Vector(:string, size=8):0x0000000000011b20>
+    #     ["A", "B", "C", "D", "E", "F", "G", "H"]
+    #
+    #     v.sample
+    #     # =>
+    #     "C"
+    #
+    # @overload sample(n)
+    #   Pick up n elements at random.
+    #
+    #   @param n [Integer] positive number of elements to pick.
+    #     If n is smaller or equal to size, elements are picked by non-repeating.
+    #     If n is greater than `size`, elements are picked repeatedly.
+    #   @return [Vector] sampled elements.
+    #     If n == 1 (in case of `sample(1)`), it returns a Vector of size == 1
+    #     not a scalar.
+    #   @example sample Vector in size 1
+    #     v.sample(1)
+    #     # =>
+    #     #<RedAmber::Vector(:string, size=1):0x000000000001a3b0>
+    #     ["H"]
+    #
+    #   @example sample same size of self: every element is picked in random order
+    #     v.sample(8)
+    #     # =>
+    #     #<RedAmber::Vector(:string, size=8):0x000000000001bda0>
+    #     ["H", "D", "B", "F", "E", "A", "G", "C"]
+    #
+    #   @example over sampling: "E" and "A" are sampled repeatedly
+    #     v.sample(9)
+    #     # =>
+    #     #<RedAmber::Vector(:string, size=9):0x000000000001d790>
+    #     ["E", "E", "A", "D", "H", "C", "A", "F", "H"]
+    #
+    # @overload sample(prop)
+    #   Pick up elements by proportion `prop` at random.
+    #
+    #   @param prop [Float] positive proportion of elements to pick.
+    #     Absolute number of elements to pick:`prop*size` is rounded (by `half: :up``).
+    #     If prop is smaller or equal to 1.0, elements are picked by non-repeating.
+    #     If prop is greater than 1.0, some elements are picked repeatedly.
+    #   @return [Vector] sampled elements.
+    #     If picked element is only one, it returns a Vector of size == 1
+    #     not a scalar.
+    #   @example sample same size of self: every element is picked in random order
+    #     v.sample(1.0)
+    #     # =>
+    #     #<RedAmber::Vector(:string, size=8):0x000000000001bda0>
+    #     ["D", "H", "F", "C", "A", "B", "E", "G"]
+    #
+    #   @example 2 times over sampling
+    #     v.sample(2.0)
+    #     # =>
+    #     #<RedAmber::Vector(:string, size=16):0x00000000000233e8>
+    #     ["H", "B", "C", "B", "C", "A", "F", "A", "E", "C", "H", "F", "F", "A", ... ]
+    #
+    # @since 0.3.1
+    #
+    def sample(n_or_prop = nil)
+      require 'arrow-numo-narray'
+
+      return nil if size == 0
+
+      n_sample =
+        case n_or_prop
+        in Integer
+          n_or_prop
+        in Float
+          (n_or_prop * size).round
+        in nil
+          return to_a.sample
+        else
+          raise VectorArgumentError, "must specify Integer or Float but #{n_or_prop}"
+        end
+      if n_or_prop < 0
+        raise VectorArgumentError, '#sample does not accept negative number.'
+      end
+      return Vector.new([]) if n_sample == 0
+
+      over_sample = [8 * size, n_sample].max
+      over_size = n_sample > size ? n_sample / size * size * 2 : size
+      over_vector =
+        Vector.create(Numo::UInt32.new(over_size).rand(over_sample).to_arrow_array)
+      indices = over_vector.rank.take(*0...n_sample)
+      take(indices - ((indices / size) * size))
+    end
+
     private
 
     # Accepts indices by numeric Vector

--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -219,4 +219,81 @@ class VectorTest < Test::Unit::TestCase
       assert_equal_array expect, Vector.new(string).rank
     end
   end
+
+  sub_test_case '#sample' do
+    setup do
+      @vector = Vector.new('A'..'H')
+    end
+
+    test '#sample empty Vector' do
+      assert_nil Vector.new([]).sample(1)
+    end
+
+    test '#sample negative number' do
+      assert_raise(VectorArgumentError) { @vector.sample(-1) }
+      assert_raise(VectorArgumentError) { @vector.sample(-1.0) }
+    end
+
+    test '#sample(0)' do
+      assert_equal_array [], @vector.sample(0)
+    end
+
+    test '#sample not a number' do
+      assert_raise(VectorArgumentError) { @vector.sample('1') }
+    end
+
+    test '#sample without argument' do
+      sampled = @vector.sample
+      assert_true @vector.to_a.include?(sampled)
+    end
+
+    test '#sample(1)' do
+      sampled = @vector.sample(1)
+      assert_kind_of Vector, sampled
+      assert_equal 1, sampled.size
+      assert_true sampled.is_in(@vector).all?
+    end
+
+    test '#sample by integer smaller than size' do
+      sampled = @vector.sample(3)
+      assert_equal 3, sampled.size
+      assert_equal 3, sampled.uniq.size
+      assert_true sampled.is_in(@vector).all?
+    end
+
+    test '#sample by integer equals to size' do
+      sampled = @vector.sample(8)
+      assert_equal 8, sampled.size
+      assert_equal 8, sampled.uniq.size
+      assert_true sampled.is_in(@vector).all?
+    end
+
+    test '#sample by integer oversampling' do
+      sampled = @vector.sample(10)
+      assert_equal 10, sampled.size
+      assert_true sampled.uniq.size <= 8
+      assert_true sampled.is_in(@vector).all?
+    end
+
+    test '#sample by float smaller than size' do
+      sampled = @vector.sample(0.7)
+      assert_equal 6, sampled.size
+      assert_equal 6, sampled.uniq.size
+      assert_true sampled.is_in(@vector).all?
+    end
+
+    test '#sample by float equals to size' do
+      sampled = @vector.sample(1.0)
+      assert_equal 8, sampled.size
+      assert_equal 8, sampled.uniq.size
+      assert_true sampled.is_in(@vector).all?
+    end
+
+    test '#sample by float oversampling' do
+      sampled = @vector.sample(2.0)
+      assert_equal 16, sampled.size
+      assert_true sampled.uniq.size <= 8
+      assert_true sampled.is_in(@vector).all?
+    end
+  end
 end

--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -210,6 +210,32 @@ class VectorTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case '#sort' do
+    setup do
+      @source = Vector.new(%w[B D A E C])
+      @ascending = [*'A'..'E']
+    end
+
+    test '#sort in ascending order' do
+      assert_equal_array @ascending, @source.sort
+      assert_equal_array @ascending, @source.sort(:+)
+      assert_equal_array @ascending, @source.sort('+')
+      assert_equal_array @ascending, @source.sort(:ascending)
+      assert_equal_array @ascending, @source.sort(:increasing)
+    end
+
+    test '#sort in descending order' do
+      assert_equal_array @ascending.reverse, @source.sort(:-)
+      assert_equal_array @ascending.reverse, @source.sort('-')
+      assert_equal_array @ascending.reverse, @source.sort(:descending)
+      assert_equal_array @ascending.reverse, @source.sort(:decreasing)
+    end
+
+    test '#sort with illegal argument' do
+      assert_raise(VectorArgumentError) { @source.sort :red_amber }
+    end
+  end
+
   sub_test_case '#rank' do
     test '#rank default option' do
       float = [0.1, nil, Float::NAN, 0.2, 0.1]

--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -6,19 +6,6 @@ class VectorTest < Test::Unit::TestCase
   include TestHelper
   include RedAmber
 
-  sub_test_case('drop_nil') do
-    test 'empty vector' do
-      assert_equal_array [], Vector.new([]).drop_nil
-    end
-
-    test 'drop_nil' do
-      assert_equal_array [1, 2], Vector.new([1, 2, nil]).drop_nil
-      assert_equal_array %w[A B], Vector.new(['A', 'B', nil]).drop_nil
-      assert_equal_array [true, false], Vector.new([true, false, nil]).drop_nil
-      assert_equal_array [], Vector.new([nil, nil, nil]).drop_nil
-    end
-  end
-
   sub_test_case('#take(indices)') do
     setup do
       @string = Vector.new(%w[A B C D E])
@@ -207,6 +194,29 @@ class VectorTest < Test::Unit::TestCase
       assert_equal 3, vector.index(nil)
       assert_nil vector.index(0) # out of range
       assert_equal 1, vector.index(2.0) # types are ignored
+    end
+  end
+
+  sub_test_case '#drop_nil' do
+    test 'empty vector' do
+      assert_equal_array [], Vector.new([]).drop_nil
+    end
+
+    test '#drop_nil' do
+      assert_equal_array [1, 2], Vector.new([1, 2, nil]).drop_nil
+      assert_equal_array %w[A B], Vector.new(['A', 'B', nil]).drop_nil
+      assert_equal_array [true, false], Vector.new([true, false, nil]).drop_nil
+      assert_equal_array [], Vector.new([nil, nil, nil]).drop_nil
+    end
+  end
+
+  sub_test_case '#rank' do
+    test '#rank default option' do
+      float = [0.1, nil, Float::NAN, 0.2, 0.1]
+      string = ['A', nil, 'C', 'B', 'A']
+      expect = [0, 4, 3, 2, 1]
+      assert_equal_array expect, Vector.new(float).rank
+      assert_equal_array expect, Vector.new(string).rank
     end
   end
 end


### PR DESCRIPTION
This PR will add new methods in Vector.

## Vector#rank

This method returns numerical rank of self.

`RankOptions` in C++ function is not implemented in C GLib yet. This method is currently fixed to the default behavior.

## Vector#sample

Pick up elements at random.

- Accepts Integer or Float as sample size.
  - When it is Integer (`n`), it specifies sample number itself.
  - When it is Float (`prop`), it specifies proportion for sampling.
- If `n <= self.size` (or prop <= 1.0), do non-repeating sampling.
- If `n > self.size` (or prop > 1.0), do repeating sampling.

## Vector#sort

Sort self.

- Sort ascending order by default or options `:+`, `:ascending` are specified.
- Sort descending order with options `:-` or `:descending` are specified.
