### PR TITLE
Introduce sub frames

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -140,7 +140,7 @@ Metrics/MethodLength:
     'format_table', # 53
     'slice_by', # 38
     'assign_update', # 35
-    'initialize', # 31 (SubFrames)
+    'aggregate', # 31
   ]
 
 # Max: 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,7 @@ Metrics/ClassLength:
     - 'test/**/*'
     - 'lib/red_amber/data_frame.rb' # 162
     - 'lib/red_amber/group.rb' # 105
+    - 'lib/red_amber/subframes.rb' # 110
     - 'lib/red_amber/vector.rb' # 152
 
 # Only for monitoring. I will measure by PerceivedComplexity.
@@ -139,6 +140,7 @@ Metrics/MethodLength:
     'format_table', # 53
     'slice_by', # 38
     'assign_update', # 35
+    'initialize', # 31 (SubFrames)
   ]
 
 # Max: 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -179,6 +179,7 @@ Metrics/PerceivedComplexity:
     'dataframe_info', # 13
     'replace', # 13
     'drop', # 12
+    'initialize', # 12
     '[]', # 11
     'filters', # 11
     'html_table', # 11

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,6 +182,7 @@ Metrics/PerceivedComplexity:
     'replace', # 13
     'drop', # 12
     'initialize', # 12
+    'aggregate', # 12
     '[]', # 11
     'filters', # 11
     'html_table', # 11

--- a/doc/SubFrames.md
+++ b/doc/SubFrames.md
@@ -1,0 +1,11 @@
+# SubFrames
+
+`SubFrames` represents a collection of subsets of a DataFrame.
+It has an Array of indices `#subset_indices` which is able to create an Array of sub DataFrames.
+The concept includes `group` operation of a Dataframe, rolling window operation and has more broad capabilities.
+
+This feature is experimental. It may be removed or be changed in the future.
+
+## Create SubFrames
+
+## Properties of SubFrames

--- a/lib/red_amber.rb
+++ b/lib/red_amber.rb
@@ -14,6 +14,7 @@ require_relative 'red_amber/data_frame_selectable'
 require_relative 'red_amber/data_frame_variable_operation'
 require_relative 'red_amber/data_frame'
 require_relative 'red_amber/group'
+require_relative 'red_amber/subframes'
 require_relative 'red_amber/vector_aggregation'
 require_relative 'red_amber/vector_binary_element_wise'
 require_relative 'red_amber/vector_unary_element_wise'
@@ -38,4 +39,7 @@ module RedAmber
 
   # Argument error in Group
   class GroupArgumentError < ArgumentError; end
+
+  # Argument error in SubFrames
+  class SubFramesArgumentError < ArgumentError; end
 end

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -384,7 +384,7 @@ module RedAmber
     #
     #   # =>
     #   #<RedAmber::SubFrames : 0x000000000000fc08>
-    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
     #   3 SubFrames: [2, 3, 1] in sizes.
     #   ---
     #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fc1c>
@@ -428,7 +428,7 @@ module RedAmber
     #
     #   # =>
     #   #<RedAmber::SubFrames : 0x000000000000fc58>
-    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
     #   2 SubFrames: [4, 4] in sizes.
     #   ---
     #   #<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fc6c>
@@ -473,7 +473,7 @@ module RedAmber
     #
     #   # =>
     #   #<RedAmber::SubFrames : 0x000000000000fd20>
-    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
     #   2 SubFrames: [3, 3] in sizes.
     #   ---
     #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fd34>
@@ -495,7 +495,7 @@ module RedAmber
     #
     #   # =>
     #   #<RedAmber::SubFrames : 0x000000000000fd98>
-    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
     #   3 SubFrames: [4, 4, 4] in sizes.
     #   ---
     #   #<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fdac>
@@ -545,7 +545,7 @@ module RedAmber
     #
     #   # =>
     #   #<RedAmber::SubFrames : 0x000000000000fde8>
-    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
     #   2 SubFrames: [2, 2] in sizes.
     #   ---
     #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fdfc>
@@ -589,7 +589,7 @@ module RedAmber
     #
     #     # =>
     #     #<RedAmber::SubFrames : 0x000000000000fe9c>
-    #     @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #     @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
     #     2 SubFrames: [3, 3] in sizes.
     #     ---
     #     #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000feb0>
@@ -623,7 +623,7 @@ module RedAmber
     #
     #     # =>
     #     #<RedAmber::SubFrames : 0x000000000000fe60>
-    #     @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #     @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
     #     2 SubFrames: [3, 3] in sizes.
     #     ---
     #     #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fe74>

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -17,20 +17,22 @@ module RedAmber
     using RefineArrowTable
     using RefineHash
 
-    # Quicker DataFrame constructor from a `Arrow::Table`.
-    #
-    # @param table [Arrow::Table]
-    #   A table to have in the DataFrame.
-    # @return [DataFrame]
-    #   Initialized DataFrame.
-    #
-    # @note This method will allocate table directly and may be used in the method.
-    # @note `table` must have unique keys.
-    #
-    def self.create(table)
-      instance = allocate
-      instance.instance_variable_set(:@table, table)
-      instance
+    class << self
+      # Quicker DataFrame constructor from a `Arrow::Table`.
+      #
+      # @param table [Arrow::Table]
+      #   A table to have in the DataFrame.
+      # @return [DataFrame]
+      #   Initialized DataFrame.
+      #
+      # @note This method will allocate table directly and may be used in the method.
+      # @note `table` must have unique keys.
+      #
+      def create(table)
+        instance = allocate
+        instance.instance_variable_set(:@table, table)
+        instance
+      end
     end
 
     # Creates a new DataFrame.
@@ -368,6 +370,284 @@ module RedAmber
       g = Group.new(self, group_keys)
       g = g.summarize(&block) if block
       g
+    end
+
+    # Create SubFrames by value grouping.
+    #
+    # [Experimental feature] this method may be removed or be changed in the future.
+    # @param keys [Symbol, String, Array<Symbol, String>]
+    #   grouping keys.
+    # @return [SubFrames]
+    #   a created SubFrames grouped by column values on `keys`.
+    # @example
+    #   df.sub_by_value(keys: :y)
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x000000000000fc08>
+    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   3 SubFrames: [2, 3, 1] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fc1c>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fc30>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       4 B        (nil)
+    #   2       5 B        true
+    #   ---
+    #   #<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000fc44>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       6 C        false
+    #
+    # @since 0.3.1
+    #
+    def sub_by_value(keys: nil)
+      SubFrames.new(self, group(keys).filters)
+    end
+    alias_method :subframes_by_value, :sub_by_value
+
+    # Create SubFrames by Windowing with `from`, `size` and `step`.
+    #
+    # [Experimental feature] this method may be removed or be changed in the future.
+    # @param from [Integer]
+    #   start position of window.
+    # @param size [Integer]
+    #   window size.
+    # @param step [Integer]
+    #   moving step of window.
+    # @return [SubFrames]
+    #   a created SubFrames.
+    # @example
+    #   df.sub_by_window(size: 4, step: 2)
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x000000000000fc58>
+    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   2 SubFrames: [4, 4] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fc6c>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   2       3 B        false
+    #   3       4 B        (nil)
+    #   ---
+    #   #<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fc80>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       4 B        (nil)
+    #   2       5 B        true
+    #   3       6 C        false
+    #
+    # @since 0.3.1
+    #
+    def sub_by_window(from: 0, size: nil, step: 1)
+      SubFrames.new(self) do
+        from.step(by: step, to: (size() - size)).map do |i| # rubocop:disable Style/MethodCallWithoutArgsParentheses
+          [*i...(i + size)]
+        end
+      end
+    end
+    alias_method :subframes_by_window, :sub_by_window
+
+    # Create SubFrames by Grouping/Windowing by posion from a enumrator method.
+    #
+    # This method will process the indices of self by enumerator.
+    # [Experimental feature] this method may be removed or be changed in the future.
+    # @param enumerator_method [Symbol]
+    #   Enumerator name.
+    # @param args [<Object>]
+    #   arguments for the enumerator method.
+    # @return [SubFrames]
+    #   a created SubFrames.
+    # @example Create a SubFrames object sliced by 3 rows.
+    #   df.sub_by_enum(:each_slice, 3)
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x000000000000fd20>
+    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   2 SubFrames: [3, 3] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fd34>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   2       3 B        false
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fd48>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       4 B        (nil)
+    #   1       5 B        true
+    #   2       6 C        false
+    #
+    # @example Create a SubFrames object for each consecutive 3 rows.
+    #   df.sub_by_enum(:each_cons, 4)
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x000000000000fd98>
+    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   3 SubFrames: [4, 4, 4] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fdac>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   2       3 B        false
+    #   3       4 B        (nil)
+    #   ---
+    #   #<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fdc0>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       2 A        true
+    #   1       3 B        false
+    #   2       4 B        (nil)
+    #   3       5 B        true
+    #   ---
+    #   #<RedAmber::DataFrame : 4 x 3 Vectors, 0x000000000000fdd4>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       4 B        (nil)
+    #   2       5 B        true
+    #   3       6 C        false
+    #
+    # @since 0.3.1
+    #
+    def sub_by_enum(enumerator_method, *args)
+      SubFrames.new(self, indices.send(enumerator_method, *args).to_a)
+    end
+    alias_method :subframes_by_enum, :sub_by_enum
+
+    # Create SubFrames by windowing with a kernel (i.e. masked window) and step.
+    #
+    # [Experimental feature] this method may be removed or be changed in the future.
+    # @param kernel [Array<true, false>, Vector]
+    #   boolean array-like to pick records in the window.
+    #   Kernel is a boolean Array and it behaves like a masked window.
+    # @param step [Integer]
+    #   moving step of window.
+    # @return [SubFrames]
+    #   a created SubFrames.
+    # @example
+    #   kernel = [true, false, false, true]
+    #   df.sub_by_kernel(kernel, step: 2)
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x000000000000fde8>
+    #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #   2 SubFrames: [2, 2] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fdfc>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       4 B        (nil)
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fe10>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       6 C        false
+    #
+    # @since 0.3.1
+    #
+    def sub_by_kernel(kernel, step: 1)
+      limit_size = size - kernel.size
+      kernel_vector = Vector.new(kernel.concat([nil] * limit_size))
+      SubFrames.new(self) do
+        0.step(by: step, to: limit_size).map do |i|
+          kernel_vector.shift(i)
+        end
+      end
+    end
+    alias_method :subframes_by_kernel, :sub_by_kernel
+
+    # Generic builder of sub-dataframes from self.
+    #
+    # [Experimental feature] this method may be removed or be changed in the future.
+    # @overload build_subframes(subset_specifier)
+    #   Create a new SubFrames object.
+    #
+    #   @param subset_specifier [Array<Vector>, Array<array-like>]
+    #     an Array of numeric indices or boolean filters
+    #     to create subsets of DataFrame.
+    #   @return [SubFrames]
+    #     new SubFrames.
+    #   @example
+    #     df.build_subframes([[0, 2, 4], [1, 3, 5]])
+    #
+    #     # =>
+    #     #<RedAmber::SubFrames : 0x000000000000fe9c>
+    #     @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #     2 SubFrames: [3, 3] in sizes.
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000feb0>
+    #             x y        z
+    #       <uint8> <string> <boolean>
+    #     0       1 A        false
+    #     1       3 B        false
+    #     2       5 B        true
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fec4>
+    #             x y        z
+    #       <uint8> <string> <boolean>
+    #     0       2 A        true
+    #     1       4 B        (nil)
+    #     2       6 C        false
+    #
+    # @overload build_subframes
+    #   Create a new SubFrames object by block.
+    #
+    #   @yield [self]
+    #     the block is called within the context of self.
+    #     (Block is called by instance_eval(&block). )
+    #   @yieldreturn [Array<numeric_array_like>, Array<boolean_array_like>]
+    #     an Array of index or boolean array-likes to create subsets of DataFrame.
+    #     All array-likes are responsible to #numeric? or #boolean?.
+    #   @example
+    #     dataframe.build_subframes do
+    #       even = indices.map(&:even?)
+    #       [even, !even]
+    #     end
+    #
+    #     # =>
+    #     #<RedAmber::SubFrames : 0x000000000000fe60>
+    #     @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+    #     2 SubFrames: [3, 3] in sizes.
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fe74>
+    #             x y        z
+    #       <uint8> <string> <boolean>
+    #     0       1 A        false
+    #     1       3 B        false
+    #     2       5 B        true
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fe88>
+    #             x y        z
+    #       <uint8> <string> <boolean>
+    #     0       2 A        true
+    #     1       4 B        (nil)
+    #     2       6 C        false
+    #
+    # @since 0.3.1
+    #
+    def build_subframes(subset_specifier = nil, &block)
+      if block
+        SubFrames.new(self, instance_eval(&block))
+      else
+        SubFrames.new(self, subset_specifier)
+      end
     end
 
     # Catch variable (column) key as method name.

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -15,6 +15,10 @@ module RedAmber
     #
     # @param width [Integer]
     #   maximum size of result.
