### PR TITLE
Upgrade Arrow version to 11.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :test do
   gem 'rake'
 
-  gem 'red-parquet', '~> 10.0.0'
+  gem 'red-parquet', '~> 11.0.0'
   gem 'rover-df', '~> 0.3.0'
 
   gem 'rubocop'

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -2,5 +2,5 @@
 
 module RedAmber
   # Library version
-  VERSION = '0.3.1-HEAD'
+  VERSION = '0.4.0-HEAD'
 end

--- a/red_amber.gemspec
+++ b/red_amber.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'red-arrow', '~> 10.0.0'
+  spec.add_dependency 'red-arrow', '~> 11.0.0'
 
   # Development dependency has gone to the Gemfile (rubygems/bundler#7237)
 

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -141,11 +141,24 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       assert_true df.drop(:key).empty?
     end
 
+    test 'drop nothing' do
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 4 Vectors
+        Vectors : 2 numeric, 1 string, 1 boolean
+        # key type    level data_preview
+        0 :a  uint8       3 [1, 2, 3]
+        1 :b  double      3 [0.0, NaN, nil], 1 NaN, 1 nil
+        2 :c  string      3 ["A", "B", "C"]
+        3 :d  boolean     3 [true, false, nil], 1 nil
+      STR
+      assert_equal str, @df.drop.tdr_str
+      assert_equal str, @df.drop([]).tdr_str
+      assert_equal str, @df.drop { nil }.tdr_str
+    end
+
     test 'drop by arguments' do
       assert_raise(DataFrameArgumentError) { @df.drop(:a) { :block } }
 
-      assert_equal @df, @df.drop # drop nothing
-      assert_equal @df, @df.drop([]) # drop nothing
       assert_true @df.drop(@df.keys).empty? # drop all
 
       str = <<~STR
@@ -192,7 +205,6 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
         1 :b  double     3 [0.0, NaN, nil], 1 NaN, 1 nil
         2 :c  string     3 ["A", "B", "C"]
       STR
-      assert_equal(@df, @df.drop { nil }) # drop nothing
       assert_equal str, @df.drop { 3 }.tdr_str
       assert_equal str, @df.drop { [3] }.tdr_str
       assert_equal str, @df.drop { :d }.tdr_str
@@ -243,15 +255,25 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       assert_raise(DataFrameArgumentError) { df.rename(:key) }
     end
 
+    test 'rename nothing' do
+      str = <<~OUTPUT
+        RedAmber::DataFrame : 5 x 4 Vectors
+        Vectors : 2 numeric, 1 string, 1 boolean
+        # key     type    level data_preview
+        0 :index  uint8       5 [0, 1, 2, 3, nil], 1 nil
+        1 :float  double      5 [0.0, 1.1, 2.2, NaN, nil], 1 NaN, 1 nil
+        2 :string string      5 ["A", "B", "C", "D", nil], 1 nil
+        3 :bool   boolean     3 {true=>2, false=>2, nil=>1}
+      OUTPUT
+      assert_equal str, @df2.rename.tdr_str
+      assert_equal str, @df2.rename([]).tdr_str
+      unchanged_key_pair = @df2.keys.each_with_object({}) { |k, h| h[k] = k }
+      assert_equal str, @df2.rename(unchanged_key_pair).tdr_str
+    end
+
     test 'rename by arguments' do
       assert_raise(DataFrameArgumentError) { @df2.rename(:key) { :block } }
       assert_raise(DataFrameArgumentError) { @df2.rename(:key) }
-
-      assert_equal @df2, @df2.rename # rename nothing
-      assert_equal @df2, @df2.rename([])
-
-      unchanged_key_pair = @df2.keys.each_with_object({}) { |k, h| h[k] = k }
-      assert_equal @df2, @df2.rename(unchanged_key_pair)
 
       str = <<~OUTPUT
         RedAmber::DataFrame : 5 x 4 Vectors


### PR DESCRIPTION
Red Arrow/Red Arrow GLib 11.0.0 are finally out! (https://rubygems.org/gems/red-arrow)

I will upgrade dependencies to 11.0.0 .

Closes #187, #171.