### PR TITLE
Miscellaneous Improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,19 @@ Style/TrailingCommaInHashLiteral:
 
 # To let you know the possibility of refactoring ===
 
+# Max: 120
+# This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, IgnoredPatterns.
+# URISchemes: http, https
+Layout/LineLength:
+  Max: 90
+  Exclude:
+    - 'test/**/*'
+
+# EnforcedStyle: aligned
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
 # avoid unused variable asignment
 Rubycw/Rubycw:
   Exclude:
@@ -52,15 +65,6 @@ Lint/EmptyBlock:
 # avoid unused variable asignment
 # Offense count: 6
 Lint/UselessAssignment:
-  Exclude:
-    - 'test/**/*'
-
-# Max: 120
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, IgnoredPatterns.
-# URISchemes: http, https
-Layout/LineLength:
-  Max: 90
   Exclude:
     - 'test/**/*'
 

--- a/doc/DataFrame.md
+++ b/doc/DataFrame.md
@@ -279,6 +279,7 @@ penguins.to_rover
 
   - Shows some information about self in a transposed style.
   - `tdr_str` returns same info as a String.
+  - `glimpse` is an alias. It is similar to dplyr's (or Polars's) `glimpse()`.
 
   ```ruby
   require 'red_amber'

--- a/doc/Vector.md
+++ b/doc/Vector.md
@@ -627,6 +627,42 @@ vector.merge(other, sep: '')
 ["ab", "cd", "ef"]
 ```
 
+### `concatenate(other)` or `concat(other)`
+
+Concatenate other array-like to self and return a concatenated Vector.
+- `other` is one of `Vector`, `Array`, `Arrow::Array` or `Arrow::ChunkedArray`
+- Different type will be 'resolved'.
+
+Concatenate to string
+```ruby
+string_vector
+
+# =>
+#<RedAmber::Vector(:string, size=2):0x00000000000037b4>
+["A", "B"]
+
+string_vector.concatenate([1, 2])
+
+# =>
+#<RedAmber::Vector(:string, size=4):0x0000000000003818>
+["A", "B", "1", "2"]
+```
+
+Concatenate to integer
+
+```ruby
+integer_vector
+
+# =>
+#<RedAmber::Vector(:uint8, size=2):0x000000000000382c>
+[1, 2]
+
+nteger_vector.concatenate(["A", "B"])
+# =>
+#<RedAmber::Vector(:uint8, size=4):0x0000000000003840>
+[1, 2, 65, 66]
+```
+
 ### `rank`
 
 Returns numerical rank of self.

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -389,15 +389,16 @@ module RedAmber
     # initialize @variable, @keys, @vectors and return one of them
     def init_instance_vars(var)
       ary =
-        @table.columns
-              .each_with_object([{}, [], []]) do |column, (variables, keys, vectors)|
-          v = Vector.create(column.data)
-          k = column.name.to_sym
-          v.key = k
-          variables[k] = v
-          keys << k
-          vectors << v
-        end
+        @table
+          .columns
+          .each_with_object([{}, [], []]) do |column, (variables, keys, vectors)|
+            v = Vector.create(column.data)
+            k = column.name.to_sym
+            v.key = k
+            variables[k] = v
+            keys << k
+            vectors << v
+          end
 
       @variables, @keys, @vectors = ary
       ary[%i[variables keys vectors].index(var)]

--- a/lib/red_amber/data_frame_combinable.rb
+++ b/lib/red_amber/data_frame_combinable.rb
@@ -447,8 +447,13 @@ module RedAmber
     #     2 D          (nil) (nil)
     #
     def right_join(other, join_keys = nil, suffix: '.1', force_order: true)
-      join(other, join_keys,
-           type: :right_outer, suffix: suffix, force_order: force_order)
+      join(
+        other,
+        join_keys,
+        type: :right_outer,
+        suffix: suffix,
+        force_order: force_order
+      )
     end
 
     # Filtering joins (#semi_join, #anti_join)
@@ -838,10 +843,13 @@ module RedAmber
 
       # Should we rescue errors in Arrow::Table#join for usability ?
       joined_table =
-        left_table.join(right_table, join_keys,
-                        type: type,
-                        left_outputs: left_outputs,
-                        right_outputs: right_outputs)
+        left_table.join(
+          right_table,
+          join_keys,
+          type: type,
+          left_outputs: left_outputs,
+          right_outputs: right_outputs
+        )
 
       case type
       when :inner, :left_outer, :left_semi, :left_anti, :right_semi, :right_anti