+    # @param head [Integer]
+    #   number of records to show from head.
+    # @param tail [Integer]
+    #   number of records to show at tail.
     # @return [String]
     #   string representation of self.
     # @example Show penguins dataset
@@ -33,10 +37,10 @@ module RedAmber
     #   342 Gentoo   Biscoe              45.2          14.8               212 ...     2009
     #   343 Gentoo   Biscoe              49.9          16.1               213 ...     2009
     #
-    def to_s(width: 80)
+    def to_s(width: 80, head: 5, tail: 3)
       return '' if empty?
 
-      format_table(width: width)
+      format_table(width: width, head: head, tail: tail)
     end
 
     # Show statistical summary by a new DataFrame.

--- a/lib/red_amber/data_frame_indexable.rb
+++ b/lib/red_amber/data_frame_indexable.rb
@@ -3,21 +3,45 @@
 module RedAmber
   # Mix-ins for the class DataFrame
   module DataFrameIndexable
-    # Returns row indices (start...(size+start)) in a Vector.
+    # Returns row index Vector.
     #
-    # @param start [Object]
-    #   object which have `#succ` method.
-    # @return [Array]
-    #   a Vector of row indices.
-    # @example When self.size == 5
-    #   indices # => Vector[0, 1, 2, 3, 4]
+    # @overload indices
+    #   return @indices as row indices (0...size).
     #
-    #   indices(1) # => Vector[1, 2, 3, 4, 5]
+    #   @return [Vector]
+    #     a Vector of row indices.
+    #   @example When `dataframe.size == 5`;
+    #     dataframe.indices
     #
-    #   indices('a') # => Vector['a', 'b', 'c', 'd', 'e']
+    #     # =>
+    #     #<RedAmber::Vector(:uint8, size=5):0x000000000000fb54>
+    #     [0, 1, 2, 3, 4]
+    #
+    # @overload indices(start)
+    #   return customized index Vector `(start..).take(size)`.
+    #
+    #   @param start [#succ]
+    #     element of start which have `#succ` method.
+    #   @return [Vector]
+    #     a Vector of row indices.
+    #   @example When `dataframe.size == 5`;
+    #     dataframe.indices(1)
+    #
+    #     # =>
+    #     #<RedAmber::Vector(:uint8, size=5):0x000000000000fba4>
+    #     [1, 2, 3, 4, 5]
+    #
+    #     dataframe.indices('a')
+    #     # =>
+    #     #<RedAmber::Vector(:string, size=5):0x000000000000fbb8>
+    #     ["a", "b", "c", "d", "e"]
     #
     def indices(start = 0)
-      Vector.new((start..).take(size))
+      if start == 0 # rubocop:disable Style/NumericPredicate
+        @indices ||= Vector.new(0...size)
+      else
+        Vector.new((start..).take(size))
+      end
     end
     alias_method :indexes, :indices
 

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -7,6 +7,8 @@ module RedAmber
 
     using RefineArrowTable
 
+    attr_reader :dataframe, :group_keys
+
     class << self
       private
 
@@ -65,8 +67,6 @@ module RedAmber
       @group = @dataframe.table.group(*@group_keys)
     end
 
-    attr_reader :dataframe, :group_keys
-
     define_group_aggregation(:count)
     alias_method :__count, :count
     private :__count
@@ -97,6 +97,7 @@ module RedAmber
 
     # Returns Array of boolean filters to select each records in the Group.
     #
+    # @api private
     # @return [Array]
     #   an Array of boolean filter Vectors.
     #
@@ -117,6 +118,7 @@ module RedAmber
 
     # Iterates over each record group as a DataFrame or returns a Enumerator.
     #
+    # @api private
     # @overload each
     #   Returns a new Enumerator if no block given.
     #

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module RedAmber
+  # class SubFrames treats a set of subsets of a DataFrame
+  # [Experimental feature] It may be removed or be changed in the future.
+  class SubFrames
+    include Helper
+
+    using RefineArray
+    using RefineArrayLike
+
+    # Create a new SubFrames object from a DataFrame and the array of indices.
+    # [Experimental feature]
+    #
+    # @param dataframe [DataFrame]
+    #   source dataframe.
+    # @param subset_indices [Array<#numeric?>]
+    #   an Array of index array-likes to create subsets of DataFrame.
+    #   All index array-likes are responsible to #numeric?.
+    # @return [SubFrames]
+    #   new SubFrames.
+    # @since 0.3.1
+    #
+    def initialize(dataframe, subset_indices)
+      unless dataframe.is_a?(DataFrame)
+        raise SubFramesArgumentError, "not a DataFrame: #{dataframe}"
+      end
+
+      @universal_frame = dataframe
+      @universal_indices = dataframe.indices
+      @subset_indices =
+        if subset_indices.empty? || dataframe.empty?
+          []
+        else
+          subset_indices.map do |idxs|
+            vector =
+              if idxs.is_a?(Vector)
+                idxs
+              else
+                Vector.new(idxs)
+              end
+            raise SubFramesArgumentError, "illegal type: #{idxs}" unless vector.numeric?
+
+            unless vector.is_in(@universal_indices).all?
+              raise SubFramesArgumentError, "index out of range: #{vector.to_a}"
+            end
+
+            vector
+          end
+        end
+    end
+
+    attr_reader :universal_frame, :subset_indices
+
+    # Number of subsets.
+    #
+    # @return [Integer]
+    #   number of subsets in self.
+    # @since 0.3.1
+    #
+    def size
+      @size ||= @subset_indices.size
+    end
+
+    # Size list of subsets.
+    #
+    # @return [Array<Integer>]
+    #   sizes of sub DataFrames.
+    # @since 0.3.1
+    #
+    def sizes
+      @sizes ||= @subset_indices.map(&:size)
+    end
+
+    # Test if subset is empty?.
+    #
+    # @return [true, false]
+    #   true if self is an empty subset.
+    # @since 0.3.1
+    #
+    def empty?
+      @subset_indices.empty?
+    end
+
+    # Test if self has only one subset and it is comprehensive.
+    #
+    # @return [true, false]
+    #   true if only member of self is equal to universal DataFrame.
+    # @since 0.3.1
+    #
+    def universal?
+      size == 1 && (@subset_indices[0] == @universal_indices).all?
+    end
+
+    # Return summary information of self.
+    #
+    # @return [String]
+    #   return class name, object id, universal DataFrame,
+    #   size and subset sizes in a String.
+    # @since 0.3.1
+    #
+    def inspect
+      limit = 16
+      sizes_truncated = (size > limit ? sizes.take(limit) << '...' : sizes).join(', ')
+      "#<#{self.class} : #{format('0x%016x', object_id)}>\n" \
+        "@universal_frame = #<#{@universal_frame.shape_str(with_id: true)}>\n" \
+        "#{size} SubFrame#{pl(size)}: " \
+        "[#{sizes_truncated}] in size#{pl(size)}.\n"
+    end
+  end
+end

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -9,17 +9,46 @@ module RedAmber
     using RefineArray
     using RefineArrayLike
 
