### PR TITLE
Prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,116 @@
+## [0.4.0] - 2023-02-25
+
+:memo: Update documents for consistency
+
+- Breaking change
+  - Upgrade dependency to Arrow 11.0.0 (#188)
+
+- Bug fixes
+  - Add :force_order option for DataFrame#join (#174)
+  - Return error for empty DataFrame in DataFrame#filter (#172)
+  - Accept ChunkedArray in DataFrame#filter (#172)
+  - Fix Vector#replace to accept Arrow::Array as a replacer (#179)
+  - Fix Vector#round_to_multiple to accept Float or Integer (#180)
+  - Change Vector atan2 to a class method (#180)
+  - Fix Vector#shift when boolean Vector (#184)
+  - Fix processing empty SubFrames (#183)
+  - Do not check object id in DataFrame#rename, #drop for self (#188)
+
+- New features and improvements
+  - Accept a block in DataFrame#filter (#172)
+  - Add Vector.aggregate? method (#175)
+  - Introduce Vector#propagate method (#175)
+  - Add Vector#rank methods (#176)
+  - Add Vector#sample method (#176)
+  - Add Vector#sort method (#176)
+  - Promote DataFrame#shape_str to public (#184)
+  - Introduce Vector#concatenate (#184)
+  - Add #numeric? in refinements of Array (#184)
+  - Add Vector#cumulative_sum_checked and #cumsum (#184)
+  - Add Vector#resolve method (#184)
+  - Add DataFrame#tdra method (#184)
+  - Add #expand as an alias for Vector#propagate (#184)
+  - Add #glimpse as an alias for DataFrame#tdr (#184)
+  - New class SubFrames (#183)
+    - Introduce class SubFrames
+    - Memorize dataframes in SubFrames
+    - Add @frames to memorize sub DataFrames
+    - Accept filters in SubFrames.new
+    - Accept block in SubFrames.new
+    - Add SubFrames.by_filter
+    - Introduce methods creating SubFrames from DataFrame
+    - Introduce SubFrames#each method
+    - Add SubFrames#to_s method
+    - Add SubFrames#concatenate method
+    - Add SubFrames#offset_indices method
+    - SubFrames#aggregate method
+    - Redefine SubFrames#map to return SubFrames
+    - Define SubFrame#map dynamically
+    - Add SubFrames#assign method
+    - Redefine SubFrames#select to return SubFrames
+    - Add SubFrames#reject method
+    - Add SubFrames#filter_map method
+    - Refine DataFrame#indices memorizing @indices
+    - Rename SubFrames#universal_frame as #baseframe
+    - Set Group iteration feature to @api private
+
+- Refactoring
+  - Generate Vector functions in class method (#177)
+  - Set Constant visibility to private (#179)
+  - Separate test_vector_function (#179)
+  - Relocate methods in DataFrameIndexable (#179)
+  - Rename Array refinements to the same name as Vector (#184)
+
+- Improve in tests/CI
+  - Tests
+    - Update benchmarks to set 0.3.0 as a reference (#167)
+    - Move test of Vector#logb to proper location (#180)
+
+  - Cops
+    - Update .rubocop.yml to align with latest cops (#174)
+    - Unify style of MethodCallIndentation as relative to reciever (#184)
+
+  - CI
+    - Fix setting up Arrow by homebrew in CI (#167)
+    - Fix CI error on homebrew deleting python link (#167)
+    - Set cache-version to get new C extensions in CI (#173) Thanks to @kou for suggestion.
+
+- Documentation
+  - Update DataFrame.md about loading csv without headers (#165)
+    - Thanks to kojix2
+  - Update YARD in DataFrame combinable (#168)
+  - Update comment for Ruby 2.7 support in README.md
+  - Update license year
+  - Update README (#172)
+  - Update Vector.md and yardoc in #propagate (#175)
+  - Use customized style sheet for YARD (#179)
+  - Add examples for the doc of #pick and #drop (#179)
+  - Add examples to YARD in DataFrame reshaping methods (#179)
+  - Update documents in DataFrameDisplayable (#179)
+  - Update documents in DataFrameVariableOperation (#179)
+  - Update document for dynamically generated methods (#179)
+  - Unify style in document (#179)
+  - Update documents in DataFrameSelectable (#179)
+  - Update documents of basic Vector methods (#179)
+  - Update document in VectorUpdatable (#179)
+  - Update document of Group (#179)
+  - Update document of DataFrameLoadSave (#180)
+  - Add examples for document of ArrowFunction (#180)
+  - Update document of Vector_unary_aggregation (#180)
+  - Update document of Vector_unary_element_wise (#180)
+  - Update document of Vector_biary_element_wise (#180)
+  - Add documentation to give comparison of dataframes(#169)
+    - Thanks to Benson Muite
+  - Update documents for consistency of method indentation (#189)
+  - Update CHANGELOG (#189)
+  - Update README for 0.4.0 (#189)
+
+- GitHub site
+
+- Thanks
+  - kojix2
+  - Benson Muite
+
 ## [0.3.0] - 2022-12-18
 
 - Breaking change

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Supported Ruby version is >= 3.0 (since RedAmber 0.3.0).
 
 ### Libraries
 ```ruby
-gem 'red-arrow',   '~> 10.0.0' # Requires Apache Arrow (see installation below)
-gem 'red-parquet', '~> 10.0.0' # Optional, if you use IO from/to parquet
+gem 'red-arrow',   '~> 11.0.0' # Requires Apache Arrow (see installation below)
+gem 'red-parquet', '~> 11.0.0' # Optional, if you use IO from/to parquet
 gem 'rover-df',    '~> 0.3.0' # Optional, if you use IO from/to Rover::DataFrame
 ```
 
@@ -31,9 +31,9 @@ gem 'rover-df',    '~> 0.3.0' # Optional, if you use IO from/to Rover::DataFrame
 
 Install requirements before you install Red Amber.
 
-- Apache Arrow (~> 10.0.0)
-- Apache Arrow GLib (~> 10.0.0)
-- Apache Parquet GLib (~> 10.0.0)  # If you use IO from/to parquet
+- Apache Arrow (~> 11.0.0)
+- Apache Arrow GLib (~> 11.0.0)
+- Apache Parquet GLib (~> 11.0.0)  # If you use IO from/to parquet
 
 See [Apache Arrow install document](https://arrow.apache.org/install/).
   
@@ -66,9 +66,9 @@ See [Apache Arrow install document](https://arrow.apache.org/install/).
 If you prepared Apache Arrow, add these lines to your Gemfile:
 
 ```ruby
-gem 'red-arrow',   '~> 10.0.0'
+gem 'red-arrow',   '~> 11.0.0'
 gem 'red_amber'
-gem 'red-parquet', '~> 10.0.0' # Optional, if you use IO from/to parquet
+gem 'red-parquet', '~> 11.0.0' # Optional, if you use IO from/to parquet
 gem 'rover-df',    '~> 0.3.0'  # Optional, if you use IO from/to Rover::DataFrame
 gem 'red-datasets-arrow'       # Optional, recommended if you use Red Datasets
 gem 'red-arrow-numo-narray'    # Optional, recommended if you use inputs from Numo::NArray
@@ -78,11 +78,17 @@ And then execute `bundle install` or install them yourself such as `gem install 
 
 ## Docker image and Jupyter Notebook
 
-[RubyData Docker Stacks](https://github.com/RubyData/docker-stacks) is available as a ready-to-run Docker image containing Jupyter and useful data tools as well as RedAmber (Thanks to @mrkn).
+[RubyData Docker Stacks](https://github.com/RubyData/docker-stacks) is available as a ready-to-run Docker image containing Jupyter and useful data tools as well as RedAmber (Thanks to Kenta Murata).
 
 Also you can try the contents of this README interactively by [Binder](https://mybinder.org/v2/gh/heronshoes/docker-stacks/RedAmber-binder?filepath=red-amber.ipynb). 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/heronshoes/docker-stacks/RedAmber-binder?filepath=red-amber.ipynb)
 
+## Comparison of DataFrames
+
+Comparison of  basic features of RedAmber with Python 
+[pandas](https://pandas.pydata.org/),
+R [Tidyverse](https://www.tidyverse.org/) and
+Julia [Dataframes](https://dataframes.juliadata.org/stable/) is [here](doc/DataFrame_Comparison.md) (Thanks to Benson Muite).
 
 ## Data frame in `RedAmber`
 
@@ -206,7 +212,7 @@ See [Vector.md](doc/Vector.md) for details.
 
 ## Jupyter notebook
 
-[89 Examples of Red Amber](https://github.com/heronshoes/docker-stacks/blob/RedAmber-binder/binder/examples_of_red_amber.ipynb)
+[Examples of Red Amber](https://github.com/heronshoes/docker-stacks/blob/RedAmber-binder/binder/examples_of_red_amber.ipynb)
 ([raw file](https://raw.githubusercontent.com/heronshoes/docker-stacks/RedAmber-binder/binder/examples_of_red_amber.ipynb)) shows more examples in jupyter notebook.
 
 You can try this notebook on [Binder](https://mybinder.org/v2/gh/heronshoes/docker-stacks/RedAmber-binder?filepath=examples_of_red_amber.ipynb). 

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -37,11 +37,42 @@ module RedAmber
 
     # Creates a new DataFrame.
     #
+    # @overload initialize(hash)
+    #   Initialize a DataFrame by a Hash.
+    #
+    #   @param hash [Hash<key => <Array, Arrow::Array, #to_arrow_array>>]
+    #     a Hash of `key` with array-like for column values.
+    #     `key`s are Symbol or String.
+    #   @example Initialize by a Hash
+    #     hash = { x: [1, 2, 3], y: %w[A B C] }
+    #     DataFrame.new(hash)
+    #   @example Initialize by a Hash like arguments.
+    #     DataFrame.new(x: [1, 2, 3], y: %w[A B C])
+    #   @example Initialize from #to_arrow_array responsibles.
+    #     # #to_arrow_array responsible `array-like` is also available.
+    #     require 'arrow-numo-narray'
+    #     DataFrame.new(numo: Numo::DFloat.new(3).rand)
+    #
     # @overload initialize(table)
-    #   Initialize DataFrame by an `Arrow::Table`
+    #   Initialize a DataFrame by an `Arrow::Table`.
     #
     #   @param table [Arrow::Table]
-    #     A table to have in the DataFrame.
+    #     a table to have in the DataFrame.
+    #   @example Initialize by a Table
+    #     table = Arrow::Table.new(x: [1, 2, 3], y: %w[A B C])
+    #     DataFrame.new(table)
+    #
+    # @overload initialize(schama, row_oriented_array)
+    #   Initialize a DataFrame by schema and row_oriented_array.
+    #
+    #   @param schema [Hash<key => type>]
+    #     a schema of key and data type.
+    #   @param row_oriented_array [Array]
+    #     an Array of rows.
+    #   @example Initialize by a schema and a row_oriented_array.
+    #     schema = { x: :uint8, y: :string }
+    #     row_oriented_array = [[1, 'A'], [2, 'B'], [3, 'C']]
+    #     DataFrame.new(schema, row_oriented_array)
     #
     # @overload initialize(arrowable)
     #   Initialize DataFrame by a `#to_arrow` responsible object.
@@ -52,6 +83,11 @@ module RedAmber
     #
     #   @note `RedAmber::DataFrame` itself is readable by this.
     #   @note Hash is refined to respond to `#to_arrow` in this class.
+    #   @example Initialize by Red Dataset object.
+    #     require 'datasets-arrow'
+    #     dataset = Datasets::Penguins.new
+    #     penguins = DataFrame.new(dataset)
+    #   @since 0.2.2
     #
     # @overload initialize(rover_like)
     #   Initialize DataFrame by a `Rover::DataFrame`-like `#to_h` responsible object.
@@ -73,14 +109,10 @@ module RedAmber
     #
     #   @param empty [nil, [], {}]
     #
-    #   @example
-    #     DataFrame.new([]), DataFrame.new({}), DataFrame.new(nil)
-    #
-    # @overload initialize(args)
-    #
-    #   @param args [values]
-    #     Accepts any argments which is valid for `Arrow::Table.new(args)`. See
-    #     {https://github.com/apache/arrow/blob/master/ruby/red-arrow/lib/arrow/table.rb
+    #   @example Return empty DataFrame.
+    #     DataFrame.new([])
+    #     DataFrame.new({})
+    #     DataFrame.new(nil)
     #
     def initialize(*args)
       case args
@@ -295,12 +327,12 @@ module RedAmber
     # @overload each_row(&block)
     #   Yields with key and row pairs.
     #
-    #   @yield [key_row_pairs]
-    #     yields with key and row pairs.
-    #   @yieldparam [Hash]
+    #   @yieldparam key_row_pairs [Hash]
     #     key and row pairs.
     #   @yieldreturn [Integer]
     #     size of the DataFrame.
+    #   @return [Integer]
+    #     returns size.
     #
     def each_row
       return enum_for(:each_row) unless block_given?
@@ -347,8 +379,6 @@ module RedAmber
     # @overload group(*group_keys)
     #   Create a Group and summarize it by aggregation functions from the block.
     #
-    #   @yield [Group]
-    #     passes created group.
     #   @yieldparam group [Group]
     #     passes Group object.
     #   @yieldreturn [DataFrame, Array<DataFrame>]

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -435,7 +435,7 @@ module RedAmber
     #     <uint8> <string> <boolean>
     #   0       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def sub_by_value(keys: nil)
       SubFrames.new(self, group(keys).filters)
@@ -477,7 +477,7 @@ module RedAmber
     #   2       5 B        true
     #   3       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def sub_by_window(from: 0, size: nil, step: 1)
       SubFrames.new(self) do
@@ -552,7 +552,7 @@ module RedAmber
     #   2       5 B        true
     #   3       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def sub_by_enum(enumerator_method, *args)
       SubFrames.new(self, indices.send(enumerator_method, *args).to_a)
@@ -590,7 +590,7 @@ module RedAmber
     #   0       3 B        false
     #   1       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def sub_by_kernel(kernel, step: 1)
       limit_size = size - kernel.size
@@ -670,7 +670,7 @@ module RedAmber
     #     1       4 B        (nil)
     #     2       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def build_subframes(subset_specifier = nil, &block)
       if block

--- a/lib/red_amber/data_frame_loadsave.rb
+++ b/lib/red_amber/data_frame_loadsave.rb
@@ -35,7 +35,7 @@ module RedAmber
       # @example Load from URI
       #   DataFrame.load(URI("https://some_uri/file.csv"))
       #
-      # @example Load from Buffer
+      # @example Load from a Buffer
       #   DataFrame.load(Arrow::Buffer.new(<<~BUFFER), format: :csv)
       #     name,age
       #     Yasuko,68
@@ -43,7 +43,7 @@ module RedAmber
       #     Hinata,28
       #   BUFFER
       #
-      # @example Load from Buffer skipping comment line
+      # @example Load from a Buffer skipping comment line
       #   DataFrame.load(Arrow::Buffer.new(<<~BUFFER), format: :csv, skip_lines: /^#/)
       #     # comment
       #     name,age

--- a/lib/red_amber/data_frame_selectable.rb
+++ b/lib/red_amber/data_frame_selectable.rb
@@ -193,7 +193,7 @@ module RedAmber
     #   @param row [Indeger, Float]
     #     a row index to select.
     #   @return [DataFrame]
-    #     selected variables as a DataFrame.
+    #     selected records as a DataFrame.
     #   @example Select a row
     #   penguins
     #
@@ -226,7 +226,7 @@ module RedAmber
     #   @param rows [<Integer>, <Float>, Range<Integer>, Vector, Arrow::Array]
     #     row indeces to select.
     #   @return [DataFrame]
-    #     selected variables as a DataFrame.
+    #     selected records as a DataFrame.
     #   @example Select rows
     #     penguins.slice(300..-1)
     #
@@ -244,36 +244,61 @@ module RedAmber
     #     42 Gentoo   Biscoe             45.2          14.8               212 ...     2009
     #     43 Gentoo   Biscoe             49.9          16.1               213 ...     2009
     #
+    # @overload slice(enumerator)
+    #   Select records and return a DataFrame.
+    #   - Duplicated selection is acceptable. The same record will be returned.
+    #   - The order of records will be the same as specified indices.
+    #
+    #   @param enumerator [Enumerator]
+    #     an enumerator which returns row indeces to select.
+    #   @return [DataFrame]
+    #     selected records as a DataFrame.
+    #   @example Select rows by Enumerator.
+    #     penguins.assign_left(index: penguins.indices) # 0.2.0 feature
+    #             .slice(0.step(by: 10, to: 340))
+    #
+    #     # =>
+    #     #<RedAmber::DataFrame : 35 x 9 Vectors, 0x000000000000f2e4>
+    #     index species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year
+    #     <uint16> <string> <string>        <double>      <double>           <uint8> ... <uint16>
+    #     0        0 Adelie   Torgersen           39.1          18.7               181 ...     2007
+    #     1       10 Adelie   Torgersen           37.8          17.1               186 ...     2007
+    #     2       20 Adelie   Biscoe              37.8          18.3               174 ...     2007
+    #     3       30 Adelie   Dream               39.5          16.7               178 ...     2007
+    #     4       40 Adelie   Dream               36.5          18.0               182 ...     2007
+    #     :        : :        :                      :             :                 : ...        :
+    #     32      320 Gentoo   Biscoe              48.5          15.0               219 ...     2009
+    #     33      330 Gentoo   Biscoe              50.5          15.2               216 ...     2009
+    #     34      340 Gentoo   Biscoe              46.8          14.3               215 ...     2009
+    #
     # @overload slice
     #   Select records by indices with block and return a DataFrame.
     #   - Duplicated selection is acceptable. The same record will be returned.
     #   - The order of records will be the same as specified indices.
     #
-    #   @yield [self]
+    #   @yieldparam self [DataFrame]
     #     gives self to the block.
     #     The block is evaluated within the context of self.
-    #   @yieldparam self [DataFrame]
-    #     self. Usually, it can be omitted.
-    #   @yieldreturn [<Integer>, <Float>, Range<Integer>, Vector, Arrow::Array]
+    #   @yieldreturn [<Integer>, <Float>, Range<Integer>, Vector, Arrow::Array, Enumerator]
     #     row indeces to select.
     #   @return [DataFrame]
     #     selected records as a DataFrame.
     #   @example Select rows by block
-    #     penguins.slice { 0.step(size, 10) }
+    #     penguins.assign_left(index: penguins.indices) # 0.2.0 feature
+    #             .slice { 0.step(by: 100, to: 300).map { |i| i..(i+1) } }
     #
     #     # =>
-    #     #<RedAmber::DataFrame : 35 x 8 Vectors, 0x000000000000fd84>
-    #        species  island    bill_length_mm bill_depth_mm flipper_length_mm ...     year
-    #        <string> <string>        <double>      <double>           <uint8> ... <uint16>
-    #      0 Adelie   Torgersen           39.1          18.7               181 ...     2007
-    #      1 Adelie   Torgersen           37.8          17.1               186 ...     2007
-    #      2 Adelie   Biscoe              37.8          18.3               174 ...     2007
-    #      3 Adelie   Dream               39.5          16.7               178 ...     2007
-    #      4 Adelie   Dream               36.5          18.0               182 ...     2007
-    #      : :        :                      :             :                 : ...        :
-    #     32 Gentoo   Biscoe              48.5          15.0               219 ...     2009
-    #     33 Gentoo   Biscoe              50.5          15.2               216 ...     2009
-    #     34 Gentoo   Biscoe              46.8          14.3               215 ...     2009
+    #     #<RedAmber::DataFrame : 8 x 9 Vectors, 0x000000000000f3ac>
+    #          index species   island    bill_length_mm bill_depth_mm flipper_length_mm ...     year
+    #       <uint16> <string>  <string>        <double>      <double>           <uint8> ... <uint16>
+    #     0        0 Adelie    Torgersen           39.1          18.7               181 ...     2007
+    #     1        1 Adelie    Torgersen           39.5          17.4               186 ...     2007
+    #     2      100 Adelie    Biscoe              35.0          17.9               192 ...     2009
+    #     3      101 Adelie    Biscoe              41.0          20.0               203 ...     2009
+    #     4      200 Chinstrap Dream               51.5          18.7               187 ...     2009
+    #     5      201 Chinstrap Dream               49.8          17.3               198 ...     2009
+    #     6      300 Gentoo    Biscoe              49.1          14.5               212 ...     2009
+    #     7      301 Gentoo    Biscoe              52.5          15.6               221 ...     2009
     #
     # @overload slice(booleans)
     #   Select records by filtering with booleans and return a DataFrame.
@@ -302,11 +327,9 @@ module RedAmber
     # @overload slice
     #   Select records by filtering with block and return a DataFrame.
     #
-    #   @yield [self]
+    #   @yieldparam self [DataFrame]
     #     gives self to the block.
     #     The block is evaluated within the context of self.
-    #   @yieldparam self [DataFrame]
-    #     self. Usually, it can be omitted.
     #   @yieldreturn [<Boolean, nil>, Vector, Arrow::Array]
     #     a boolean filter. `Vector` or `Arrow::Array` must be boolean type.
     #   @return [DataFrame]
@@ -373,11 +396,9 @@ module RedAmber
     #     a key to select column.
     #   @param keep_key [true, false]
     #     preserve column specified by key in the result if true.
-    #   @yield [self]
+    #   @yieldparam self [DataFrame]
     #     gives self to the block.
     #     The block is evaluated within the context of self.
-    #   @yieldparam self [DataFrame]
-    #     self. Usually, it can be omitted.
     #   @yieldreturn [<elements>]
     #     array of elements to select.
     #   @return [DataFrame]
@@ -411,11 +432,9 @@ module RedAmber
     #     a key to select column.
     #   @param keep_key [true, false]
     #     preserve column specified by key in the result if true.
-    #   @yield [self]
+    #   @yieldparam self [DataFrame]
     #     gives self to the block.
     #     The block is evaluated within the context of self.
-    #   @yieldparam self [DataFrame]
-    #     self. Usually, it can be omitted.
     #   @yieldreturn [Range]
     #     specifies position of elements at the start and the end and
     #     select records between them.
@@ -520,11 +539,9 @@ module RedAmber
     # @overload filter
     #   Select records by filtering with block and return a DataFrame.
     #
-    #   @yield [self]
+    #   @yieldparam self [DataFrame]
     #     gives self to the block.
     #     The block is evaluated within the context of self.
-    #   @yieldparam self [DataFrame]
-    #     self. Usually, it can be omitted.
     #   @yieldreturn [<Boolean, nil>, Vector, Arrow::Array]
     #     a boolean filter. `Vector` or `Arrow::Array` must be boolean type.
     #   @return [DataFrame]
@@ -636,11 +653,9 @@ module RedAmber
     #   - Duplicated selection is acceptable.
     #   - The order of records in self will be preserved.
     #
-    #   @yield [self]
+    #   @yieldparam self [DataFrame]
     #     gives self to the block.
     #     The block is evaluated within the context of self.
-    #   @yieldparam self [DataFrame]
-    #     self. Usually, it can be omitted.
     #   @yieldreturn [<Integer, Float>, Range<Integer>, Vector, Arrow::Array]
     #     row indeces to remove.
     #   @return [DataFrame]
@@ -692,11 +707,9 @@ module RedAmber
     #   and remove them to create a remainer DataFrame.
     #   - The order of records in self will be preserved.
     #
-    #   @yield [self]
+    #   @yieldparam self [DataFrame]
     #     gives self to the block.
     #     The block is evaluated within the context of self.
-    #   @yieldparam self [DataFrame]
-    #     self. Usually, it can be omitted.
     #   @yieldreturn [<Boolean, nil>, Vector, Arrow::Array]
     #     a boolean filter to remove. `Vector` or `Arrow::Array` must be boolean type.
     #   @return [DataFrame]

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -7,7 +7,19 @@ module RedAmber
 
     using RefineArrowTable
 
-    attr_reader :dataframe, :group_keys
+    # Source DataFrame.
+    #
+    # @return [DataFrame]
+    #   source DataFrame.
+    #
+    attr_reader :dataframe
+
+    # Keys for grouping by value.
+    #
+    # @return [Array]
+    #   group keys.
+    #
+    attr_reader :group_keys
 
     class << self
       private
@@ -128,8 +140,6 @@ module RedAmber
     # @overload each
     #   When a block given, passes each record group as a DataFrame to the block.
     #
-    #   @yield [DataFrame]
-    #     each record group
     #   @yieldparam df [DataFrame]
     #     passes each record group as a DataFrame by a block parameter.
     #   @yieldreturn [Object]
@@ -189,8 +199,6 @@ module RedAmber
 
     # Summarize Group by aggregation functions from the block.
     #
-    # @yield [self]
-    #   passes self.
     # @yieldparam group [Group]
     #   passes group object self.
     # @yieldreturn [DataFrame, Array<DataFrame>]
@@ -253,7 +261,10 @@ module RedAmber
       end
     end
 
+    # Aggregating summary.
+    #
     # @api private
+    #
     def agg_sum(*summary_keys)
       call_aggregating_function(:sum, summary_keys, _options = nil)
     end

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -58,7 +58,7 @@ module RedAmber
       #     <uint8> <string> <boolean>
       #   0       6 C        false
       #
-      # @since 0.3.1
+      # @since 0.4.0
       #
       def by_group(group)
         SubFrames.new(group.dataframe, group.filters)
@@ -74,7 +74,7 @@ module RedAmber
       #   an Array of numeric indices to create subsets of DataFrame.
       # @return [SubFrames]
       #   a new SubFrames object.
-      # @since 0.3.1
+      # @since 0.4.0
       #
       def by_indices(dataframe, subset_indices)
         instance = allocate
@@ -100,7 +100,7 @@ module RedAmber
       #   Each filters must have same length as dataframe.
       # @return [SubFrames]
       #   a new SubFrames object.
-      # @since 0.3.1
+      # @since 0.4.0
       #
       def by_filters(dataframe, subset_filters)
         instance = allocate
@@ -123,7 +123,7 @@ module RedAmber
       #   an array of DataFrames which have same schema.
       # @return [SubFrames]
       #   a new SubFrames object.
-      # @since 0.3.1
+      # @since 0.4.0
       #
       def by_dataframes(dataframes)
         instance = allocate
@@ -251,7 +251,7 @@ module RedAmber
     #     1       3 B        false
     #     2       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def initialize(dataframe, subset_specifier = nil, &block)
       unless dataframe.is_a?(DataFrame)
@@ -294,7 +294,7 @@ module RedAmber
     # Once evaluated, memorize it as @baseframe.
     # @return [DataFrame]
     #   a concatenated DataFrame.
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def baseframe
       @baseframe ||= reduce(&:concatenate)
@@ -367,7 +367,7 @@ module RedAmber
     #   4       5 B        true
     #   5       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def each(&block)
       return enum_for(__method__) { size } unless block
@@ -453,7 +453,7 @@ module RedAmber
     #     1 B              3       2      12       1
     #     2 C              1       1       6       0
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def aggregate(group_keys, aggregations)
       aggregator =
@@ -572,7 +572,7 @@ module RedAmber
     #     <uint8> <string> <boolean> <uint8>
     #   0       6 C        false           7
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     define_subframable_method :map
     alias_method :collect, :map
@@ -720,7 +720,7 @@ module RedAmber
     #       <uint8> <string> <boolean> <uint8>
     #     0       6 C        false           0
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def assign(...)
       map { |df| df.assign(...) }
@@ -788,7 +788,7 @@ module RedAmber
     #   1       4 B        (nil)
     #   2       5 B        true
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     define_subframable_method :select
     alias_method :filter, :select
@@ -847,7 +847,7 @@ module RedAmber
     #     <uint8> <string> <boolean>
     #   0       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     define_subframable_method :reject
 
@@ -883,7 +883,7 @@ module RedAmber
     #   1       4 B2       (nil)
     #   2       5 B3       true
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     define_subframable_method :filter_map
 
@@ -891,7 +891,7 @@ module RedAmber
     #
     # @return [Integer]
     #   number of subsets in self.
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def size
       @size ||= @enum.size
@@ -901,7 +901,7 @@ module RedAmber
     #
     # @return [Array<Integer>]
     #   sizes of sub DataFrames.
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def sizes
       @sizes ||= @enum.map(&:size)
@@ -913,7 +913,7 @@ module RedAmber
     #   indices of offset of each sub DataFrames.
     # @example When `sizes` is [2, 3, 1].
     #   sf.offset_indices # => [0, 2, 5]
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def offset_indices
       sum = 0
@@ -927,7 +927,7 @@ module RedAmber
     #
     # @return [true, false]
     #   true if self is an empty subset.
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def empty?
       size.zero?
@@ -937,7 +937,7 @@ module RedAmber
     #
     # @return [true, false]
     #   true if only member of self is equal to universal DataFrame.
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def universal?
       size == 1 && @enum.first == baseframe
@@ -981,7 +981,7 @@ module RedAmber
     #     <uint8> <string> <boolean>
     #   0       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def to_s(limit: 16)
       _to_s(limit: limit)
@@ -1033,7 +1033,7 @@ module RedAmber
     #     <uint8> <string> <boolean>
     #   0       6 C        false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def inspect(limit: 16)
       sizes_truncated = (size > limit ? sizes.take(limit) << '...' : sizes).join(', ')

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -220,8 +220,8 @@ module RedAmber
     #
     #   @param dataframe [DataFrame]
     #     a source dataframe.
-    #   @yield [DataFrame]
-    #     the block is called with the parameter `dataframe`.
+    #   @yieldparam dataframe [DataFrame]
+    #     the block is called with `dataframe`.
     #   @yieldreturn [Array<numeric_array_like>, Array<boolean_array_like>]
     #     an Array of index or boolean array-likes to create subsets of DataFrame.
     #     All array-likes are responsible to #numeric? or #boolean?.
@@ -317,8 +317,6 @@ module RedAmber
     # @overload each
     #   When a block given, passes each sub DataFrames to the block.
     #
-    #   @yield [DataFrame]
-    #     each sub DataFrame.
     #   @yieldparam subframe [DataFrame]
     #     passes sub DataFrame by a block parameter.
     #   @yieldreturn [Object]

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -39,7 +39,7 @@ module RedAmber
     #
     #   Vector.aggregate?(:round) # => false
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def self.aggregate?(function)
       %i[
@@ -121,7 +121,7 @@ module RedAmber
     #   #<RedAmber::Vector(:uint16, size=2):0x000000000000c328>
     #   [1, 2]
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def resolve(other)
       case other
@@ -523,7 +523,7 @@ module RedAmber
     #     #<RedAmber::Vector(:uint8, size=4):0x000000000000cb98>
     #     [3, 3, 3, 3]
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def propagate(function = nil, &block)
       value =

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -101,7 +101,7 @@ module RedAmber
     #   ["1", "2"]
     #
     # @example String to Ineger
-    #   Vector.new(1).resolve(["A"])
+    #   Vector.new(1).resolve(['A'])
     #
     #   # =>
     #   #<RedAmber::Vector(:uint8, size=1):0x00000000000037dc>
@@ -334,8 +334,6 @@ module RedAmber
     # @overload each
     #   When a block given, passes each element in self to the block.
     #
-    #   @yield [Object]
-    #     each element.
     #   @yieldparam element [Object]
     #     passes element by a block parameter.
     #   @yieldreturn [Object]
@@ -364,8 +362,6 @@ module RedAmber
     #   When a block given, calls the block with successive elements.
     #   Returns a Vector of the objects returned by the block.
     #
-    #   @yield [Object]
-    #     each element.
     #   @yieldparam element [Object]
     #     passes element by a block parameter.
     #   @yieldreturn [Object]
@@ -380,13 +376,21 @@ module RedAmber
     end
     alias_method :collect, :map
 
+    # Tests wheather self is chunked or not.
+    #
     # @api private
+    # @return [true, false]
+    #   returns true if #data is chunked.
     #
     def chunked?
       @data.is_a? Arrow::ChunkedArray
     end
 
+    # Returns the number of chunks.
+    #
     # @api private
+    # @return [Integer]
+    #   the number of chunks. If self is not chunked, returns zero.
     #
     def n_chunks
       chunked? ? @data.n_chunks : 0
@@ -452,6 +456,36 @@ module RedAmber
       is_nil.any
     end
 
+    # Enable to compute with coercion mechanism.
+    #
+    # @example
+    #   vector = Vector.new(1,2,3)
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:uint8, size=3):0x00000000000decc4>
+    #   [1, 2, 3]
+    #
+    #   # Vector's `#*` method
+    #   vector * -1
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:int16, size=3):0x00000000000e3698>
+    #   [-1, -2, -3]
+    #
+    #   # coerced calculation
+    #   -1 * vector
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:int16, size=3):0x00000000000ea4ac>
+    #   [-1, -2, -3]
+    #
+    #   # `@-` operator
+    #   -vector
+    #
+    #   # =>
+    #   #<RedAmber::Vector(:uint8, size=3):0x00000000000ee7b4>
+    #   [255, 254, 253]
+    #
     def coerce(other)
       [Vector.new(Array(other) * size), self]
     end
@@ -476,10 +510,8 @@ module RedAmber
     # @overload propagate
     #   Returns a Vector of same size as self spreading the value from block.
     #
-    #   @yield [self]
-    #     gives self to the block.
     #   @yieldparam self [Vector]
-    #     self.
+    #     gives self to the block.
     #   @yieldreturn [scalar]
     #     a scalar value.
     #   @return [Vector]

--- a/lib/red_amber/vector_aggregation.rb
+++ b/lib/red_amber/vector_aggregation.rb
@@ -102,7 +102,7 @@ module RedAmber
 
     # Count the number of unique values.
     #
-    # @!method count_distinct(mode: :non_null)
+    # @!method count_distinct(mode: :only_valid)
     # @macro count_options
     # @return [Integer]
     #   unique count of self.

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -183,7 +183,7 @@ module RedAmber
     #   #<RedAmber::Vector(:string, size=5):0x000000000000c148>
     #   ["E", "D", "C", "B", "A"]
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def sort(order = :ascending)
       order =
@@ -233,7 +233,7 @@ module RedAmber
     #   #<RedAmber::Vector(:uint64, size=5):0x0000000000003868>
     #   [0, 2, 4, 1, 3]
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def rank
       datum = Arrow::Function.find(:rank).execute([data])
@@ -318,7 +318,7 @@ module RedAmber
     #     #<RedAmber::Vector(:string, size=16):0x00000000000233e8>
     #     ["H", "B", "C", "B", "C", "A", "F", "A", "E", "C", "H", "F", "F", "A", ... ]
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def sample(n_or_prop = nil)
       require 'arrow-numo-narray'

--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -13,9 +13,9 @@ module RedAmber
     # Select elements in the self by indices.
     #
     # @param indices [Array<Numeric>, Vector]
-    #   indices.
-    # @yield [Array<Numeric>, Vector]
-    #   indices.
+    #   an array-like of indices.
+    # @yieldreturn [Array<Numeric>, Vector]
+    #   an array-like of indices from the block.
     # @return [Vector]
     #   vector by selected elements.
     #
@@ -51,9 +51,9 @@ module RedAmber
     # Select elements in the self by booleans.
     #
     # @param booleans [Array<true, false, nil>, Vector]
-    #   booleans.
-    # @yield [Array<true, false, nil>, Vector]
-    #   booleans.
+    #   an array-like of booleans.
+    # @yieldreturn [Array<true, false, nil>, Vector]
+    #   an array-like of booleans from the block.
     # @return [Vector]
     #   vector by selected elements.
     #
@@ -94,9 +94,9 @@ module RedAmber
     # Select elements in the self by indices or booleans.
     #
     # @param args [Array<Numeric, true, false, nil>, Vector]
-    #   specifier.
-    # @yield [Array<Numeric, true, false, nil>, Vector]
-    #   specifier.
+    #   specifier. Indices or booleans.
+    # @yieldparam [Array<Numeric, true, false, nil>, Vector]
+    #   specifier. Indices or booleans.
     # @return [scalar, Array]
     #   returns scalar or array.
     #

--- a/lib/red_amber/vector_updatable.rb
+++ b/lib/red_amber/vector_updatable.rb
@@ -433,7 +433,7 @@ module RedAmber
     #   #<RedAmber::Vector(:uint8, size=4):0x0000000000003840>
     #   [1, 2, 65, 66]
     #
-    # @since 0.3.1
+    # @since 0.4.0
     #
     def concatenate(other)
       concatenated_array =

--- a/lib/red_amber/vector_updatable.rb
+++ b/lib/red_amber/vector_updatable.rb
@@ -428,7 +428,7 @@ module RedAmber
     #   #<RedAmber::Vector(:uint8, size=2):0x000000000000382c>
     #   [1, 2]
     #
-    #   nteger_vector.concatenate(["A", "B"])
+    #   integer_vector.concatenate(["A", "B"])
     #   # =>
     #   #<RedAmber::Vector(:uint8, size=4):0x0000000000003840>
     #   [1, 2, 65, 66]

--- a/lib/red_amber/version.rb
+++ b/lib/red_amber/version.rb
@@ -2,5 +2,5 @@
 
 module RedAmber
   # Library version
-  VERSION = '0.4.0-HEAD'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
This PR will prepare RedAmber v0.4.0.

- Bump version 0.4.0
Next version was planned to be 0.3.1. But there are so many changes from 0.3.0, so I decided to bump the version up to 0.4.0 .

- Upgrade dependency of Arrow to 11.0.0 .
- Create link for `DataFrame_Comparison.md` (Thanks to Benson Muite).
- Update documents for consistency of method indentation.