@@ -873,8 +881,10 @@ module RedAmber
             DataFrame.create(joined_table)
           end
         if force_order
-          dataframe = dataframe.sort(left_index, right_index)
-                               .drop(left_index, right_index)
+          dataframe =
+            dataframe
+              .sort(left_index, right_index)
+              .drop(left_index, right_index)
         end
         dataframe.pick do
           [right_keys, keys.map(&:to_s) - right_keys]

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -427,7 +427,7 @@ module RedAmber
       df = df.assign do
         vectors.each_with_object({}) do |v, assigner|
           vec = v.replace(0, v.key == INDEX_KEY ? '' : v.key.to_s)
-                 .replace(1, v.key == INDEX_KEY ? '' : "<#{original[v.key].type}>")
+                  .replace(1, v.key == INDEX_KEY ? '' : "<#{original[v.key].type}>")
           assigner[v.key] =
             original.size > head + tail + 1 ? vec.replace(head + 2, ':') : vec
         end

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -275,13 +275,31 @@ module RedAmber
       end
     end
 
-    private # =====
-
+    # Return class and shape of self by a String.
+    #
+    # @param with_id [true, false]
+    #   show id if true.
+    # @return [String]
+    #   shape string.
+    # @example Default (without id)
+    #   penguins.shape_str
+    #
+    #   # =>
+    #   "RedAmber::DataFrame : 344 x 8 Vectors"
+    #
+    # @example With id
+    #   penguins.shape_str(with_id: true)
+    #
+    #   # =>
+    #   "RedAmber::DataFrame : 344 x 8 Vectors, 0x0000000000003980"
+    #
     def shape_str(with_id: false)
       shape_info = empty? ? '(empty)' : "#{size} x #{n_keys} Vector#{pl(n_keys)}"
       id = with_id ? format(', 0x%016x', object_id) : ''
       "#{self.class} : #{shape_info}#{id}"
     end
+
+    private # =====
 
     def dataframe_info(limit, tally_level: 5, max_element: 5)
       return '' if empty?

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -234,6 +234,7 @@ module RedAmber
     def tdr(limit = 10, tally: 5, elements: 5)
       puts tdr_str(limit, tally: tally, elements: elements)
     end
+    alias_method :glimpse, :tdr
 
     # Shortcut for `tdr(:all)``.
     #

--- a/lib/red_amber/data_frame_displayable.rb
+++ b/lib/red_amber/data_frame_displayable.rb
@@ -235,6 +235,14 @@ module RedAmber
       puts tdr_str(limit, tally: tally, elements: elements)
     end
 
+    # Shortcut for `tdr(:all)``.
+    #
+    # @return (see #tdr)
+    #
+    def tdra
+      puts tdr_str(:all)
+    end
+
     # rubocop:enable Layout/LineLength
 
     # Returns some information about self in a transposed style by a string.

--- a/lib/red_amber/data_frame_selectable.rb
+++ b/lib/red_amber/data_frame_selectable.rb
@@ -145,10 +145,10 @@ module RedAmber
         arrow_array = aa
       else
         a = parse_args(args, size)
-        return select_variables_by_keys(a) if a.symbols?
-        return take(normalize_indices(Arrow::Array.new(a))) if a.integers?
+        return select_variables_by_keys(a) if a.symbol?
+        return take(normalize_indices(Arrow::Array.new(a))) if a.integer?
         return remove_all_values if a.compact.empty?
-        return filter_by_array(Arrow::BooleanArray.new(a)) if a.booleans?
+        return filter_by_array(Arrow::BooleanArray.new(a)) if a.boolean?
 
         raise DataFrameArgumentError, "invalid arguments: #{args}"
       end
@@ -157,7 +157,7 @@ module RedAmber
       return filter_by_array(arrow_array) if arrow_array.boolean?
 
       a = arrow_array.to_a
-      return select_variables_by_keys(a) if a.symbols_or_strings?
+      return select_variables_by_keys(a) if a.symbol_or_string?
 
       raise DataFrameArgumentError, "invalid arguments: #{args}"
     end

--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -126,9 +126,9 @@ module RedAmber
       case args
       in [] | [nil]
         return DataFrame.new
-      in [*] if args.symbols?
+      in [*] if args.symbol?
         return DataFrame.create(@table.select_columns(*args))
-      in [*] if args.booleans?
+      in [*] if args.boolean?
         picker = keys.select_by_booleans(args)
         return DataFrame.create(@table.select_columns(*picker))
       in [(Vector | Arrow::Array | Arrow::ChunkedArray) => a]