-    # Create a new SubFrames object from a DataFrame and the array of indices.
-    # [Experimental feature]
-    #
-    # @param dataframe [DataFrame]
-    #   source dataframe.
-    # @param subset_indices [Array<#numeric?>]
-    #   an Array of index array-likes to create subsets of DataFrame.
-    #   All index array-likes are responsible to #numeric?.
-    # @return [SubFrames]
-    #   new SubFrames.
-    # @since 0.3.1
+    class << self
+      # @!macro subframes_initialize
+      #   Create a new SubFrames object from a DataFrame and the array of indices.
+      #
+      #   @param dataframe [DataFrame]
+      #     source dataframe.
+      #   @param subset_indices [Array<#numeric?>]
+      #     an Array of index array-likes to create subsets of DataFrame.
+      #     All index array-likes are responsible to #numeric?.
+      #   @return [SubFrames]
+      #     new SubFrames.
+      #   @since 0.3.1
+
+      # @macro subframes_initialize
+      # @note Same as SubFrames.new
+      #
+      def by_indices(dataframe, subset_indices)
+        new(dataframe, subset_indices)
+      end
+
+      # Create a new SubFrames by the array of filters.
+      #
+      # @param dataframe [DataFrame]
+      #   source dataframe.
+      # @param subset_filters [Array<#boolean?>]
+      #   an Array of boolean filters to specify subsets of DataFrame.
+      #   All boolean filters are responsible to #boolean?.
+      # @return [SubFrames]
+      #   new SubFrames.
+      # @since 0.3.1
+      #
+      def by_filters(dataframe, subset_filters)
+        subset_indices = subset_filters.map do |f|
+          dataframe.indices.filter(f)
+        end
+        new(dataframe, subset_indices)
+      end
+    end
+
+    # @macro subframes_initialize
     #
     def initialize(dataframe, subset_indices)
       unless dataframe.is_a?(DataFrame)

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -354,6 +354,17 @@ module RedAmber
       self
     end
 
+    # Concatenate SubFrames to create a DataFrame.
+    #
+    # @return [DataFrame]
+    #   a concatenated DataFrame.
+    # @since 0.3.1
+    #
+    def concatenate
+      reduce(&:concatenate)
+    end
+    alias_method :concat, :concatenate
+
     private
 
     # def _to_s(limit: 16, with_id: false)

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -79,7 +79,6 @@ module RedAmber
       def by_indices(dataframe, subset_indices)
         instance = allocate
         instance.instance_variable_set(:@universal_frame, dataframe)
-        instance.instance_variable_set(:@universal_indices, dataframe.indices)
         instance.instance_variable_set(:@subset_indices, subset_indices)
         instance.instance_variable_set(:@frames, [])
         instance
@@ -147,7 +146,6 @@ module RedAmber
       end
 
       @universal_frame = dataframe
-      @universal_indices = dataframe.indices
       @subset_indices =
         if subset_specifier.nil? || subset_specifier.empty? || dataframe.empty?
           []
@@ -155,14 +153,14 @@ module RedAmber
           subset_specifier.map do |i|
             vector =
               if i.boolean?
-                @universal_indices.filter(i)
+                universal_frame.indices.filter(i)
               elsif i.numeric?
                 Vector.new(i)
               else
                 raise SubFramesArgumentError, "illegal type: #{i}"
               end
 
-            unless vector.is_in(@universal_indices).all?
+            unless vector.is_in(universal_frame.indices).all?
               raise SubFramesArgumentError, "index out of range: #{vector.to_a}"
             end
 
@@ -392,7 +390,7 @@ module RedAmber
     # @since 0.3.1
     #
     def universal?
-      size == 1 && (@subset_indices[0] == @universal_indices).all?
+      size == 1 && (@subset_indices[0] == universal_frame.indices).all?
     end
 
     # Return string representation of self.

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -52,24 +52,49 @@ module RedAmber
 
     # Create a new SubFrames object from a DataFrame and an array of indices or filters.
     #
-    # @param dataframe [DataFrame]
-    #   a source dataframe.
-    # @param subset_specifier [Array<Vector>, Array<array-like>]
-    #   an Array of numeric indices or boolean filters
-    #   to create subsets of DataFrame.
-    # @return [SubFrames]
-    #   new SubFrames.
+    # @overload initialize(dataframe, subset_specifier)
+    #   Create a new SubFrames object.
+    #
+    #   @param dataframe [DataFrame]
+    #     a source dataframe.
+    #   @param subset_specifier [Array<Vector>, Array<array-like>]
+    #     an Array of numeric indices or boolean filters
+    #     to create subsets of DataFrame.
+    #   @return [SubFrames]
+    #     new SubFrames.
+    #
+    # @overload initialize(dataframe)
+    #   Create a new SubFrames object by block.
+    #
+    #   @param dataframe [DataFrame]
+    #     a source dataframe.
+    #   @yield dataframe [DataFrame]
+    #     the block is called with the parameter `dataframe`.
+    #   @yieldreturn [Array<numeric_array_like>, Array<boolean_array_like>]
+    #     an Array of index or boolean array-likes to create subsets of DataFrame.
+    #     All array-likes are responsible to #numeric? or #boolean?.
+    #   @return [SubFrames]
+    #     new SubFrames.
+    #
     # @since 0.3.1
     #
-    def initialize(dataframe, subset_specifier)
+    def initialize(dataframe, subset_specifier = nil, &block)
       unless dataframe.is_a?(DataFrame)
         raise SubFramesArgumentError, "not a DataFrame: #{dataframe}"
+      end
+
+      if block
+        unless subset_specifier.nil?
+          raise SubFramesArgumentError, 'Must not specify both arguments and block.'
+        end
+
+        subset_specifier = yield(dataframe)
       end
 
       @universal_frame = dataframe
       @universal_indices = dataframe.indices
       @subset_indices =
-        if subset_specifier.empty? || dataframe.empty?
+        if subset_specifier.nil? || subset_specifier.empty? || dataframe.empty?
           []
         else
           subset_specifier.map do |i|

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -290,6 +290,22 @@ module RedAmber
       @sizes ||= @subset_indices.map(&:size)
     end
 
+    # Indices at the top of each sub DataFrames.
+    #
+    # @return [Array<Integer>]
+    #   indices of offset of each sub DataFrames.
+    # @example When `sizes` is [2, 3, 1].
+    #   sf.offset_indices # => [0, 2, 5]
+    # @since 0.3.1
+    #
+    def offset_indices
+      sum = 0
+      sizes.map do |size|
+        sum += size
+        sum - size
+      end
+    end
+
     # Test if subset is empty?.
     #
     # @return [true, false]

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -11,6 +11,59 @@ module RedAmber
     using RefineArrayLike
 
     class << self
+      # Create SubFrames from a Group.
+      #
+      # [Experimental feature] this method may be removed or be changed in the future.
+      # @param group [Group]
+      #   a Group to be used to create SubFrames.
+      # @return [SubFrames]
+      #   a created SubFrames.
+      # @example
+      #   dataframe
+      #
+      #   # =>
+      #   #<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fba4>
+      #   x y        z
+      #   <uint8> <string> <boolean>
+      #   0       1 A        false
+      #   1       2 A        true
+      #   2       3 B        false
+      #   3       4 B        (nil)
+      #   4       5 B        true
+      #   5       6 C        false
+      #
+      #   group = Group.new(dataframe, [:y])
+      #   sf = SubFrames.by_group(group)
+      #
+      #   # =>
+      #   #<RedAmber::SubFrames : 0x000000000000fbb8>
+      #   @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000fb7c>
+      #   3 SubFrames: [2, 3, 1] in sizes.
+      #   ---
+      #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000fbcc>
+      #           x y        z
+      #     <uint8> <string> <boolean>
+      #   0       1 A        false
+      #   1       2 A        true
+      #   ---
+      #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fbe0>
+      #           x y        z
+      #     <uint8> <string> <boolean>
+      #   0       3 B        false
+      #   1       4 B        (nil)
+      #   2       5 B        true
+      #   ---
+      #   #<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000fbf4>
+      #           x y        z
+      #     <uint8> <string> <boolean>
+      #   0       6 C        false
+      #
+      # @since 0.3.1
+      #
+      def by_group(group)
+        SubFrames.new(group.dataframe, group.filters)
+      end
+
       # Create a new SubFrames object from a DataFrame and an array of indices.
       #
       # @api private

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -560,6 +560,155 @@ module RedAmber
     end
     alias_method :collect, :map
 