@@ -139,7 +139,7 @@ module RedAmber
 
       return DataFrame.new if picker.compact.empty?
 
-      if picker.booleans?
+      if picker.boolean?
         picker = keys.select_by_booleans(picker)
         return DataFrame.create(@table.select_columns(*picker))
       end
@@ -257,21 +257,21 @@ module RedAmber
       return self if args.empty? || empty?
 
       picker =
-        if args.symbols?
+        if args.symbol?
           keys - args
-        elsif args.booleans?
+        elsif args.boolean?
           keys.reject_by_booleans(args)
-        elsif args.integers?
+        elsif args.integer?
           keys.reject_by_indices(args)
         else
           dropper = parse_args(args, n_keys)
-          if dropper.booleans?
+          if dropper.boolean?
             keys.reject_by_booleans(dropper)
-          elsif dropper.symbols?
+          elsif dropper.symbol?
             keys - dropper
           else
             dropper.compact!
-            unless dropper.integers?
+            unless dropper.integer?
               raise DataFrameArgumentError, "Invalid argument #{args}"
             end
 

--- a/lib/red_amber/refinements.rb
+++ b/lib/red_amber/refinements.rb
@@ -155,7 +155,7 @@ module RedAmber
   # Add additional capabilities to Array
   module RefineArray
     refine Array do
-      def integers?
+      def integer?
         all? { |e| e.is_a?(Integer) } # rubocop:disable Performance/RedundantEqualityComparisonBlock
       end
 
@@ -163,19 +163,19 @@ module RedAmber
         all? { |e| e.is_a?(Numeric) } # rubocop:disable Performance/RedundantEqualityComparisonBlock
       end
 
-      def booleans?
+      def boolean?
         all? { |e| e.is_a?(TrueClass) || e.is_a?(FalseClass) || e.is_a?(NilClass) }
       end
 
-      def symbols?
+      def symbol?
         all? { |e| e.is_a?(Symbol) } # rubocop:disable Performance/RedundantEqualityComparisonBlock
       end
 
-      def strings?
+      def string?
         all? { |e| e.is_a?(String) } # rubocop:disable Performance/RedundantEqualityComparisonBlock
       end
 
-      def symbols_or_strings?
+      def symbol_or_string?
         all? { |e| e.is_a?(Symbol) || e.is_a?(String) }
       end
 

--- a/lib/red_amber/refinements.rb
+++ b/lib/red_amber/refinements.rb
@@ -159,6 +159,10 @@ module RedAmber
         all? { |e| e.is_a?(Integer) } # rubocop:disable Performance/RedundantEqualityComparisonBlock
       end
 
+      def numeric?
+        all? { |e| e.is_a?(Numeric) } # rubocop:disable Performance/RedundantEqualityComparisonBlock
+      end
+
       def booleans?
         all? { |e| e.is_a?(TrueClass) || e.is_a?(FalseClass) || e.is_a?(NilClass) }
       end

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -508,6 +508,7 @@ module RedAmber
         end
       Vector.new([value] * size)
     end
+    alias_method :expand, :propagate
 
     private # =======
 

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -86,6 +86,53 @@ module RedAmber
     #
     attr_accessor :key
 
+    # Return other as a Vector which is same data type as self.
+    #
+    # @param other [Vector, Array, Arrow::Array, Arrow::ChunkedArray]
+    #   a source array-like which will be converted.
+    # @return [Vector]
+    #   resolved Vector.
+    # @example Integer to String
+    #   Vector.new('A').resolve([1, 2])
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:string, size=2):0x00000000000037b4>
+    #   ["1", "2"]
+    #
+    # @example String to Ineger
+    #   Vector.new(1).resolve(["A"])
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:uint8, size=1):0x00000000000037dc>
+    #   [65]
+    #
+    # @example Upcast to uint16
+    #   vector = Vector.new(256)
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:uint16, size=1):0x000000000000c1fc>
+    #   [256]
+    #
+    #   vector.resolve([1, 2])
+    #
+    #   # =>
+    #   # Not a uint8 Vector
+    #   #<RedAmber::Vector(:uint16, size=2):0x000000000000c328>
+    #   [1, 2]
+    #
+    # @since 0.3.1
+    #
+    def resolve(other)
+      case other
+      when Vector
+        Vector.create(data.resolve(other.data))
+      when Array, Arrow::Array, Arrow::ChunkedArray
+        Vector.create(data.resolve(other))
+      else
+        raise VectorArgumentError, "invalid argument: #{other}"
+      end
+    end
+
     # String representation of self like an Array.
     #
     # @return [String]