+    # Update existing column(s) or create new columns(s) for each DataFrames in self.
+    #
+    # Column values are updated by an oveloaded common operation.
+    #
+    # @overload assign(key)
+    #   Assign a column by argument and block.
+    #
+    #   @param key [Symbol, String]
+    #     a key of column to assign.
+    #   @yieldparam dataframe [DataFrame]
+    #     gives overloaded dataframe in self to the block.
+    #   @yieldreturn [Vector, Array, Arrow::Array]
+    #     an updated column value which are overloaded.
+    #   @return [SubFrames]
+    #     a new SubFrames object with updated DataFrames.
+    #   @example
+    #     subframes
+    #
+    #     # =>
+    #     #<RedAmber::SubFrames : 0x000000000000c33c>
+    #     @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x000000000000c350>
+    #     3 SubFrames: [2, 3, 1] in sizes.
+    #     ---
+    #     #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000000c364>
+    #             x y        z
+    #       <uint8> <string> <boolean>
+    #     0       1 A        false
+    #     1       2 A        true
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000c378>
+    #             x y        z
+    #       <uint8> <string> <boolean>
+    #     0       3 B        false
+    #     1       4 B        (nil)
+    #     2       5 B        true
+    #     ---
+    #     #<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000000c38c>
+    #             x y        z
+    #       <uint8> <string> <boolean>
+    #     0       6 C        false
+    #
+    #     subframes.assign(:x_plus1) { x + 1 }
+    #
+    #     # =>
+    #     #<RedAmber::SubFrames : 0x000000000000c3a0>
+    #     @baseframe=#<RedAmber::DataFrame : 6 x 4 Vectors, 0x000000000000c3b4>
+    #     3 SubFrames: [2, 3, 1] in sizes.
+    #     ---
+    #     #<RedAmber::DataFrame : 2 x 4 Vectors, 0x000000000000c3c8>
+    #             x y        z         x_plus1
+    #       <uint8> <string> <boolean> <uint8>
+    #     0       1 A        false           2
+    #     1       2 A        true            3
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000c3dc>
+    #             x y        z         x_plus1
+    #       <uint8> <string> <boolean> <uint8>
+    #     0       3 B        false           4
+    #     1       4 B        (nil)           5
+    #     2       5 B        true            6
+    #     ---
+    #     #<RedAmber::DataFrame : 1 x 4 Vectors, 0x000000000000c3f0>
+    #             x y        z         x_plus1
+    #       <uint8> <string> <boolean> <uint8>
+    #     0       6 C        false           7
+    #
+    # @overload assign(keys)
+    #   Assign columns by arguments and block.
+    #
+    #   @param keys [Array<Symbol, String>]
+    #     keys of columns to assign.
+    #   @yieldparam dataframe [DataFrame]
+    #     gives overloaded dataframes in self to the block.
+    #   @yieldreturn [Array<Vector, Array, Arrow::Array>]
+    #     an updated column values which are overloaded.
+    #   @return [SubFrames]
+    #     a new SubFrames object with updated DataFrames.
+    #   @example
+    #     subframes.assign(:sum_x, :frac_x) do
+    #       group_sum = x.sum
+    #       [[group_sum] * size, x / s.to_f]
+    #     end
+    #
+    #     # =>
+    #     #<RedAmber::SubFrames : 0x000000000000fce4>
+    #     @baseframe=#<RedAmber::DataFrame : 6 x 5 Vectors, 0x000000000000fcf8>
+    #     3 SubFrames: [2, 3, 1] in sizes.
+    #     ---
+    #     #<RedAmber::DataFrame : 2 x 5 Vectors, 0x000000000000fd0c>
+    #             x y        z           sum_x   frac_x
+    #       <uint8> <string> <boolean> <uint8> <double>
+    #     0       1 A        false           3     0.33
+    #     1       2 A        true            3     0.67
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 5 Vectors, 0x000000000000fd20>
+    #             x y        z           sum_x   frac_x
+    #       <uint8> <string> <boolean> <uint8> <double>
+    #     0       3 B        false          12     0.25
+    #     1       4 B        (nil)          12     0.33
+    #     2       5 B        true           12     0.42
+    #     ---
+    #     #<RedAmber::DataFrame : 1 x 5 Vectors, 0x000000000000fd34>
+    #             x y        z           sum_x   frac_x
+    #       <uint8> <string> <boolean> <uint8> <double>
+    #     0       6 C        false           6      1.0
+    #
+    # @overload assign
+    #   Assign column(s) by block.
+    #
+    #   @yieldparam dataframe [DataFrame]
+    #     gives overloaded dataframes in self to the block.
+    #   @yieldreturn [Hash, Array]
+    #     pairs of keys and column values which are overloaded.
+    #   @return [SubFrames]
+    #     a new SubFrames object with updated DataFrames.
+    #   @example Compute 'x * z' when (true, not_true) = (1, 0) in z
+    #     subframes.assign do
+    #       { 'x*z': x * z.if_else(1, 0) }
+    #     end
+    #
+    #     # =>
+    #     #<RedAmber::SubFrames : 0x000000000000fd98>
+    #     @baseframe=#<RedAmber::DataFrame : 6 x 4 Vectors, 0x000000000000fdac>
+    #     3 SubFrames: [2, 3, 1] in sizes.
+    #     ---
+    #     #<RedAmber::DataFrame : 2 x 4 Vectors, 0x000000000000fdc0>
+    #             x y        z             x*z
+    #       <uint8> <string> <boolean> <uint8>
+    #     0       1 A        false           0
+    #     1       2 A        true            2
+    #     ---
+    #     #<RedAmber::DataFrame : 3 x 4 Vectors, 0x000000000000fdd4>
+    #             x y        z             x*z
+    #       <uint8> <string> <boolean> <uint8>
+    #     0       3 B        false           0
+    #     1       4 B        (nil)       (nil)
+    #     2       5 B        true            5
+    #     ---
+    #     #<RedAmber::DataFrame : 1 x 4 Vectors, 0x000000000000fde8>
+    #             x y        z             x*z
+    #       <uint8> <string> <boolean> <uint8>
+    #     0       6 C        false           0
+    #
+    # @since 0.3.1
+    #
+    def assign(...)
+      map { |df| df.assign(...) }
+    end
+
     # Number of subsets.
     #
     # @return [Integer]

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -719,6 +719,90 @@ module RedAmber
       map { |df| df.assign(...) }
     end
 
+    # Returns a SubFrames containing DataFrames selected by the block.
+    #
+    # With a block given, calls the block with successive DataFrames;
+    # returns a SubFrames of those DataFrames for
+    # which the block returns a truthy value.
+    #
+    # @example Select all.
+    #   subframes
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x00000000000039e4>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x00000000000039f8>
+    #   3 SubFrames: [2, 3, 1] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000003a0c>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x0000000000003a20>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       4 B        (nil)
+    #   2       5 B        true
+    #   ---
+    #   #<RedAmber::DataFrame : 1 x 3 Vectors, 0x0000000000003a34>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       6 C        false
+    #
+    #   subframes.select { true }
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x0000000000003a84>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x0000000000003a98>
+    #   3 SubFrames: [2, 3, 1] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000003a0c>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x0000000000003a20>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       4 B        (nil)
+    #   2       5 B        true
+    #   ---
+    #   #<RedAmber::DataFrame : 1 x 3 Vectors, 0x0000000000003a34>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       6 C        false
+    #
+    # @example Select if Vector `:z` has any true.
+    #   subframes.select { |df| df[:z].any? }
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x000000000000fba4>
+    #   @baseframe=#<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000000fbb8>
+    #   2 SubFrames: [2, 1] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000003a0c>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x0000000000003a20>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       4 B        (nil)
+    #   2       5 B        true
+    #
+    # @since 0.3.1
+    #
+    define_subframable_method :select
+    alias_method :filter, :select
+    alias_method :find_all, :select
+
     # Number of subsets.
     #
     # @return [Integer]

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -4,6 +4,7 @@ module RedAmber
   # class SubFrames treats a set of subsets of a DataFrame
   # [Experimental feature] Class SubFrames may be removed or be changed in the future.
   class SubFrames
+    include Enumerable
     include Helper
 
     using RefineArray
@@ -184,6 +185,35 @@ module RedAmber
         "@universal_frame=#<#{@universal_frame.shape_str(with_id: true)}>\n" \
         "#{size} SubFrame#{pl(size)}: " \
         "[#{sizes_truncated}] in size#{pl(size)}.\n"
+    end
+
+    # Iterates over sub DataFrames or returns an Enumerator.
+    #
+    # @overload each
+    #   Returns a new Enumerator if no block given.
+    #
+    #   @return [Enumerator]
+    #     Enumerator of each elements.
+    #
+    # @overload each
+    #   When a block given, passes each sub DataFrames to the block.
+    #
+    #   @yield [DataFrame]
+    #     each sub DataFrame.
+    #   @yieldparam subframe [DataFrame]
+    #     passes sub DataFrame by a block parameter.
+    #   @yieldreturn [Object]
+    #     evaluated result value from the block.
+    #   @return [self]
+    #     returns self.
+    #
+    def each
+      return enum_for(:each) unless block_given?
+
+      @subset_indices.each do |i|
+        yield @universal_frame.take(i.data)
+      end
+      self
     end
   end
 end

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -853,6 +853,42 @@ module RedAmber
     #
     define_subframable_method :reject
 
+    # Returns a SubFrames containing truthy DataFrames returned by the block.
+    #
+    # With a block given, calls the block with successive DataFrames;
+    # returns a SubFrames of those DataFrames for
+    # which the block returns nil or false.
+    # @example Filter for size is larger than 1 and append number to column 'y'.
+    #   subframes.filter_map do |df|
+    #     if df.size > 1
+    #       df.assign(:y) do
+    #         y.merge(indices('1'), sep: '')
+    #       end
+    #     end
+    #   end
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x000000000001da88>
+    #   @baseframe=#<RedAmber::DataFrame : 5 x 3 Vectors, 0x000000000001da9c>
+    #   2 SubFrames: [2, 3] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x000000000001dab0>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A1       false
+    #   1       2 A2       true
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000001dac4>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B1       false
+    #   1       4 B2       (nil)
+    #   2       5 B3       true
+    #
+    # @since 0.3.1
+    #
+    define_subframable_method :filter_map
+
     # Number of subsets.
     #
     # @return [Integer]

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -735,31 +735,6 @@ module RedAmber
     # which the block returns a truthy value.
     #
     # @example Select all.
-    #   subframes
-    #
-    #   # =>
-    #   #<RedAmber::SubFrames : 0x00000000000039e4>
-    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x00000000000039f8>
-    #   3 SubFrames: [2, 3, 1] in sizes.
-    #   ---
-    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000003a0c>
-    #           x y        z
-    #     <uint8> <string> <boolean>
-    #   0       1 A        false
-    #   1       2 A        true
-    #   ---
-    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x0000000000003a20>
-    #           x y        z
-    #     <uint8> <string> <boolean>
-    #   0       3 B        false
-    #   1       4 B        (nil)
-    #   2       5 B        true
-    #   ---
-    #   #<RedAmber::DataFrame : 1 x 3 Vectors, 0x0000000000003a34>
-    #           x y        z
-    #     <uint8> <string> <boolean>
-    #   0       6 C        false
-    #
     #   subframes.select { true }
     #
     #   # =>
@@ -784,6 +759,15 @@ module RedAmber
     #           x y        z
     #     <uint8> <string> <boolean>
     #   0       6 C        false
+    #
+    # @example Select nothing.
+    #   subframes.select { false }
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x00000000000238c0>
+    #   @baseframe=#<RedAmber::DataFrame : (empty), 0x00000000000238d4>
+    #   0 SubFrame: [] in size.
+    #   ---
     #
     # @example Select if Vector `:z` has any true.
     #   subframes.select { |df| df[:z].any? }
@@ -811,6 +795,63 @@ module RedAmber
     define_subframable_method :select
     alias_method :filter, :select
     alias_method :find_all, :select
+
+    # Returns a SubFrames containing DataFrames rejected by the block.
+    #
+    # With a block given, calls the block with successive DataFrames;
+    # returns a SubFrames of those DataFrames for
+    # which the block returns nil or false.
+    # @example Reject all.
+    #   subframes.reject { true }
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x00000000000238c0>
+    #   @baseframe=#<RedAmber::DataFrame : (empty), 0x00000000000238d4>
+    #   0 SubFrame: [] in size.
+    #   ---
+    #
+    # @example Reject nothing.
+    #   subframes.reject { false }
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x0000000000003a84>
+    #   @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, 0x0000000000003a98>
+    #   3 SubFrames: [2, 3, 1] in sizes.
+    #   ---
+    #   #<RedAmber::DataFrame : 2 x 3 Vectors, 0x0000000000003a0c>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       1 A        false
+    #   1       2 A        true
+    #   ---
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x0000000000003a20>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       3 B        false
+    #   1       4 B        (nil)
+    #   2       5 B        true
+    #   ---
+    #   #<RedAmber::DataFrame : 1 x 3 Vectors, 0x0000000000003a34>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       6 C        false
+    #
+    # @example Reject if Vector `:z` has any true.
+    #   subframes.reject { |df| df[:z].any? }
+    #
+    #   # =>
+    #   #<RedAmber::SubFrames : 0x0000000000038d74>
+    #   @baseframe=#<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000001ad10>
+    #   1 SubFrame: [1] in size.
+    #   ---
+    #   #<RedAmber::DataFrame : 1 x 3 Vectors, 0x000000000001ad10>
+    #           x y        z
+    #     <uint8> <string> <boolean>
+    #   0       6 C        false
+    #
+    # @since 0.3.1
+    #
+    define_subframable_method :reject
 
     # Number of subsets.
     #

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -5,6 +5,7 @@ module RedAmber
   #   @data : holds Arrow::ChunkedArray
   class Vector
     # mix-in
+    include Enumerable
     include Helper
     include ArrowFunction
     include VectorUpdatable

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -25,6 +25,43 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case '#to_s' do
+    setup do
+      hash = { integer: [1, 2, 3, 4, 5, 6],
+               double: [1, 0 / 0.0, 1 / 0.0, -1 / 0.0, nil, ''],
+               string: %w[A A B C D E],
+               boolean: [true, false, nil, true, false, nil] }
+      @df = DataFrame.new(hash)
+    end
+
+    test '#to_s default' do
+      str = <<~OUTPUT
+          integer    double string   boolean
+          <uint8>  <double> <string> <boolean>
+        0       1       1.0 A        true
+        1       2       NaN A        false
+        2       3  Infinity B        (nil)
+        3       4 -Infinity C        true
+        4       5     (nil) D        false
+        5       6       0.0 E        (nil)
+      OUTPUT
+      assert_equal str, @df.to_s
+    end
+
+    test '#to_s specify head and tail' do
+      str = <<~OUTPUT
+          integer   double string   boolean
+          <uint8> <double> <string> <boolean>
+        0       1      1.0 A        true
+        1       2      NaN A        false
+        :       :        : :        :
+        4       5    (nil) D        false
+        5       6      0.0 E        (nil)
+      OUTPUT
+      assert_equal str, @df.to_s(head: 2, tail: 2)
+    end
+  end
+
   sub_test_case 'inspect by table mode' do
     setup do
       ENV['RED_AMBER_OUTPUT_MODE'] = nil # Table mode

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -435,6 +435,44 @@ class SubFranesTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case '#select' do
+    setup do
+      @df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [false, true, false, nil, true, false]
+      )
+      @sf = SubFrames.new(@df, [[0, 1], [2, 3, 4], [5]])
+    end
+
+    test '#select w/o block' do
+      assert_kind_of Enumerator, @sf.select
+      assert_equal 3, @sf.select.size
+    end
+
+    test '#select as it is' do
+      sf = @sf.select { true }
+      assert_kind_of SubFrames, sf
+      assert_false @sf.equal?(sf) # object ids are not equal
+      assert_equal @sf.to_a, sf.to_a # but have same contents
+    end
+
+    test '#select elements' do
+      sf = @sf.select { |df| df.size < 3 }
+      assert_equal <<~STR, sf.to_s
+                x y        z
+          <uint8> <string> <boolean>
+        0       1 A        false
+        1       2 A        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       6 C        false
+      STR
+      assert_equal @df.remove(2..4), sf.baseframe
+    end
+  end
+
   # Tests for #size, #sizes, #offset_indices, #empty? and #universal?
   sub_test_case 'properties' do
     setup do

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -213,4 +213,26 @@ class SubFranesTest < Test::Unit::TestCase
       STR
     end
   end
+
+  sub_test_case '#each' do
+    setup do
+      @df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [false, true, false, nil, true, false]
+      )
+      @sf = SubFrames.new(@df, [[0, 1], [2, 3, 4], [5]])
+    end
+
+    test '#each w/o block' do
+      assert_kind_of Enumerator, @sf.each
+    end
+
+    test '#each yielded block' do
+      expect = [[[1, 'A', false], [2, 'A', true]],
+                [[3, 'B', false], [4, 'B', nil], [5, 'B', true]],
+                [[6, 'C', false]]]
+      assert_equal expect, @sf.each.with_object([]) { |df, a| a << df.to_a }
+    end
+  end
 end

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -199,7 +199,7 @@ class SubFranesTest < Test::Unit::TestCase
     end
   end
 
-  # Tests for #size, #sizes, #empty? and #universal?
+  # Tests for #size, #sizes, #offset_indices, #empty? and #universal?
   sub_test_case 'properties' do
     setup do
       @df = DataFrame.new(
@@ -213,6 +213,7 @@ class SubFranesTest < Test::Unit::TestCase
       empty_subframe = SubFrames.new(@df, [])
       assert_equal 0, empty_subframe.size
       assert_equal [], empty_subframe.sizes
+      assert_equal [], empty_subframe.offset_indices
       assert_true empty_subframe.empty?
       assert_false empty_subframe.universal?
     end
@@ -222,6 +223,7 @@ class SubFranesTest < Test::Unit::TestCase
       sf = SubFrames.new(@df, specifier)
       assert_equal 3, sf.size
       assert_equal [2, 3, 1], sf.sizes
+      assert_equal [0, 2, 5], sf.offset_indices
       assert_false sf.empty?
       assert_false sf.universal?
     end
@@ -231,6 +233,7 @@ class SubFranesTest < Test::Unit::TestCase
       universal = SubFrames.new(@df, specifier)
       assert_equal 1, universal.size
       assert_equal [6], universal.sizes
+      assert_equal [0], universal.offset_indices
       assert_false universal.empty?
       assert_true universal.universal?
     end

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -347,4 +347,20 @@ class SubFranesTest < Test::Unit::TestCase
       assert_equal expect, @sf.each.with_object([]) { |df, a| a << df.to_a }
     end
   end
+
+  sub_test_case '#concatenate' do
+    setup do
+      @df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [false, true, false, nil, true, false]
+      )
+      @sf = SubFrames.new(@df, [[0, 1], [2, 3, 4], [5]])
+    end
+
+    test '#concatenate' do
+      assert_kind_of DataFrame, @sf.concatenate
+      assert_equal_array @df.to_a, @sf.concatenate
+    end
+  end
 end

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -11,48 +11,28 @@ class SubFranesTest < Test::Unit::TestCase
       @df = DataFrame.new(x: [*1..3])
     end
 