--- a/lib/red_amber/vector_unary_element_wise.rb
+++ b/lib/red_amber/vector_unary_element_wise.rb
@@ -129,6 +129,28 @@ module RedAmber
     #
     define_unary_element_wise :cos
 
+    # Compute cumulative sum over the numeric Vector.
+    #
+    # @note Self must be numeric.
+    # @note Return error for integer overflow.
+    # @return [Vector]
+    #   cumulative sum of self.
+    #
+    define_unary_element_wise :cumulative_sum_checked
+
+    # Compute cumulative sum over the numeric Vector.
+    #
+    # @note Self must be numeric.
+    # @note Try to cast to Int64 if integer overflow occured.
+    # @return [Vector]
+    #   cumulative sum of self.
+    #
+    def cumsum
+      cumulative_sum_checked
+    rescue Arrow::Error::Invalid
+      Vector.create(Arrow::Int64Array.new(data)).cumulative_sum_checked
+    end
+
     # Carry non-nil values backward to fill nil slots.
     #
     # Propagate next valid value backward to previous nil values.

--- a/lib/red_amber/vector_updatable.rb
+++ b/lib/red_amber/vector_updatable.rb
@@ -391,6 +391,53 @@ module RedAmber
       Vector.create(datum.value)
     end
 
+    # Concatenate other array-like to self.
+    #
+    # @param other [Vector, Array, Arrow::Array, Arrow::ChunkedArray]
+    #   other array-like to concatenate.
+    # @return [Vector]
+    #   concatenated Vector.
+    # @example Concatenate to string
+    #   string_vector
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:string, size=2):0x00000000000037b4>
+    #   ["A", "B"]
+    #
+    #   string_vector.concatenate([1, 2])
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:string, size=4):0x0000000000003818>
+    #   ["A", "B", "1", "2"]
+    #
+    # @example Concatenate to integer
+    #   integer_vector
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:uint8, size=2):0x000000000000382c>
+    #   [1, 2]
+    #
+    #   nteger_vector.concatenate(["A", "B"])
+    #   # =>
+    #   #<RedAmber::Vector(:uint8, size=4):0x0000000000003840>
+    #   [1, 2, 65, 66]
+    #
+    # @since 0.3.1
+    #
+    def concatenate(other)
+      concatenated_array =
+        case other
+        when Vector
+          data + other.data
+        when Arrow::ChunkedArray
+          data + other.pack
+        else
+          data + other
+        end
+      Vector.create(concatenated_array)
+    end
+    alias_method :concat, :concatenate
+
     private
 
     # Replace elements selected with a boolean mask

--- a/lib/red_amber/vector_updatable.rb
+++ b/lib/red_amber/vector_updatable.rb
@@ -245,13 +245,24 @@ module RedAmber
       is_nil.if_else(false, self).invert
     end
 
+    # Shift elements in self.
+    #
+    # @param amount [Integer]
+    #   amount of shift. Positive value will shift right, negative will shift left.
+    # @param fill [Object]
+    #   complementary element to fill the new seat.
+    # @return [Vector]
+    #   shifted Vector.
+    #
     def shift(amount = 1, fill: nil)
-      raise VectorArgumentError, 'Shift amount is too large' if amount.abs > size
+      raise VectorArgumentError, 'Shift amount is too large' if amount.abs >= size
 
       if amount.positive?
-        replace(amount..-1, self[0...-amount]).replace(0...amount, fill)
+        filler = [fill] * amount
+        Vector.new(filler.concat(Array(self[0...-amount])))
       elsif amount.negative?
-        replace(0...amount, self[-amount..]).replace(amount..-1, fill)
+        filler = [fill] * -amount
+        Vector.new(Array(self[-amount...]).concat(filler))
       else # amount == 0
         self
       end

--- a/test/test_data_frame_combinable.rb
+++ b/test/test_data_frame_combinable.rb
@@ -212,9 +212,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df1.right_join(@right1, [:KEY])
         assert_equal expected, @df1.right_join(@right1.table, :KEY)
         assert_equal expected, @df1.right_join(@right1, { left: :KEY, right: :KEY })