-    test '.by_indices a SubFrames with Array' do
-      sf = SubFrames.by_indices(@df, [[0, 2]])
-      assert_equal_array [[0, 2]], sf.subset_indices
-    end
-
     test '.by_indices a SubFrames with Vector' do
       sf = SubFrames.by_indices(@df, [Vector.new(0, 2)])
       assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
     end
   end
 
   sub_test_case '.by_filters' do
-    test '.by_filters illegal dataframe' do
-      assert_raise(SubFramesArgumentError) { SubFrames.by_filters('a', []) }
-    end
-
-    test '.by_filters empty dataframe' do
-      filter = Vector.new(Arrow::BooleanArray.new([]))
-      sf = SubFrames.by_filters(DataFrame.new, [filter])
-      assert_equal [], sf.subset_indices
-    end
-
     setup do
       @df = DataFrame.new(x: [*1..3])
-    end
-
-    test '.by_filters empty specifier' do
-      assert_equal [], SubFrames.by_filters(@df, []).subset_indices
-    end
-
-    test '.by_filters illegal specifier' do
-      assert_raise(VectorTypeError) { SubFrames.by_filters(@df, [%w[0 1]]) }
     end
 
     test '.by_filters a SubFrames with Array' do
       sf = SubFrames.by_filters(@df, [[true, false, true]])
       assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
     end
 
     test '.by_filters a SubFrames with Vector' do
       sf = SubFrames.by_filters(@df, [Vector.new(true, false, true)])
       assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
     end
   end
 
@@ -78,18 +58,32 @@ class SubFranesTest < Test::Unit::TestCase
       assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [%w[0 1]]) }
     end
 
-    test '.new a SubFrames with Array' do
+    test '.new a SubFrames with index Array' do
       sf = SubFrames.new(@df, [[0, 2]])
       assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
     end
 
-    test '.new a SubFrames with Vector' do
+    test '.new a SubFrames with index Vector' do
       sf = SubFrames.new(@df, [Vector.new(0, 2)])
       assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
     end
 
     test '.new index out of range' do
       assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [[0, 2, 4]]) }
+    end
+
+    test '.new a SubFrames with boolean Array' do
+      sf = SubFrames.new(@df, [[true, false, true]])
+      assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
+    end
+
+    test '.new a SubFrames with boolean Vector' do
+      sf = SubFrames.new(@df, [Vector.new(true, false, true)])
+      assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
     end
   end
 
@@ -99,7 +93,7 @@ class SubFranesTest < Test::Unit::TestCase
       @df = DataFrame.new(
         x: [*1..6],
         y: %w[A A B B B C],
-        z: [true, true, true, false, nil, false]
+        z: [false, true, false, nil, true, false]
       )
     end
 
@@ -135,7 +129,7 @@ class SubFranesTest < Test::Unit::TestCase
       @df = DataFrame.new(
         x: [*1..6],
         y: %w[A A B B B C],
-        z: [true, true, true, false, nil, false]
+        z: [false, true, false, nil, true, false]
       )
     end
 
@@ -143,7 +137,7 @@ class SubFranesTest < Test::Unit::TestCase
       empty_subframe = SubFrames.new(@df, [])
       assert_equal <<~STR, empty_subframe.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', empty_subframe.object_id)}>
-        @universal_frame = #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         0 SubFrame: [] in size.
       STR
     end
@@ -153,7 +147,7 @@ class SubFranesTest < Test::Unit::TestCase
       sf = SubFrames.new(@df, specifier)
       assert_equal <<~STR, sf.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', sf.object_id)}>
-        @universal_frame = #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         3 SubFrames: [2, 3, 1] in sizes.
       STR
     end
@@ -163,7 +157,7 @@ class SubFranesTest < Test::Unit::TestCase
       universal = SubFrames.new(@df, specifier)
       assert_equal <<~STR, universal.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', universal.object_id)}>
-        @universal_frame = #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         1 SubFrame: [6] in size.
       STR
     end

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -6,6 +6,45 @@ class SubFranesTest < Test::Unit::TestCase
   include RedAmber
   include TestHelper
 
+  sub_test_case '.by_group' do
+    test '.by_group' do
+      df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [false, true, false, nil, true, false]
+      )
+      # @df is:
+      #         x y        z
+      #   <uint8> <string> <boolean>
+      # 0       1 A        false
+      # 1       2 A        true
+      # 2       3 B        false
+      # 3       4 B        (nil)
+      # 4       5 B        true
+      # 5       6 C        false
+
+      group = Group.new(df, [:y])
+      sf = SubFrames.by_group(group)
+      assert_kind_of SubFrames, sf
+      assert_equal <<~STR, sf.to_s
+                x y        z
+          <uint8> <string> <boolean>
+        0       1 A        false
+        1       2 A        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       3 B        false
+        1       4 B        (nil)
+        2       5 B        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       6 C        false
+      STR
+    end
+  end
+
   sub_test_case '.by_indices' do
     setup do
       @df = DataFrame.new(x: [*1..3])

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -105,16 +105,16 @@ class SubFranesTest < Test::Unit::TestCase
 
     test '.new empty dataframe' do
       sf = SubFrames.new(DataFrame.new, [[0, 1, 2]])
-      assert_equal 1, sf.size
-      assert_equal [0], sf.sizes
-      assert_true sf.first.empty?
+      assert_equal 0, sf.size
+      assert_equal [], sf.sizes
+      assert_true sf.first.nil?
     end
 
     test '.new empty dataframe by a block' do
       sf = SubFrames.new(DataFrame.new) { [[0, 1, 2]] }
-      assert_equal 1, sf.size
-      assert_equal [0], sf.sizes
-      assert_true sf.first.empty?
+      assert_equal 0, sf.size
+      assert_equal [], sf.sizes
+      assert_true sf.first.nil?
     end
 
     setup do
@@ -127,30 +127,30 @@ class SubFranesTest < Test::Unit::TestCase
 
     test '.new empty specifier, nil' do
       sf = SubFrames.new(@df)
-      assert_equal 1, sf.size
-      assert_equal [0], sf.sizes
-      assert_true sf.first.empty?
+      assert_equal 0, sf.size
+      assert_equal [], sf.sizes
+      assert_true sf.first.nil?
     end
 
     test '.new empty specifier, []' do
       sf = SubFrames.new(@df, [])
-      assert_equal 1, sf.size
-      assert_equal [0], sf.sizes
-      assert_true sf.first.empty?
+      assert_equal 0, sf.size
+      assert_equal [], sf.sizes
+      assert_true sf.first.nil?
     end
 
     test '.new empty specifier by a block, nil' do
       sf = SubFrames.new(@df) { nil }
-      assert_equal 1, sf.size
-      assert_equal [0], sf.sizes
-      assert_true sf.first.empty?
+      assert_equal 0, sf.size
+      assert_equal [], sf.sizes
+      assert_true sf.first.nil?
     end
 
     test '.new empty specifier by a block, []' do
       sf = SubFrames.new(@df) { [] }
-      assert_equal 1, sf.size
-      assert_equal [0], sf.sizes
-      assert_true sf.first.empty?
+      assert_equal 0, sf.size
+      assert_equal [], sf.sizes
+      assert_true sf.first.nil?
     end
 
     test '.new illegal specifier' do
@@ -364,6 +364,13 @@ class SubFranesTest < Test::Unit::TestCase
       assert_equal 3, @sf.map.size
     end
 
+    test '#map empty SubFrames' do
+      empty = SubFrames.new(DataFrame.new, [])
+      assert_kind_of Enumerator, empty.map
+      assert_true empty.map.first.nil?
+      assert_equal [], empty.map.to_a
+    end
+
     test '#map as it is' do
       sf = @sf.map { |df| df }
       assert_kind_of SubFrames, sf
@@ -450,11 +457,18 @@ class SubFranesTest < Test::Unit::TestCase
       assert_equal 3, @sf.select.size
     end
 
-    test '#select as it is' do
+    test '#select all' do
       sf = @sf.select { true }
       assert_kind_of SubFrames, sf
       assert_false @sf.equal?(sf) # object ids are not equal
       assert_equal @sf.to_a, sf.to_a # but have same contents
+    end
+
+    test '#select nothing' do
+      sf = @sf.select { false }
+      assert_kind_of SubFrames, sf
+      assert_true sf.empty?
+      assert_equal_array [], sf.baseframe.to_a
     end
 
     test '#select elements' do
@@ -485,11 +499,11 @@ class SubFranesTest < Test::Unit::TestCase
 
     test 'properties of empty SubFrame' do
       empty_subframe = SubFrames.new(@df, [])
-      assert_equal 1, empty_subframe.size
-      assert_equal [0], empty_subframe.sizes
-      assert_equal [0], empty_subframe.offset_indices
+      assert_equal 0, empty_subframe.size
+      assert_equal [], empty_subframe.sizes
+      assert_equal [], empty_subframe.offset_indices
       assert_true empty_subframe.empty?
-      assert_true empty_subframe.universal?
+      assert_false empty_subframe.universal?
     end
 
     test 'properties of SubFrames' do
@@ -528,9 +542,8 @@ class SubFranesTest < Test::Unit::TestCase
       assert_equal <<~STR, sf.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', sf.object_id)}>
         @baseframe=#<RedAmber::DataFrame : (empty), #{format('0x%016x', sf.baseframe.object_id)}>
-        1 SubFrame: [0] in size.
+        0 SubFrame: [] in size.
         ---
-        #<RedAmber::DataFrame : (empty), #{format('0x%016x', enum.next.object_id)}>
       STR
     end
 

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -6,6 +6,56 @@ class SubFranesTest < Test::Unit::TestCase
   include RedAmber
   include TestHelper
 
+  sub_test_case '.by_indices' do
+    setup do
+      @df = DataFrame.new(x: [*1..3])
+    end
+
+    test '.by_indices a SubFrames with Array' do
+      sf = SubFrames.by_indices(@df, [[0, 2]])
+      assert_equal_array [[0, 2]], sf.subset_indices
+    end
+
+    test '.by_indices a SubFrames with Vector' do
+      sf = SubFrames.by_indices(@df, [Vector.new(0, 2)])
+      assert_equal_array [[0, 2]], sf.subset_indices
+    end
+  end
+
+  sub_test_case '.by_filters' do
+    test '.by_filters illegal dataframe' do
+      assert_raise(SubFramesArgumentError) { SubFrames.by_filters('a', []) }
+    end
+
+    test '.by_filters empty dataframe' do
+      filter = Vector.new(Arrow::BooleanArray.new([]))
+      sf = SubFrames.by_filters(DataFrame.new, [filter])
+      assert_equal [], sf.subset_indices
+    end
+
+    setup do
+      @df = DataFrame.new(x: [*1..3])
+    end
+
+    test '.by_filters empty specifier' do
+      assert_equal [], SubFrames.by_filters(@df, []).subset_indices
+    end
+
+    test '.by_filters illegal specifier' do
+      assert_raise(VectorTypeError) { SubFrames.by_filters(@df, [%w[0 1]]) }
+    end
+
+    test '.by_filters a SubFrames with Array' do
+      sf = SubFrames.by_filters(@df, [[true, false, true]])
+      assert_equal_array [[0, 2]], sf.subset_indices
+    end
+
+    test '.by_filters a SubFrames with Vector' do
+      sf = SubFrames.by_filters(@df, [Vector.new(true, false, true)])
+      assert_equal_array [[0, 2]], sf.subset_indices
+    end
+  end
+
   sub_test_case '.new' do
     test '.new illegal dataframe' do
       assert_raise(SubFramesArgumentError) { SubFrames.new('a', []) }

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SubFranesTest < Test::Unit::TestCase
+  include RedAmber
+  include TestHelper
+
+  sub_test_case '.new' do
+    test '.new illegal dataframe' do
+      assert_raise(SubFramesArgumentError) { SubFrames.new('a', []) }
+    end
+
+    test '.new empty dataframe' do
+      sf = SubFrames.new(DataFrame.new, [[0, 1, 2]])
+      assert_equal [], sf.subset_indices
+    end
+
+    setup do
+      @df = DataFrame.new(x: [*1..3])
+    end
+
+    test '.new empty specifier' do
+      assert_equal [], SubFrames.new(@df, []).subset_indices
+    end
+
+    test '.new illegal specifier' do
+      assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [%w[0 1]]) }
+    end
+
+    test '.new a SubFrames with Array' do
+      sf = SubFrames.new(@df, [[0, 2]])
+      assert_equal_array [[0, 2]], sf.subset_indices
+    end
+
+    test '.new a SubFrames with Vector' do
+      sf = SubFrames.new(@df, [Vector.new(0, 2)])
+      assert_equal_array [[0, 2]], sf.subset_indices
+    end
+
+    test '.new index out of range' do
+      assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [[0, 2, 4]]) }
+    end
+  end
+
+  # Tests for #size, #sizes, #empty? and #universal?
+  sub_test_case 'properties' do
+    setup do
+      @df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [true, true, true, false, nil, false]
+      )
+    end
+
+    test 'properties of empty SubFrame' do
+      empty_subframe = SubFrames.new(@df, [])
+      assert_equal 0, empty_subframe.size
+      assert_equal [], empty_subframe.sizes
+      assert_true empty_subframe.empty?
+      assert_false empty_subframe.universal?
+    end
+
+    test 'properties of SubFrames' do
+      specifier = [[0, 1], [2, 3, 4], [5]]
+      sf = SubFrames.new(@df, specifier)
+      assert_equal 3, sf.size
+      assert_equal [2, 3, 1], sf.sizes
+      assert_false sf.empty?
+      assert_false sf.universal?
+    end
+
+    test 'properties of universal SubFrame' do
+      specifier = [[*0..5]]
+      universal = SubFrames.new(@df, specifier)
+      assert_equal 1, universal.size
+      assert_equal [6], universal.sizes
+      assert_false universal.empty?
+      assert_true universal.universal?
+    end
+  end
+
+  sub_test_case '#inspect' do
+    setup do
+      @df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [true, true, true, false, nil, false]
+      )
+    end
+
+    test '#inspect empty SubFrame' do
+      empty_subframe = SubFrames.new(@df, [])
+      assert_equal <<~STR, empty_subframe.inspect
+        #<RedAmber::SubFrames : #{format('0x%016x', empty_subframe.object_id)}>
+        @universal_frame = #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        0 SubFrame: [] in size.
+      STR
+    end
+
+    test '#inspect SubFrames' do
+      specifier = [[0, 1], [2, 3, 4], [5]]
+      sf = SubFrames.new(@df, specifier)
+      assert_equal <<~STR, sf.inspect
+        #<RedAmber::SubFrames : #{format('0x%016x', sf.object_id)}>
+        @universal_frame = #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        3 SubFrames: [2, 3, 1] in sizes.
+      STR
+    end
+
+    test '#inspect universal SubFrame' do
+      specifier = [[*0..5]]
+      universal = SubFrames.new(@df, specifier)
+      assert_equal <<~STR, universal.inspect
+        #<RedAmber::SubFrames : #{format('0x%016x', universal.object_id)}>
+        @universal_frame = #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        1 SubFrame: [6] in size.
+      STR
+    end
+  end
+end

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -279,6 +279,7 @@ class SubFranesTest < Test::Unit::TestCase
 
     test '#each w/o block' do
       assert_kind_of Enumerator, @sf.each
+      assert_equal 3, @sf.each.size
     end
 
     test '#each yielded block' do
@@ -360,6 +361,7 @@ class SubFranesTest < Test::Unit::TestCase
 
     test '#map w/o block' do
       assert_kind_of Enumerator, @sf.map
+      assert_equal 3, @sf.map.size
     end
 
     test '#map as it is' do

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -41,25 +41,54 @@ class SubFranesTest < Test::Unit::TestCase
       assert_raise(SubFramesArgumentError) { SubFrames.new('a', []) }
     end
 
+    test '.new illegal dataframe by a block' do
+      assert_raise(SubFramesArgumentError) { SubFrames.new('a') { [] } }
+    end
+
     test '.new empty dataframe' do
       sf = SubFrames.new(DataFrame.new, [[0, 1, 2]])
       assert_equal [], sf.subset_indices
     end
 
+    test '.new empty dataframe by a block' do
+      sf = SubFrames.new(DataFrame.new) { [[0, 1, 2]] }
+      assert_equal [], sf.subset_indices
+    end
+
     setup do
-      @df = DataFrame.new(x: [*1..3])
+      @df = DataFrame.new(x: [*1..6], y: %w[A A B B B C])
     end
 
     test '.new empty specifier' do
+      assert_equal [], SubFrames.new(@df).subset_indices
       assert_equal [], SubFrames.new(@df, []).subset_indices
+    end
+
+    test '.new empty specifier by a block' do
+      assert_equal [], SubFrames.new(@df) { nil }.subset_indices
+      assert_equal [], SubFrames.new(@df) { [] }.subset_indices
     end
 
     test '.new illegal specifier' do
       assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [%w[0 1]]) }
     end
 
+    test '.new illegal specifier by a block' do
+      assert_raise(SubFramesArgumentError) { SubFrames.new(@df) { [%w[0 1]] } }
+    end
+
+    test '.new both specifier and block' do
+      assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [[0]]) { [[0]] } }
+    end
+
     test '.new a SubFrames with index Array' do
       sf = SubFrames.new(@df, [[0, 2]])
+      assert_equal_array [[0, 2]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
+    end
+
+    test '.new a SubFrames with index Array by a block' do
+      sf = SubFrames.new(@df) { [[0, 2]] }
       assert_equal_array [[0, 2]], sf.subset_indices
       assert_kind_of Vector, sf.subset_indices[0]
     end
@@ -70,19 +99,41 @@ class SubFranesTest < Test::Unit::TestCase
       assert_kind_of Vector, sf.subset_indices[0]
     end
 
+    test '.new a SubFrames with index Vector by a block' do
+      sf = SubFrames.new(@df) { [Vector.new(0, 2, 5)] }
+      assert_equal_array [[0, 2, 5]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
+    end
+
     test '.new index out of range' do
-      assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [[0, 2, 4]]) }
+      assert_raise(SubFramesArgumentError) { SubFrames.new(@df, [[0, 2, 6]]) }
+    end
+
+    test '.new index out of range by a block' do
+      assert_raise(SubFramesArgumentError) { SubFrames.new(@df) { [[0, 2, 6]] } }
     end
 
     test '.new a SubFrames with boolean Array' do