-        assert_equal expected, @df1.rename(KEY: :KEY1)
-                                   .right_join(@right1,
-                                               { left: :KEY1, right: :KEY })
+        assert_equal expected, @df1
+                                 .rename(KEY: :KEY1)
+                                 .right_join(@right1, { left: :KEY1, right: :KEY })
       end
 
       test '#semi_join with a join_key' do
@@ -254,13 +254,16 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         )
         assert_equal expected, @df1.join(@right1, type: :right_semi)
         assert_equal expected, @df1.join(@right1, :KEY, type: :right_semi)
-        assert_equal expected, @df1.join(@right1,
-                                         { left: :KEY, right: :KEY },
-                                         type: :right_semi)
-        assert_equal expected, @df1.rename(KEY: :KEY1)
-                                   .join(@right1,
-                                         { left: :KEY1, right: :KEY },
-                                         type: :right_semi)
+        assert_equal(
+          expected,
+          @df1.join(@right1, { left: :KEY, right: :KEY }, type: :right_semi)
+        )
+        assert_equal(
+          expected,
+          @df1
+            .rename(KEY: :KEY1)
+            .join(@right1, { left: :KEY1, right: :KEY }, type: :right_semi)
+        )
       end
 
       test 'right_anti' do
@@ -270,13 +273,16 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         )
         assert_equal expected, @df1.join(@right1, type: :right_anti)
         assert_equal expected, @df1.join(@right1, :KEY, type: :right_anti)
-        assert_equal expected, @df1.join(@right1,
-                                         { left: :KEY, right: :KEY },
-                                         type: :right_anti)
-        assert_equal expected, @df1.rename(KEY: :KEY1)
-                                   .join(@right1,
-                                         { left: :KEY1, right: :KEY },
-                                         type: :right_anti)
+        assert_equal(
+          expected,
+          @df1.join(@right1, { left: :KEY, right: :KEY }, type: :right_anti)
+        )
+        assert_equal(
+          expected,
+          @df1
+            .rename(KEY: :KEY1)
+            .join(@right1, { left: :KEY1, right: :KEY }, type: :right_anti)
+        )
       end
     end
 
@@ -398,9 +404,12 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         assert_equal expected, @df2.right_join(@right2.table, %i[KEY1 KEY2])
         assert_equal expected, @df2.right_join(@right2,
                                                { left: %i[KEY1 KEY2], right: %w[KEY1 KEY2] })
-        assert_equal expected, @df2.rename(KEY1: :KEY3)
-                                   .right_join(@right2,
-                                               { left: %i[KEY3 KEY2], right: %w[KEY1 KEY2] })
+        assert_equal(
+          expected,
+          @df2
+            .rename(KEY1: :KEY3)
+            .right_join(@right2, { left: %i[KEY3 KEY2], right: %w[KEY1 KEY2] })
+        )
       end
 
       test '#right_join with join_keys, partial join_key/rename' do

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -543,4 +543,16 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
       assert_equal html, df.to_iruby[1]
     end
   end
+
+  sub_test_case '#shape_str' do
+    setup do
+      @df = DataFrame.new(x: [1, 2, 3])
+    end
+
+    test '#shape_str' do
+      assert_equal 'RedAmber::DataFrame : 3 x 1 Vector', @df.shape_str
+      e = "RedAmber::DataFrame : 3 x 1 Vector, #{format('0x%016x', @df.object_id)}"
+      assert_equal e, @df.shape_str(with_id: true)
+    end
+  end
 end