-      sf = SubFrames.new(@df, [[true, false, true]])
-      assert_equal_array [[0, 2]], sf.subset_indices
+      sf = SubFrames.new(@df, [[true, false, true, false, nil, true]])
+      assert_equal_array [[0, 2, 5]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
+    end
+
+    test '.new a SubFrames with boolean Array by a block' do
+      sf = SubFrames.new(@df) { [[true, false, true, false, nil, true]] }
+      assert_equal_array [[0, 2, 5]], sf.subset_indices
       assert_kind_of Vector, sf.subset_indices[0]
     end
 
     test '.new a SubFrames with boolean Vector' do
-      sf = SubFrames.new(@df, [Vector.new(true, false, true)])
-      assert_equal_array [[0, 2]], sf.subset_indices
+      sf = SubFrames.new(@df, [Vector.new(true, false, true, false, nil, true)])
+      assert_equal_array [[0, 2, 5]], sf.subset_indices
+      assert_kind_of Vector, sf.subset_indices[0]
+    end
+
+    test '.new a SubFrames with boolean Vector by a block' do
+      sf = SubFrames.new(@df) { |df| [df.y == 'B'] }
+      assert_equal_array [[2, 3, 4]], sf.subset_indices
       assert_kind_of Vector, sf.subset_indices[0]
     end
   end

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -190,6 +190,7 @@ class SubFranesTest < Test::Unit::TestCase
         #<RedAmber::SubFrames : #{format('0x%016x', empty_subframe.object_id)}>
         @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         0 SubFrame: [] in size.
+        ---
       STR
     end
 
@@ -200,6 +201,21 @@ class SubFranesTest < Test::Unit::TestCase
         #<RedAmber::SubFrames : #{format('0x%016x', sf.object_id)}>
         @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         3 SubFrames: [2, 3, 1] in sizes.
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       1 A        false
+        1       2 A        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       3 B        false
+        1       4 B        (nil)
+        2       5 B        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       6 C        false
       STR
     end
 
@@ -210,7 +226,64 @@ class SubFranesTest < Test::Unit::TestCase
         #<RedAmber::SubFrames : #{format('0x%016x', universal.object_id)}>
         @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         1 SubFrame: [6] in size.
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       1 A        false
+        1       2 A        true
+        :       : :        :
+        4       5 B        true
+        5       6 C        false
       STR
+    end
+  end
+
+  sub_test_case '#to_s' do
+    setup do
+      @df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [false, true, false, nil, true, false]
+      )
+      @sf = SubFrames.new(@df, [[0, 1], [2, 3, 4], [5]])
+    end
+
+    test '#to_s' do
+      expected = <<~STR
+                x y        z
+          <uint8> <string> <boolean>
+        0       1 A        false
+        1       2 A        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       3 B        false
+        1       4 B        (nil)
+        2       5 B        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       6 C        false
+      STR
+      assert_equal expected, @sf.to_s
+    end
+
+    test '#to_s set limit' do
+      expected = <<~STR
+                x y        z
+          <uint8> <string> <boolean>
+        0       1 A        false
+        1       2 A        true
+        ---
+                x y        z
+          <uint8> <string> <boolean>
+        0       3 B        false
+        1       4 B        (nil)
+        2       5 B        true
+        ---
+        + 1 more DataFrame.
+      STR
+      assert_equal expected, @sf.to_s(limit: 2)
     end
   end
 

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -311,7 +311,7 @@ class SubFranesTest < Test::Unit::TestCase
       empty_subframe = SubFrames.new(@df, [])
       assert_equal <<~STR, empty_subframe.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', empty_subframe.object_id)}>
-        @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         0 SubFrame: [] in size.
         ---
       STR
@@ -323,7 +323,7 @@ class SubFranesTest < Test::Unit::TestCase
       a = sf.to_a
       assert_equal <<~STR, sf.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', sf.object_id)}>
-        @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         3 SubFrames: [2, 3, 1] in sizes.
         ---
         #<RedAmber::DataFrame : 2 x 3 Vectors, #{format('0x%016x', a[0].object_id)}>
@@ -351,7 +351,7 @@ class SubFranesTest < Test::Unit::TestCase
       universal = SubFrames.new(@df, specifier)
       assert_equal <<~STR, universal.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', universal.object_id)}>
-        @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
+        @baseframe=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         1 SubFrame: [6] in size.
         ---
         #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', universal.to_a[0].object_id)}>

--- a/test/test_subframes.rb
+++ b/test/test_subframes.rb
@@ -177,6 +177,28 @@ class SubFranesTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case '#each' do
+    setup do
+      @df = DataFrame.new(
+        x: [*1..6],
+        y: %w[A A B B B C],
+        z: [false, true, false, nil, true, false]
+      )
+      @sf = SubFrames.new(@df, [[0, 1], [2, 3, 4], [5]])
+    end
+
+    test '#each w/o block' do
+      assert_kind_of Enumerator, @sf.each
+    end
+
+    test '#each yielded block' do
+      expect = [[[1, 'A', false], [2, 'A', true]],
+                [[3, 'B', false], [4, 'B', nil], [5, 'B', true]],
+                [[6, 'C', false]]]
+      assert_equal expect, @sf.each.with_object([]) { |df, a| a << df.to_a }
+    end
+  end
+
   # Tests for #size, #sizes, #empty? and #universal?
   sub_test_case 'properties' do
     setup do
@@ -236,22 +258,26 @@ class SubFranesTest < Test::Unit::TestCase
     test '#inspect SubFrames' do
       specifier = [[0, 1], [2, 3, 4], [5]]
       sf = SubFrames.new(@df, specifier)
+      a = sf.to_a
       assert_equal <<~STR, sf.inspect
         #<RedAmber::SubFrames : #{format('0x%016x', sf.object_id)}>
         @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         3 SubFrames: [2, 3, 1] in sizes.
         ---
+        #<RedAmber::DataFrame : 2 x 3 Vectors, #{format('0x%016x', a[0].object_id)}>
                 x y        z
           <uint8> <string> <boolean>
         0       1 A        false
         1       2 A        true
         ---
+        #<RedAmber::DataFrame : 3 x 3 Vectors, #{format('0x%016x', a[1].object_id)}>
                 x y        z
           <uint8> <string> <boolean>
         0       3 B        false
         1       4 B        (nil)
         2       5 B        true
         ---
+        #<RedAmber::DataFrame : 1 x 3 Vectors, #{format('0x%016x', a[2].object_id)}>
                 x y        z
           <uint8> <string> <boolean>
         0       6 C        false
@@ -266,6 +292,7 @@ class SubFranesTest < Test::Unit::TestCase
         @universal_frame=#<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', @df.object_id)}>
         1 SubFrame: [6] in size.
         ---
+        #<RedAmber::DataFrame : 6 x 3 Vectors, #{format('0x%016x', universal.to_a[0].object_id)}>
                 x y        z
           <uint8> <string> <boolean>
         0       1 A        false
@@ -323,28 +350,6 @@ class SubFranesTest < Test::Unit::TestCase
         + 1 more DataFrame.
       STR
       assert_equal expected, @sf.to_s(limit: 2)
-    end
-  end
-
-  sub_test_case '#each' do
-    setup do
-      @df = DataFrame.new(
-        x: [*1..6],
-        y: %w[A A B B B C],
-        z: [false, true, false, nil, true, false]
-      )
-      @sf = SubFrames.new(@df, [[0, 1], [2, 3, 4], [5]])
-    end
-
-    test '#each w/o block' do
-      assert_kind_of Enumerator, @sf.each
-    end
-
-    test '#each yielded block' do
-      expect = [[[1, 'A', false], [2, 'A', true]],
-                [[3, 'B', false], [4, 'B', nil], [5, 'B', true]],
-                [[6, 'C', false]]]
-      assert_equal expect, @sf.each.with_object([]) { |df, a| a << df.to_a }
     end
   end
 


### PR DESCRIPTION
This PR will introduce a new feature `SubFrames`
(closes #170).

- Introduced a new class `SubFrames`
  - ~`@universal_dataframe`~ `@baseframe`
    source DataFrame as an universal set.
  - ~`@universal_indices`
    index Vector of @universal_dataframe~
  - ~`@subset_indices`
    an Array of index Vector to select sub DataFrames.~
  - `@frames`
    an Array of sub DataFrames created from ~@subset_indices~ @enum. It is created when `each` was called.
  - `@enum` 
    an Enumerator which returns sub dataframes one by one.
- Introduced many constructors.
  - `SubFrames.initialize(dataframe, subset_specifier=nil, &block)`
    Create SubFrames from indices or filters, by arguments or blocks.
  - `SubFrames.by_group(group)`
    Create SubFrames by Group object
  - `DataFrame#sub_by_value(keys: nil)`
    Create SubFrames from keys and group by values in columns specified by the key.
  - `DataFrame#sub_by_window(from: 0, size: nil, step: 1)`
    Create SubFrames by window in `size` rolling `from` by `step`.
  - `DataFrame#sub_by_enum(enumerator_method, *args)`
    Create SubFrames by Grouping/Windowing by posion. The position is specified by `Array`'s enumerator method such as `each_slice` or `each_cons`.
  - `DataFrame#sub_by_kernel(kernel, step: 1)`
    Create SubFrames by windowing with a kernel and step. Kernel is a boolean Array and it behaves like a masked window.
  - `DataFrame#build_subframes(subset_specifier = nil, &block)`
    Generic builder of sub-dataframe from self.
  - `SubFrames.by_dataframes(dataframes)`
    Create SubFrames from an Array of DataFrames.