--- a/test/test_data_frame_displayable.rb
+++ b/test/test_data_frame_displayable.rb
@@ -213,7 +213,7 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case 'tdr_str' do
+  sub_test_case 'tdr' do
     setup do
       hash = { integer: [1, 2, 3, 4, 5, 6],
                double: [1, 0 / 0.0, 1 / 0.0, -1 / 0.0, nil, ''],
@@ -328,6 +328,32 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
         1 :double  double      6 [1.0, NaN, Infinity, -Infinity, nil, ... ], 1 NaN, 1 nil
         2 :string  string      5 {"A"=>2, "B"=>1, "C"=>1, "D"=>1, "E"=>1}
         3 :boolean boolean     3 {true=>2, false=>2, nil=>2}
+      STR
+    ensure
+      $stdout = STDOUT
+    end
+
+    test '#tdra' do
+      df = DataFrame.new(
+        (1..11).map { [(_1 + 96).chr, [_1 - 1, _1]] }
+      )
+      $stdout = StringIO.new
+      assert_nil df.tdra
+      assert_equal <<~STR, $stdout.string
+        RedAmber::DataFrame : 2 x 11 Vectors
+        Vectors : 11 numeric
+        #  key type  level data_preview
+        0  :a  uint8     2 [0, 1]
+        1  :b  uint8     2 [1, 2]
+        2  :c  uint8     2 [2, 3]
+        3  :d  uint8     2 [3, 4]
+        4  :e  uint8     2 [4, 5]
+        5  :f  uint8     2 [5, 6]
+        6  :g  uint8     2 [6, 7]
+        7  :h  uint8     2 [7, 8]
+        8  :i  uint8     2 [8, 9]
+        9  :j  uint8     2 [9, 10]
+        10 :k  uint8     2 [10, 11]
       STR
     ensure
       $stdout = STDOUT

--- a/test/test_refinements.rb
+++ b/test/test_refinements.rb
@@ -11,6 +11,7 @@ class RefinementsTest < Test::Unit::TestCase
   sub_test_case 'refine Array' do
     setup do
       @integers = [1, 0, -1]
+      @floats = [1.0, -1.0, Float::NAN]
       @booleans = [true, false, nil]
       @symbols = %i[a b c]
       @strings = %w[a b c]
@@ -21,6 +22,13 @@ class RefinementsTest < Test::Unit::TestCase
       assert_true @integers.integers?
       assert_true [].integers?
       assert_false @booleans.integers?
+    end
+
+    test 'Array#numeric?' do
+      assert_true @integers.numeric?
+      assert_true @floats.numeric?
+      assert_true [].numeric?
+      assert_false @booleans.numeric?
     end
 
     test 'Array#booleans?' do

--- a/test/test_refinements.rb
+++ b/test/test_refinements.rb
@@ -18,10 +18,10 @@ class RefinementsTest < Test::Unit::TestCase
       @symbols_or_strings = [:a, 'b', :c]
     end
 
-    test 'Array#integers?' do
-      assert_true @integers.integers?
-      assert_true [].integers?
-      assert_false @booleans.integers?
+    test 'Array#integer?' do
+      assert_true @integers.integer?
+      assert_true [].integer?
+      assert_false @booleans.integer?
     end
 
     test 'Array#numeric?' do
@@ -31,28 +31,28 @@ class RefinementsTest < Test::Unit::TestCase
       assert_false @booleans.numeric?
     end
 
-    test 'Array#booleans?' do
-      assert_true @booleans.booleans?
-      assert_true [].booleans?
-      assert_false @integers.booleans?
+    test 'Array#boolean?' do
+      assert_true @booleans.boolean?
+      assert_true [].boolean?
+      assert_false @integers.boolean?
     end
 
-    test 'Array#symbols?' do
-      assert_true @symbols.symbols?
-      assert_true [].symbols?
-      assert_false @integers.symbols?
+    test 'Array#symbol?' do
+      assert_true @symbols.symbol?
+      assert_true [].symbol?
+      assert_false @integers.symbol?
     end
 
-    test 'Array#strings?' do
-      assert_true @strings.strings?
-      assert_true [].strings?
-      assert_false @integers.strings?
+    test 'Array#string?' do
+      assert_true @strings.string?
+      assert_true [].string?
+      assert_false @integers.string?
     end
 
-    test 'Array#symbols_or_strings?' do
-      assert_true @symbols_or_strings.symbols_or_strings?
-      assert_true [].symbols_or_strings?
-      assert_false @integers.symbols_or_strings?
+    test 'Array#symbol_or_string?' do
+      assert_true @symbols_or_strings.symbol_or_string?
+      assert_true [].symbol_or_string?
+      assert_false @integers.symbol_or_string?
     end
 
     test 'Array#booleans_to_indices' do

--- a/test/test_vector.rb
+++ b/test/test_vector.rb
@@ -65,6 +65,29 @@ class VectorTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case '#resolve' do
+    test '#resolve integer upcast' do
+      assert_equal :uint16, Vector.new(256).resolve([1]).type
+      assert_equal :uint16, Vector.new(256).resolve(Vector.new(1)).type
+    end
+
+    test '#resolve integer overflow' do
+      assert_equal_array [0], Vector.new(1).resolve([256])
+    end
+
+    test '#resolve string' do
+      assert_equal_array ['1'], Vector.new('A').resolve([1])
+    end
+
+    test '#resolve string to integer' do
+      assert_equal_array [65], Vector.new(1).resolve(['A'])
+    end
+
+    test '#resolve invalid argument' do
+      assert_raise(VectorArgumentError) { Vector.new(1).resolve(1) }
+    end
+  end
+
   sub_test_case 'Basic properties' do
     data(keep: true) do
       a = [0, 1, nil, 4]

--- a/test/test_vector_unary_element_wise.rb
+++ b/test/test_vector_unary_element_wise.rb
@@ -6,7 +6,7 @@ class VectorFunctionTest < Test::Unit::TestCase
   include TestHelper
   include RedAmber
 
-  sub_test_case('unary element-wise') do
+  sub_test_case 'unary element-wise' do
     setup do
       @boolean = Vector.new([true, true, nil])
       @integer = Vector.new([1, 2, 3])
@@ -112,7 +112,7 @@ class VectorFunctionTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case('element-wise with NaN or Infinity') do
+  sub_test_case 'element-wise with NaN or Infinity' do
     setup do
       @boolean = Vector.new([true, false, nil])
       @integer = Vector.new([-1, 0, 1, 2])
@@ -169,7 +169,7 @@ class VectorFunctionTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case('unary element-wise rounding') do
+  sub_test_case 'unary element-wise rounding' do
     setup do
       @boolean = Vector.new([true, true, nil])
       @integer = Vector.new([1, 2, 3])
@@ -233,7 +233,7 @@ class VectorFunctionTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case('unary output vector') do
+  sub_test_case 'unary output vector' do
     setup do
       @boolean = Vector.new([true, true, nil, false, nil])
       @integer = Vector.new([1, 2, 1, nil])
@@ -260,7 +260,7 @@ class VectorFunctionTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case('unary element-wise categorizations') do
+  sub_test_case 'unary element-wise categorizations' do
     setup do
       @boolean = Vector.new([true, false, true, false, nil])
       @integer = Vector.new([0, 1, -2, 3, nil])
@@ -311,7 +311,7 @@ class VectorFunctionTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case('unary element-wise fill_nil_forward/backward') do
+  sub_test_case 'unary element-wise fill_nil_forward/backward' do
     setup do
       @boolean = Vector.new([true, false, nil, true, nil])
       @integer = Vector.new([0, 1, nil, 3, nil])
@@ -331,6 +331,24 @@ class VectorFunctionTest < Test::Unit::TestCase
       assert_equal_array [0, 1, 1, 3, 3], @integer.fill_nil_forward
       assert_equal_array_with_nan [Math::PI, Float::INFINITY, Float::INFINITY, Float::NAN, Float::NAN], @double.fill_nil_forward
       assert_equal_array ['A', 'B', 'B', '', ''], @string.fill_nil_forward
+    end
+  end
+
+  sub_test_case '#cumulative_sum' do
+    test '#cumulative_sum' do
+      assert_equal_array [1, 3, 6, 255], Vector.new(1, 2, 3, 249).cumulative_sum_checked
+      assert_raise(Arrow::Error::Invalid) { Vector.new(1, 2, 3, 250).cumulative_sum_checked }
+      assert_equal_array [1.0, 3.0, 6.0, 256.0], Vector.new(1.0, 2, 3, 250).cumulative_sum_checked
+      assert_raise(Arrow::Error::NotImplemented) { Vector.new(%w[A B C]).cumulative_sum_checked }
+      assert_raise(Arrow::Error::NotImplemented) { Vector.new(true, false, nil).cumulative_sum_checked }
+    end
+
+    test '#cumsum' do
+      assert_equal_array [1, 3, 6, 255], Vector.new(1, 2, 3, 249).cumsum
+      assert_equal_array [1, 3, 6, 256], Vector.new(1, 2, 3, 250).cumsum
+      assert_equal_array [1.0, 3.0, 6.0, 256.0], Vector.new(1.0, 2, 3, 250).cumsum
+      assert_raise(Arrow::Error::NotImplemented) { Vector.new(%w[A B C]).cumsum }
+      assert_raise(Arrow::Error::NotImplemented) { Vector.new(true, false, nil).cumsum }
     end
   end
 end

--- a/test/test_vector_updatable.rb
+++ b/test/test_vector_updatable.rb
@@ -319,4 +319,46 @@ class VectorTest < Test::Unit::TestCase
       assert_raise(NameError) { Vector.new(array).merge(other) }
     end
   end
+
+  sub_test_case '#concatenate' do
+    setup do
+      @string = Vector.new(%w[A B C])
+      @integer = Vector.new([1, 2])
+    end
+
+    test '#concatenate []' do
+      assert_raise(ArgumentError) { @string.concatenate }
+      assert_equal_array %w[A B C], @string.concatenate([])
+      assert_equal_array %w[A B C], @string.concatenate(Vector.new)
+      assert_equal_array [1, 2], @integer.concatenate([])
+      assert_equal_array [1, 2], @integer.concatenate(Vector.new)
+    end
+
+    test '#concatenate integer into string' do
+      expected = %w[A B C 1 2]
+      assert_equal_array expected, @string.concatenate([1, 2])
+      assert_equal_array expected, @string.concatenate(@integer)
+    end
+
+    test '#concatenate string into integer' do
+      assert_equal_array [1, 2, 65, 66, 67], @integer.concatenate(%w[A B C])
+      assert_raise(Arrow::Error::Invalid) { @integer.concatenate(@string) }
+    end
+
+    test '#concatenate string' do
+      assert_equal_array %w[A B C], Vector.new.concatenate(@string)
+      assert_equal_array %w[1 2], Vector.new.concatenate(@integer)
+      assert_equal_array %w[A B C D E], @string.concatenate(%w[D E])
+      assert_equal_array %w[A B C D E], @string.concatenate(Arrow::Array.new(%w[D E]))
+      assert_equal_array %w[A B C D E], @string.concatenate(Arrow::ChunkedArray.new([%w[D E]]))
+      assert_equal_array %w[A B C D E], @string.concatenate(Vector.new(%w[D E]))
+    end
+
+    test '#concatenate integer' do
+      assert_equal_array [1, 2, 3, 4], @integer.concatenate([3, 4])
+      assert_equal_array [1, 2, 3, 4], @integer.concatenate(Arrow::Array.new([3, 4]))
+      assert_equal_array [1, 2, 3, 4], @integer.concatenate(Arrow::ChunkedArray.new([[3, 4]]))
+      assert_equal_array [1, 2, 3, 4], @integer.concatenate(Vector.new([3, 4]))
+    end
+  end
 end

--- a/test/test_vector_updatable.rb
+++ b/test/test_vector_updatable.rb
@@ -164,16 +164,31 @@ class VectorTest < Test::Unit::TestCase
   end
 
   sub_test_case '#shift' do
-    test '#shift' do
-      vector = Vector.new([1, 2, 3, 4, 5])
-      assert_equal [nil, 1, 2, 3, 4], vector.shift
-      assert_equal [3, 4, 5, nil, nil], vector.shift(-2)
-      assert_equal [0, 0, 1, 2, 3], vector.shift(2, fill: 0)
+    setup do
+      @numeric = Vector.new(1, 2, 3, 4, 5)
+      @boolean = Vector.new(true, false, true, false, false)
+    end
+
+    test '#shift amount too large' do
+      assert_raise(VectorArgumentError) { @numeric.shift(5) }
+      assert_raise(VectorArgumentError) { @numeric.shift(-5) }
+    end
+
+    test '#shift numeric Vector' do
+      assert_equal_array [nil, 1, 2, 3, 4], @numeric.shift
+      assert_equal_array [3, 4, 5, nil, nil], @numeric.shift(-2)
+      assert_equal_array [0, 0, 1, 2, 3], @numeric.shift(2, fill: 0)
+    end
+
+    test '#shift boolean Vector' do
+      assert_equal_array [nil, true, false, true, false], @boolean.shift
+      assert_equal_array [true, false, false, nil, nil], @boolean.shift(-2)
+      assert_equal_array [false, false, true, false, true], @boolean.shift(2, fill: false)
     end
 
     test '#shift, amount == 0' do
-      vector = Vector.new([1, 2, 3, 4, 5])
-      assert_equal_array vector, vector.shift(0)
+      assert_equal_array [1, 2, 3, 4, 5], @numeric.shift(0)
+      assert_equal_array [true, false, true, false, false], @boolean.shift(0)
     end
   end
 


### PR DESCRIPTION
Add miscellaneous improvements especially preparing for SubFrames.

- :zap: Promote DataFrame#shape_str to public
- :sparkles: Introduce Vector#concatenate
- :zap: Add #numeric? in refinements of Array
- :recycle: Rename Array refinements to the same name as Vector
- :butterfly: Fix Vector#shift when boolean Vector
- :zap: Add Vector#cumulative_sum_checked and #cumsum
  * It will often be used in subframe operations.
- :zap: Add Vector#resolve method
  * It is convenient to create a same type Vector of self.
- :zap: Add DataFrame#tdra method
  * A shortcut for #tdr(:all)